### PR TITLE
fix(i18n): 处理部分国际化问题

### DIFF
--- a/packages/i18n/src/locales/zh-CN/extension.json
+++ b/packages/i18n/src/locales/zh-CN/extension.json
@@ -16,11 +16,11 @@
       "version_skew": "部分能力可能不可用。"
     },
     "stateBadge": {
-      "disconnected": "Standby",
-      "connecting": "Igniting",
-      "connected": "Ready",
-      "version_skew": "Action needed",
-      "disabled": "Off"
+      "disconnected": "待机",
+      "connecting": "启动中",
+      "connected": "就绪",
+      "version_skew": "需处理",
+      "disabled": "已关闭"
     },
     "connectionToggleTitle": "BrowserSkill 连接",
     "versionSkewWarning": "扩展协议 v{{extensionProtocol}}，daemon 协议 v{{daemonProtocol}}。",


### PR DESCRIPTION
- 将断开连接状态从"Standby"改为"待机"
- 将连接中状态从"Igniting"改为"启动中"
- 将已连接状态从"Ready"改为"就绪"
- 将版本不匹配状态从"Action needed"改为"需处理"
- 将禁用状态从"Off"改为"已关闭"