### PR TITLE
config(extension): 配置WebSocket连接URL为构建时变量

### DIFF
--- a/apps/extension/src/entrypoints/background.ts
+++ b/apps/extension/src/entrypoints/background.ts
@@ -31,12 +31,9 @@ import { detectBrowserMeta } from "@/transport/handshake";
 import type { Transport } from "@/transport/transport";
 import { WSTransport } from "@/transport/ws-transport";
 
-export const DEFAULT_DAEMON_PORT = 52800;
-
 export default defineBackground(() => {
-  const port = DEFAULT_DAEMON_PORT;
   const controller = new ConnectionController();
-  const transport = new WSTransport({ url: `ws://127.0.0.1:${port}` });
+  const transport = new WSTransport({ url: __BSK_DAEMON_WS_URL__ });
   const sessions = new SessionManager();
   const cdp = new ChromiumCdp();
   const sessionsLive = attachSessionsLiveFlag({ manager: sessions });

--- a/apps/extension/src/transport/build-info.d.ts
+++ b/apps/extension/src/transport/build-info.d.ts
@@ -5,3 +5,10 @@
 // at runtime (review M3 fix to round-1).
 
 declare const __BSK_EXT_VERSION__: string;
+
+/**
+ * WebSocket URL the extension uses to connect to the local bsk daemon.
+ * Defaults to {@code ws://127.0.0.1:52800}. Override at build time by
+ * setting the {@code BSK_DAEMON_WS_URL} environment variable.
+ */
+declare const __BSK_DAEMON_WS_URL__: string;

--- a/apps/extension/vitest.config.ts
+++ b/apps/extension/vitest.config.ts
@@ -21,6 +21,9 @@ export default defineConfig({
   },
   define: {
     __BSK_EXT_VERSION__: JSON.stringify(pkg.version),
+    __BSK_DAEMON_WS_URL__: JSON.stringify(
+      process.env.BSK_DAEMON_WS_URL ?? "ws://127.0.0.1:52800",
+    ),
   },
   resolve: {
     alias: {

--- a/apps/extension/wxt.config.ts
+++ b/apps/extension/wxt.config.ts
@@ -59,6 +59,9 @@ export default defineConfig({
     ],
     define: {
       __BSK_EXT_VERSION__: JSON.stringify(EXTENSION_VERSION),
+      __BSK_DAEMON_WS_URL__: JSON.stringify(
+        process.env.BSK_DAEMON_WS_URL ?? "ws://127.0.0.1:52800",
+      ),
     },
     resolve: {
       alias: {


### PR DESCRIPTION
- 移除DEFAULT_DAEMON_PORT常量定义
- 使用__BSK_DAEMON_WS_URL__构建时变量替代硬编码端口
- 在wxt.config.ts和vitest.config.ts中添加环境变量配置
- 为__BSK_DAEMON_WS_URL__添加类型声明和文档注释
- 默认值保持为ws://127.0.0.1:52800，可通过BSK_DAEMON_WS_URL环境变量覆盖