### PR TITLE
fix(extension): never return a borrowed tab into another session's Agent Window

### DIFF
--- a/apps/extension/src/tools/__tests__/tabs.test.ts
+++ b/apps/extension/src/tools/__tests__/tabs.test.ts
@@ -613,6 +613,65 @@ describe("handleTabReturn", () => {
     expect(winSpies.create).toHaveBeenCalledOnce();
   });
 
+  it("does not fall back into another session's Agent Window (creates a new window instead)", async () => {
+    // Regression: a returned borrowed tab whose original window is gone
+    // must never be parked in *another* session's Agent Window. Agent
+    // Windows are `type: "normal"`, so getLastFocused({windowTypes:
+    // ["normal"]}) can return session bb22's window (200). Without the
+    // isAgentWindowId guard the tab would be moved into window 200,
+    // letting bb22 write to it and destroying it when bb22 stops.
+    const sm = new SessionManager({ agentWindow: fakeAgentWindow([100, 200]) });
+    const ctx = await sm.start("aa11");
+    await sm.start("bb22"); // owns Agent Window 200
+    ctx.borrowedTabs.set(7, { tabId: 7, originalWindowId: 300, originalIndex: 4 });
+    const state: FakeTabState = {
+      tabs: new Map([[7, { id: 7, windowId: 100 } as chrome.tabs.Tab]]),
+      nextTabId: 50,
+      windowsClosed: new Set([300]),
+    };
+    const { api, spies } = makeTabMutationApi(state);
+    const { api: windowsApi, spies: winSpies } = makeWindowsApi(state, {
+      lastFocused: 200, // session bb22's Agent Window
+      createWindowId: 777,
+    });
+    const res = await handleTabReturn(
+      sm,
+      { session_id: "aa11", tab_id: 7 },
+      { tabs: api, windows: windowsApi },
+    );
+    if ("code" in res) throw new Error(`unexpected error: ${JSON.stringify(res)}`);
+    expect(res.returned_to_window_id).toBe(777);
+    expect(res.fallback).toBe(true);
+    expect(winSpies.create).toHaveBeenCalledOnce();
+    expect(spies.move).not.toHaveBeenCalledWith(7, expect.objectContaining({ windowId: 200 }));
+  });
+
+  it("returnBorrowedTab honours an explicit isAgentWindowId predicate", async () => {
+    const sm = new SessionManager({ agentWindow: fakeAgentWindow([100]) });
+    const ctx = await sm.start("aa11");
+    ctx.borrowedTabs.set(7, { tabId: 7, originalWindowId: 300, originalIndex: 4 });
+    const state: FakeTabState = {
+      tabs: new Map([[7, { id: 7, windowId: 100 } as chrome.tabs.Tab]]),
+      nextTabId: 50,
+      windowsClosed: new Set([300]),
+    };
+    const { api, spies } = makeTabMutationApi(state);
+    const { api: windowsApi, spies: winSpies } = makeWindowsApi(state, {
+      lastFocused: 555,
+      createWindowId: 777,
+    });
+    const res = await returnBorrowedTab(ctx, 7, {
+      tabs: api,
+      windows: windowsApi,
+      isAgentWindowId: (windowId) => windowId === 555,
+    });
+    if ("code" in res) throw new Error(`unexpected error: ${JSON.stringify(res)}`);
+    expect(res.toWindowId).toBe(777);
+    expect(res.fallback).toBe(true);
+    expect(winSpies.create).toHaveBeenCalledOnce();
+    expect(spies.move).not.toHaveBeenCalledWith(7, expect.objectContaining({ windowId: 555 }));
+  });
+
   it("returns not_found when the tab is not borrowed by this session", async () => {
     const sm = new SessionManager({ agentWindow: fakeAgentWindow([100]) });
     await sm.start("aa11");

--- a/apps/extension/src/tools/session.ts
+++ b/apps/extension/src/tools/session.ts
@@ -113,7 +113,13 @@ export async function handleSessionStop(
   const borrowedIds = Array.from(ctx.borrowedTabs.keys());
   for (const tabId of borrowedIds) {
     try {
-      const outcome = await returnBorrowedTab(ctx, tabId, deps.tabManagement ?? {});
+      const tabManagement = {
+        ...(deps.tabManagement ?? {}),
+        isAgentWindowId:
+          deps.tabManagement?.isAgentWindowId ??
+          ((windowId: number) => manager.findByWindowId(windowId) !== null),
+      };
+      const outcome = await returnBorrowedTab(ctx, tabId, tabManagement);
       if (typeof outcome === "object" && "code" in outcome) {
         console.warn(`[bsk session_stop] auto-return failed for tab ${tabId}`, outcome);
         returnFailures?.push({

--- a/apps/extension/src/tools/tabs.ts
+++ b/apps/extension/src/tools/tabs.ts
@@ -282,6 +282,16 @@ export interface TabManagementDeps {
   approveBorrow?: BorrowConfirmationApprover;
   /** Clears Agent-scoped overlays after a borrowed tab is returned. */
   agentOverlayReset?: AgentOverlayResetApi;
+  /**
+   * Reports whether `windowId` is any live session's Agent Window.
+   * `tab_return`'s fallback window picker uses this to avoid moving a
+   * returned borrowed tab into *another* session's Agent Window (Agent
+   * Windows are created with `type: "normal"`, so they otherwise match
+   * the `getLastFocused({ windowTypes: ["normal"] })` query). Production
+   * callers derive this from the `SessionManager`; the `() => false`
+   * default only preserves legacy behaviour for direct/test callers.
+   */
+  isAgentWindowId?: (windowId: number) => boolean;
 }
 
 function getTabsApi(deps: TabManagementDeps): TabMutationApi {
@@ -290,6 +300,10 @@ function getTabsApi(deps: TabManagementDeps): TabMutationApi {
 
 function getWindowsApi(deps: TabManagementDeps): ChromeWindowsApi {
   return deps.windows ?? chromeWindowsApi;
+}
+
+function getIsAgentWindowId(deps: TabManagementDeps): (windowId: number) => boolean {
+  return deps.isAgentWindowId ?? (() => false);
 }
 
 function getAgentOverlayResetApi(deps: TabManagementDeps): AgentOverlayResetApi {
@@ -818,12 +832,20 @@ function describeError(err: unknown): string {
 async function chooseFallbackWindow(
   ctx: SessionContext,
   windowsApi: ChromeWindowsApi,
+  isAgentWindowId: (windowId: number) => boolean,
 ): Promise<{ windowId: number; index: number } | RpcError> {
   let lastFocusedError: unknown;
   try {
     const last = await windowsApi.getLastFocused({ windowTypes: ["normal"] });
     const lastId = typeof last?.id === "number" ? last.id : null;
-    if (lastId !== null && lastId !== ctx.agentWindowId) {
+    // Never relocate a user tab into *any* session's Agent Window: this
+    // session's is excluded explicitly, and other sessions' are excluded
+    // via `isAgentWindowId` (Agent Windows are `type: "normal"`, so they
+    // otherwise survive the `windowTypes: ["normal"]` filter). Parking a
+    // returned tab in another session's Agent Window would let that
+    // session write to it and, worse, see it destroyed when that session
+    // stops and closes its window.
+    if (lastId !== null && lastId !== ctx.agentWindowId && !isAgentWindowId(lastId)) {
       return { windowId: lastId, index: -1 };
     }
   } catch (err) {
@@ -888,6 +910,7 @@ export async function returnBorrowedTab(
   }
   const tabsApi = getTabsApi(deps);
   const windowsApi = getWindowsApi(deps);
+  const isAgentWindowId = getIsAgentWindowId(deps);
 
   let targetWindowId = entry.originalWindowId;
   let targetIndex = entry.originalIndex;
@@ -903,7 +926,7 @@ export async function returnBorrowedTab(
   }
   if (!originalAlive) {
     fallback = true;
-    const target = await chooseFallbackWindow(ctx, windowsApi);
+    const target = await chooseFallbackWindow(ctx, windowsApi, isAgentWindowId);
     if ("code" in target) return target;
     targetWindowId = target.windowId;
     targetIndex = target.index;
@@ -925,7 +948,7 @@ export async function returnBorrowedTab(
     };
   } catch (err) {
     if (!fallback) {
-      const target = await chooseFallbackWindow(ctx, windowsApi);
+      const target = await chooseFallbackWindow(ctx, windowsApi, isAgentWindowId);
       if ("code" in target) {
         return {
           code: "cdp_failed",
@@ -979,7 +1002,11 @@ export async function handleTabReturn(
       message: `tab_return: tab ${params.tab_id} is not borrowed by this session`,
     };
   }
-  const outcome = await returnBorrowedTab(ctx, params.tab_id, deps);
+  const outcome = await returnBorrowedTab(ctx, params.tab_id, {
+    ...deps,
+    isAgentWindowId:
+      deps.isAgentWindowId ?? ((windowId) => manager.findByWindowId(windowId) !== null),
+  });
   if (isRpcError(outcome)) return outcome;
   ctx.borrowedTabs.delete(params.tab_id);
   const result: TabReturnResult = {


### PR DESCRIPTION
## Problem

When a borrowed tab's original window has been closed, `tool.tab_return` (and `tool.session_stop`'s auto-return path) needs a fallback window to put the tab back into. The picker in `chooseFallbackWindow` used:

```ts
const last = await windowsApi.getLastFocused({ windowTypes: ["normal"] });
if (lastId !== null && lastId !== ctx.agentWindowId) {
  return { windowId: lastId, index: -1 };
}
```

It only excluded **this** session's Agent Window. But Agent Windows are created with `type: "normal"` (`session-manager/agent-window.ts`), so they survive the `windowTypes: ["normal"]` filter. If another session's Agent Window happened to be last-focused (common — agent windows grab focus), a returned user tab could be moved into **another session's Agent Window**.

Consequences:
- **Cross-session sandbox break:** the receiving session now sees the tab as a native Agent-Window tab, so its write tools (`click`/`fill`/`evaluate`/…) pass `enforceAgentWindow` and can act on a tab the user never offered to that session.
- **Silent user-data loss:** when that session later stops, `SessionManager.stop` closes its Agent Window, destroying the user's tab along with it. The owning session's `borrowedTabs` no longer references it, so it can't be returned.

This contradicts the project's stated posture ("leave the rest of your browser alone") and the cross-session isolation rule enforced everywhere else (e.g. `handleTabList`, `resolveTargetTab`, `listConfirmationCandidates`).

## Fix

Thread an `isAgentWindowId: (windowId: number) => boolean` predicate through `returnBorrowedTab` → `chooseFallbackWindow`, and skip **every** live Agent Window as a fallback target (not just the current session's). This mirrors the existing filter in `borrow-confirmation.ts`'s `listConfirmationCandidates`.

- `TabManagementDeps` gains an optional `isAgentWindowId`.
- The production handlers (`handleTabReturn`, `handleSessionStop`) default it to `(windowId) => manager.findByWindowId(windowId) !== null`, so the fix is active by default with no dispatcher wiring change.
- Direct/test callers keep the legacy `() => false` default.

## Tests

Two regression tests in `tabs.test.ts` (both **fail** on the unpatched code, verified by reverting the source change):

1. `does not fall back into another session's Agent Window` — two sessions (windows 100 & 200); session A returns a borrowed tab whose origin window is gone while `getLastFocused` returns session B's window 200. Asserts a fresh window is created (777) and the tab is never moved to 200.
2. `returnBorrowedTab honours an explicit isAgentWindowId predicate` — direct unit coverage of the predicate plumbing.

Full suite: `361 passed (34 files)`, no regressions. Biome/tsc clean for the touched files (a few pre-existing format/type findings in unrelated files are untouched).

## Scope

Deliberately minimal and focused on this one clearly-correct bug. I audited the broader sandbox/session/lifecycle surface and have a shortlist of other findings (e.g. borrow-confirmation fail-open defaults, the borrowed-tab-destroyed-on-window-close path, daemon WS event ownership) that I'm happy to follow up on in separate PRs if the maintainers are interested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)