### PR TITLE
fix(extension): make tool cancellation cooperative

### DIFF
--- a/apps/extension/src/session-manager/__tests__/manager.test.ts
+++ b/apps/extension/src/session-manager/__tests__/manager.test.ts
@@ -57,6 +57,38 @@ describe("SessionManager", () => {
     await expect(sm.start("aa11")).rejects.toThrow(/already exists/);
   });
 
+  it("removes a newly created Agent Window when startup is aborted", async () => {
+    const aw = fakeAgentWindow();
+    let resolveCreate: (windowId: number) => void = () => {};
+    aw.createMock.mockImplementationOnce(
+      () =>
+        new Promise<number>((resolve) => {
+          resolveCreate = resolve;
+        }),
+    );
+    const sm = new SessionManager({ agentWindow: aw });
+    const controller = new AbortController();
+    const pending = sm.start("aa11", { signal: controller.signal });
+
+    controller.abort();
+    resolveCreate(777);
+
+    await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+    expect(aw.removeMock).toHaveBeenCalledWith(777);
+    expect(sm.has("aa11")).toBe(false);
+  });
+
+  it("removes an incomplete Agent Window when active-tab setup fails", async () => {
+    const aw = fakeAgentWindow();
+    aw.ensureActiveTabMock.mockRejectedValueOnce(new Error("tab setup failed"));
+    const sm = new SessionManager({ agentWindow: aw });
+
+    await expect(sm.start("aa11")).rejects.toThrow("tab setup failed");
+
+    expect(aw.removeMock).toHaveBeenCalledWith(100);
+    expect(sm.has("aa11")).toBe(false);
+  });
+
   it("stop() closes the Agent Window and forgets the session", async () => {
     const aw = fakeAgentWindow();
     const sm = new SessionManager({ agentWindow: aw });

--- a/apps/extension/src/session-manager/manager.ts
+++ b/apps/extension/src/session-manager/manager.ts
@@ -25,6 +25,16 @@ export interface SessionManagerOptions {
   now?: () => number;
 }
 
+export interface SessionStartOptions {
+  signal?: AbortSignal;
+}
+
+function sessionStartAbortError(): Error {
+  const err = new Error("session_start aborted");
+  err.name = "AbortError";
+  return err;
+}
+
 /**
  * Owner of all live agent sessions inside the extension.
  *
@@ -128,22 +138,38 @@ export class SessionManager {
    * Returns the created window id so callers can echo it back to the
    * daemon in the `tool.session_start` reply.
    */
-  async start(sessionId: string): Promise<SessionContext> {
+  async start(sessionId: string, options: SessionStartOptions = {}): Promise<SessionContext> {
     if (this.sessions.has(sessionId)) {
       throw new Error(`[bh] session ${sessionId} already exists`);
     }
-    const windowId = await this.agentWindow.create(AGENT_WINDOW_HOME);
-    await this.agentWindow.ensureActiveTab(windowId, AGENT_WINDOW_HOME);
-    const ctx: SessionContext = {
-      sessionId,
-      agentWindowId: windowId,
-      refStore: new RefStore(),
-      borrowedTabs: new Map(),
-      createdAtMs: this.now(),
-    };
-    this.sessions.set(sessionId, ctx);
-    this.windowIndex.set(windowId, sessionId);
-    return ctx;
+    if (options.signal?.aborted) throw sessionStartAbortError();
+
+    let windowId: number | null = null;
+    try {
+      windowId = await this.agentWindow.create(AGENT_WINDOW_HOME);
+      if (options.signal?.aborted) throw sessionStartAbortError();
+      await this.agentWindow.ensureActiveTab(windowId, AGENT_WINDOW_HOME);
+      if (options.signal?.aborted) throw sessionStartAbortError();
+      const ctx: SessionContext = {
+        sessionId,
+        agentWindowId: windowId,
+        refStore: new RefStore(),
+        borrowedTabs: new Map(),
+        createdAtMs: this.now(),
+      };
+      this.sessions.set(sessionId, ctx);
+      this.windowIndex.set(windowId, sessionId);
+      return ctx;
+    } catch (err) {
+      if (windowId !== null) {
+        try {
+          await this.agentWindow.remove(windowId);
+        } catch (cleanupErr) {
+          console.warn(`[bh] failed to remove incomplete Agent Window ${windowId}`, cleanupErr);
+        }
+      }
+      throw err;
+    }
   }
 
   /**

--- a/apps/extension/src/tools/__tests__/dispatcher.test.ts
+++ b/apps/extension/src/tools/__tests__/dispatcher.test.ts
@@ -334,23 +334,31 @@ describe("ToolDispatcher", () => {
     await flushMicrotasks();
     expect(ac?.signal.aborted).toBe(true);
 
-    // Cancel ack arrived synchronously; the slow tool replies with
-    // `cancelled` once the dispatcher's race observes the abort.
+    // Cancel ack arrives synchronously, but the original RPC must not reply
+    // until the in-progress window creation has completed and been rolled back.
     const ack = sent.find(
       (m) =>
         typeof (m as { id?: string }).id === "string" && (m as { id: string }).id === "cancel-1",
     );
     expect(ack).toEqual({ id: "cancel-1", result: { cancelled: true } });
 
+    expect(
+      sent.find(
+        (m) => typeof (m as { id?: string }).id === "string" && (m as { id: string }).id === "r-1",
+      ),
+    ).toBeUndefined();
+    expect(dispatcher.inflightAbortControllers.has("r-1")).toBe(true);
+
+    resolveCreate(9999);
+    await flushMicrotasks();
+
     const slow = sent.find(
       (m) => typeof (m as { id?: string }).id === "string" && (m as { id: string }).id === "r-1",
     );
     expect(slow).toMatchObject({ id: "r-1", error: { code: "cancelled" } });
     expect(dispatcher.inflightAbortControllers.has("r-1")).toBe(false);
-
-    // Drain the dangling create promise so vitest does not warn.
-    resolveCreate(9999);
-    await flushMicrotasks();
+    expect(sessions.has("aa44")).toBe(false);
+    expect(sessions.list()).toEqual([]);
   });
 
   it("cancel for an unknown rpc_id replies with cancelled=false", async () => {

--- a/apps/extension/src/tools/__tests__/observation.test.ts
+++ b/apps/extension/src/tools/__tests__/observation.test.ts
@@ -524,6 +524,41 @@ describe("handleSnapshot", () => {
     expect(ctx.refStore.resolve("e2")).toBe(200);
   });
 
+  it("does not overwrite refs when cancellation arrives during CDP capture", async () => {
+    const sm = new SessionManager({ agentWindow: fakeAgentWindow([100]) });
+    const ctx = await sm.start("aa11");
+    ctx.refStore.set("e1", 999, { tabId: 4 });
+    const controller = new AbortController();
+    let resolveTree: (value: { nodes: CdpAxNode[] }) => void = () => {};
+    const deps = makeDeps([]);
+    deps.send.mockImplementation(async (_tabId: number, method: string) => {
+      if (method === "Accessibility.enable") return {};
+      if (method === "Accessibility.getFullAXTree") {
+        return new Promise((resolve) => {
+          resolveTree = resolve;
+        });
+      }
+      throw new Error(`unexpected CDP method ${method}`);
+    });
+
+    const pending = handleSnapshot(sm, { session_id: "aa11" }, deps, controller.signal);
+    await vi.waitFor(() => expect(deps.send).toHaveBeenCalledTimes(2));
+    controller.abort();
+    resolveTree({
+      nodes: [
+        {
+          nodeId: "new",
+          role: { type: "role", value: "button" },
+          name: { type: "computedString", value: "New" },
+          backendDOMNodeId: 123,
+        },
+      ],
+    });
+
+    await expect(pending).resolves.toMatchObject({ code: "cancelled" });
+    expect(ctx.refStore.resolve("e1")).toBe(999);
+  });
+
   it("resets the RefStore on every fresh snapshot", async () => {
     const sm = new SessionManager({ agentWindow: fakeAgentWindow([100]) });
     const ctx = await sm.start("aa11");

--- a/apps/extension/src/tools/console.ts
+++ b/apps/extension/src/tools/console.ts
@@ -31,7 +31,9 @@ export async function handleConsole(
   manager: SessionManager,
   params: ConsoleParams,
   deps: ConsoleDeps = defaultConsoleDeps(),
+  signal?: AbortSignal,
 ): Promise<ConsoleResult | RpcError> {
+  if (signal?.aborted) return { code: "cancelled", message: "console aborted" };
   const ctxOrErr = lookupSession(manager, params, "console");
   if (isRpcError(ctxOrErr)) return ctxOrErr;
   const bounds = parseConsoleBounds(params);
@@ -44,6 +46,7 @@ export async function handleConsole(
 
   try {
     await deps.cdp.ensureConsoleCapture(target.tabId);
+    if (signal?.aborted) return { code: "cancelled", message: "console aborted" };
     deps.cdp.trackSessionTab?.(ctxOrErr.sessionId, target.tabId);
     return deps.cdp.consoleEntriesSince(
       target.tabId,

--- a/apps/extension/src/tools/dispatcher.ts
+++ b/apps/extension/src/tools/dispatcher.ts
@@ -186,7 +186,10 @@ export class ToolDispatcher {
     let body: ResponseFrame;
     let startedSession: string | null = null;
     try {
-      const result = await Promise.race([this.invoke(req, ac.signal), abortPromise(ac.signal)]);
+      // Await the handler itself. A cancel trips its AbortSignal immediately,
+      // but the RPC response is not sent until the handler has stopped or
+      // completed any required compensation for an already-started side effect.
+      const result = await this.invoke(req, ac.signal);
       if (isRpcError(result)) {
         body = { id: req.id, error: result };
       } else {
@@ -251,7 +254,7 @@ export class ToolDispatcher {
   private async invoke(req: RequestFrame, signal: AbortSignal): Promise<unknown | RpcError> {
     switch (req.method) {
       case "tool.session_start":
-        return handleSessionStart(this.sessions, req.params as SessionStartParams);
+        return handleSessionStart(this.sessions, req.params as SessionStartParams, { signal });
       case "tool.session_stop":
         return handleSessionStop(this.sessions, req.params as SessionStopParams, {
           cdp: this.cdp,
@@ -259,18 +262,18 @@ export class ToolDispatcher {
       case "tool.tab_list":
         return handleTabList(this.sessions, req.params as TabListParams);
       case "tool.tab_create":
-        return handleTabCreate(this.sessions, req.params as TabCreateParams);
+        return handleTabCreate(this.sessions, req.params as TabCreateParams, { signal });
       case "tool.tab_close":
-        return handleTabClose(this.sessions, req.params as TabCloseParams);
+        return handleTabClose(this.sessions, req.params as TabCloseParams, { signal });
       case "tool.tab_select":
-        return handleTabSelect(this.sessions, req.params as TabSelectParams);
+        return handleTabSelect(this.sessions, req.params as TabSelectParams, { signal });
       case "tool.tab_borrow":
         return handleTabBorrow(this.sessions, req.params as TabBorrowParams, {
           signal,
           approveBorrow: this.approveBorrow,
         });
       case "tool.tab_return":
-        return handleTabReturn(this.sessions, req.params as TabReturnParams);
+        return handleTabReturn(this.sessions, req.params as TabReturnParams, { signal });
       case "tool.screenshot":
         return handleScreenshot(
           this.sessions,
@@ -278,24 +281,28 @@ export class ToolDispatcher {
           this.cdp
             ? { cdp: this.cdp, tabsApi: chromeTabsCaptureApi, captureApi: chromeTabsCaptureApi }
             : undefined,
+          signal,
         );
       case "tool.console":
         return handleConsole(
           this.sessions,
           req.params as ConsoleParams,
           this.cdp ? { cdp: this.cdp, tabsApi: chromeTabsApi } : undefined,
+          signal,
         );
       case "tool.snapshot":
         return handleSnapshot(
           this.sessions,
           req.params as SnapshotParams,
           this.cdp ? { cdp: this.cdp, tabsApi: chromeTabsCaptureApi } : undefined,
+          signal,
         );
       case "tool.get_html":
         return handleGetHtml(
           this.sessions,
           req.params as GetHtmlParams,
           this.cdp ? { cdp: this.cdp, tabsApi: chromeTabsCaptureApi } : undefined,
+          signal,
         );
       case "tool.navigate":
         return handleNavigate(
@@ -406,41 +413,7 @@ function isRpcError(v: unknown): v is RpcError {
   );
 }
 
-/**
- * Resolves never; rejects with `AbortLikeError` as soon as the signal
- * fires (or immediately if it is already aborted). Used by the
- * dispatcher to race the tool invocation so handlers without explicit
- * signal plumbing still surface a `cancelled` reply promptly.
- */
-function abortPromise(signal: AbortSignal): Promise<never> {
-  return new Promise<never>((_, reject) => {
-    if (signal.aborted) {
-      reject(new AbortLikeError());
-      return;
-    }
-    signal.addEventListener(
-      "abort",
-      () => {
-        reject(new AbortLikeError());
-      },
-      { once: true },
-    );
-  });
-}
-
-/**
- * Sentinel error class so [`isAbortLikeError`] can recognise our own
- * race-rejection without confusing it with a real CDP failure.
- */
-class AbortLikeError extends Error {
-  constructor() {
-    super("rpc aborted by daemon cancel");
-    this.name = "BhAbortError";
-  }
-}
-
 function isAbortLikeError(err: unknown): boolean {
-  if (err instanceof AbortLikeError) return true;
   if (err instanceof DOMException && err.name === "AbortError") return true;
   if (typeof err === "object" && err !== null && (err as { name?: string }).name === "AbortError") {
     return true;

--- a/apps/extension/src/tools/observation.ts
+++ b/apps/extension/src/tools/observation.ts
@@ -150,7 +150,9 @@ export async function handleScreenshot(
   manager: SessionManager,
   params: ScreenshotParams,
   deps: ScreenshotDeps = defaultScreenshotDeps(),
+  signal?: AbortSignal,
 ): Promise<ScreenshotResult | RpcError> {
+  if (signal?.aborted) return { code: "cancelled", message: "screenshot aborted" };
   const ctxOrErr = lookupSession(manager, params, "screenshot");
   if (isRpcError(ctxOrErr)) return ctxOrErr;
   const ctx = ctxOrErr;
@@ -170,6 +172,7 @@ export async function handleScreenshot(
     deps.cdp.trackSessionTab?.(ctx.sessionId, target.tabId);
     const captured = await captureElementScreenshot(deps.cdp, target.tabId, node.backendNodeId);
     if (isRpcError(captured)) return captured;
+    if (signal?.aborted) return { code: "cancelled", message: "screenshot aborted" };
     return withShotDialogs({
       image_base64: captured.image_base64,
       width: captured.width,
@@ -189,6 +192,7 @@ export async function handleScreenshot(
 
   try {
     const dataUrl = await deps.captureApi.captureVisibleTab(target.windowId, { format: "png" });
+    if (signal?.aborted) return { code: "cancelled", message: "screenshot aborted" };
     const image_base64 = stripDataUrlPrefix(dataUrl);
     const dims = parsePngDimensions(image_base64) ?? { width: 0, height: 0 };
     return withShotDialogs({
@@ -459,7 +463,9 @@ export async function handleGetHtml(
   manager: SessionManager,
   params: GetHtmlParams,
   deps: SnapshotDeps = getDefaultDeps(),
+  signal?: AbortSignal,
 ): Promise<GetHtmlResult | RpcError> {
+  if (signal?.aborted) return { code: "cancelled", message: "get_html aborted" };
   const ctxOrErr = lookupSession(manager, params, "get_html");
   if (isRpcError(ctxOrErr)) return ctxOrErr;
   const ctx = ctxOrErr;
@@ -498,6 +504,7 @@ export async function handleGetHtml(
       });
       html = resp.outerHTML ?? "";
     }
+    if (signal?.aborted) return { code: "cancelled", message: "get_html aborted" };
     const originalBytes = utf8ByteLength(html);
     const { out, truncated } = truncateBytes(html, maxBytes);
     return attachDialogs(deps.cdp, target.tabId, dialogCursor, {
@@ -518,7 +525,9 @@ export async function handleSnapshot(
   manager: SessionManager,
   params: SnapshotParams,
   deps: SnapshotDeps = getDefaultDeps(),
+  signal?: AbortSignal,
 ): Promise<SnapshotResult | RpcError> {
+  if (signal?.aborted) return { code: "cancelled", message: "snapshot aborted" };
   const ctxOrErr = lookupSession(manager, params, "snapshot");
   if (isRpcError(ctxOrErr)) return ctxOrErr;
   const ctx = ctxOrErr;
@@ -534,6 +543,7 @@ export async function handleSnapshot(
       "Accessibility.getFullAXTree",
       {},
     );
+    if (signal?.aborted) return { code: "cancelled", message: "snapshot aborted" };
     const rendered = renderAxTree(result.nodes ?? [], {
       maxDepth: params.max_depth,
       maxTokens: params.max_tokens,

--- a/apps/extension/src/tools/session.ts
+++ b/apps/extension/src/tools/session.ts
@@ -11,6 +11,10 @@ export interface SessionStartResult {
   agent_window_id?: number;
 }
 
+export interface SessionStartDeps {
+  signal?: AbortSignal;
+}
+
 export interface SessionStopParams {
   session_id: string;
 }
@@ -44,6 +48,7 @@ export interface SessionStopDeps {
 export async function handleSessionStart(
   manager: SessionManager,
   params: SessionStartParams,
+  deps: SessionStartDeps = {},
 ): Promise<SessionStartResult | RpcError> {
   if (!params?.session_id) {
     return {
@@ -52,9 +57,12 @@ export async function handleSessionStart(
     };
   }
   try {
-    const ctx = await manager.start(params.session_id);
+    const ctx = await manager.start(params.session_id, { signal: deps.signal });
     return { agent_window_id: ctx.agentWindowId };
   } catch (err) {
+    if (typeof err === "object" && err !== null && (err as { name?: string }).name === "AbortError") {
+      return { code: "cancelled", message: "session_start aborted" };
+    }
     // chrome.windows.create / SessionManager failures are not CDP
     // failures (§4.5 reserves cdp_failed for raw CDP errors). Surface
     // them as protocol_error so the CLI maps to the right exit code

--- a/apps/extension/src/tools/session.ts
+++ b/apps/extension/src/tools/session.ts
@@ -60,7 +60,11 @@ export async function handleSessionStart(
     const ctx = await manager.start(params.session_id, { signal: deps.signal });
     return { agent_window_id: ctx.agentWindowId };
   } catch (err) {
-    if (typeof err === "object" && err !== null && (err as { name?: string }).name === "AbortError") {
+    if (
+      typeof err === "object" &&
+      err !== null &&
+      (err as { name?: string }).name === "AbortError"
+    ) {
       return { code: "cancelled", message: "session_start aborted" };
     }
     // chrome.windows.create / SessionManager failures are not CDP

--- a/apps/extension/vitest.config.ts
+++ b/apps/extension/vitest.config.ts
@@ -21,9 +21,7 @@ export default defineConfig({
   },
   define: {
     __BSK_EXT_VERSION__: JSON.stringify(pkg.version),
-    __BSK_DAEMON_WS_URL__: JSON.stringify(
-      process.env.BSK_DAEMON_WS_URL ?? "ws://127.0.0.1:52800",
-    ),
+    __BSK_DAEMON_WS_URL__: JSON.stringify(process.env.BSK_DAEMON_WS_URL ?? "ws://127.0.0.1:52800"),
   },
   resolve: {
     alias: {

--- a/crates/bsk-cli/tests/browser_list_ordering.rs
+++ b/crates/bsk-cli/tests/browser_list_ordering.rs
@@ -16,7 +16,6 @@ use bsk_protocol::system::BrowserStatusEntry;
 use bsk_protocol::{ErrorCode, Method};
 use rand::Rng;
 use serde::Deserialize;
-use tokio::net::TcpListener;
 use tokio::sync::mpsc;
 
 fn tempfile_path(prefix: &str) -> PathBuf {
@@ -30,9 +29,7 @@ fn tempfile_path(prefix: &str) -> PathBuf {
 }
 
 async fn spawn_daemon() -> (daemon::DaemonHandle, PathBuf) {
-    let probe = TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let port = probe.local_addr().unwrap().port();
-    drop(probe);
+    let port = 0;
 
     let config = DaemonConfig::new(port);
     let sock = tempfile_path("bsk-test-browser-list");

--- a/crates/bsk-cli/tests/browser_wait.rs
+++ b/crates/bsk-cli/tests/browser_wait.rs
@@ -15,7 +15,6 @@ use bsk_protocol::system::{BrowserListParams, HandshakeParams, HandshakeResult, 
 use bsk_protocol::{BrowserPeerInfo, Method, RequestFrame, ResponseBody, ResponseFrame};
 use futures_util::{SinkExt, StreamExt};
 use rand::Rng;
-use tokio::net::TcpListener;
 use tokio_tungstenite::tungstenite::handshake::client::generate_key;
 use tokio_tungstenite::tungstenite::http::Request;
 use tokio_tungstenite::tungstenite::protocol::Message;
@@ -77,9 +76,7 @@ fn tempfile_path(prefix: &str) -> PathBuf {
 }
 
 async fn spawn_daemon() -> (daemon::DaemonHandle, PathBuf) {
-    let probe = TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let port = probe.local_addr().unwrap().port();
-    drop(probe);
+    let port = 0;
 
     let config = DaemonConfig::new(port);
     let sock = tempfile_path("bsk-test-browser-wait");

--- a/crates/bsk-cli/tests/cancel_forwarding.rs
+++ b/crates/bsk-cli/tests/cancel_forwarding.rs
@@ -20,7 +20,6 @@ use bsk_protocol::{
 use futures_util::{SinkExt, StreamExt};
 use rand::Rng;
 use serde_json::json;
-use tokio::net::TcpListener;
 use tokio_tungstenite::tungstenite::handshake::client::generate_key;
 use tokio_tungstenite::tungstenite::http::Request;
 use tokio_tungstenite::tungstenite::protocol::Message;
@@ -40,9 +39,7 @@ fn tempfile_path(prefix: &str) -> PathBuf {
 }
 
 async fn spawn_daemon() -> (daemon::DaemonHandle, PathBuf) {
-    let probe = TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let port = probe.local_addr().unwrap().port();
-    drop(probe);
+    let port = 0;
 
     let config = DaemonConfig::new(port);
     let sock = tempfile_path("bsk-test-cancel");

--- a/crates/bsk-cli/tests/handshake_compat.rs
+++ b/crates/bsk-cli/tests/handshake_compat.rs
@@ -10,7 +10,6 @@ use bsk_protocol::system::{HandshakeParams, HandshakeResult, StatusResult};
 use bsk_protocol::{BrowserPeerInfo, ErrorCode, Method, RequestFrame, ResponseBody, ResponseFrame};
 use futures_util::{SinkExt, StreamExt};
 use rand::Rng;
-use tokio::net::TcpListener;
 use tokio_tungstenite::tungstenite::handshake::client::generate_key;
 use tokio_tungstenite::tungstenite::http::Request;
 use tokio_tungstenite::tungstenite::protocol::Message;
@@ -28,9 +27,7 @@ fn tempfile_path(prefix: &str) -> PathBuf {
 }
 
 async fn spawn_daemon() -> (daemon::DaemonHandle, PathBuf) {
-    let probe = TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let port = probe.local_addr().unwrap().port();
-    drop(probe);
+    let port = 0;
 
     let config = DaemonConfig::new(port);
     let sock = tempfile_path("bsk-test-handshake");

--- a/crates/bsk-cli/tests/per_session_queue.rs
+++ b/crates/bsk-cli/tests/per_session_queue.rs
@@ -27,7 +27,6 @@ use futures_util::{SinkExt, StreamExt};
 use rand::Rng;
 use serde::Deserialize;
 use serde_json::json;
-use tokio::net::TcpListener;
 use tokio::sync::{Mutex, mpsc};
 use tokio_tungstenite::tungstenite::handshake::client::generate_key;
 use tokio_tungstenite::tungstenite::http::Request;
@@ -46,9 +45,7 @@ fn tempfile_path(prefix: &str) -> PathBuf {
 }
 
 async fn spawn_daemon() -> (daemon::DaemonHandle, PathBuf) {
-    let probe = TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let port = probe.local_addr().unwrap().port();
-    drop(probe);
+    let port = 0;
     let sock = tempfile_path("bsk-test-queue");
     let handle = daemon::run(DaemonConfig::new(port), Some(sock.clone()))
         .await

--- a/crates/bsk-cli/tests/session_user_interrupt.rs
+++ b/crates/bsk-cli/tests/session_user_interrupt.rs
@@ -26,7 +26,6 @@ use bsk_protocol::{
 use futures_util::{SinkExt, StreamExt};
 use rand::Rng;
 use serde_json::json;
-use tokio::net::TcpListener;
 use tokio_tungstenite::tungstenite::handshake::client::generate_key;
 use tokio_tungstenite::tungstenite::http::Request;
 use tokio_tungstenite::tungstenite::protocol::Message;
@@ -46,9 +45,7 @@ fn tempfile_path(prefix: &str) -> PathBuf {
 }
 
 async fn spawn_daemon() -> (daemon::DaemonHandle, PathBuf) {
-    let probe = TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let port = probe.local_addr().unwrap().port();
-    drop(probe);
+    let port = 0;
 
     let config = DaemonConfig::new(port);
     let sock = tempfile_path("bsk-test-user-interrupt");

--- a/crates/bsk-cli/tests/sessions_ipc.rs
+++ b/crates/bsk-cli/tests/sessions_ipc.rs
@@ -15,7 +15,6 @@ use bsk_protocol::tools::{SessionStartParams, SessionStartResult, SessionStopPar
 use bsk_protocol::{BrowserPeerInfo, Frame, Method, RequestFrame, ResponseBody, ResponseFrame};
 use futures_util::{SinkExt, StreamExt};
 use rand::Rng;
-use tokio::net::TcpListener;
 use tokio_tungstenite::tungstenite::handshake::client::generate_key;
 use tokio_tungstenite::tungstenite::http::Request;
 use tokio_tungstenite::tungstenite::protocol::Message;
@@ -39,9 +38,7 @@ async fn spawn_daemon() -> (daemon::DaemonHandle, PathBuf) {
 }
 
 async fn spawn_daemon_with_connect_wait(connect_wait: Duration) -> (daemon::DaemonHandle, PathBuf) {
-    let probe = TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let port = probe.local_addr().unwrap().port();
-    drop(probe);
+    let port = 0;
 
     let config = DaemonConfig::new(port).with_extension_connect_wait(connect_wait);
     let sock = tempfile_path("bsk-test-ipc");

--- a/crates/bsk-cli/tests/tools_ipc.rs
+++ b/crates/bsk-cli/tests/tools_ipc.rs
@@ -21,7 +21,6 @@ use futures_util::stream::{SplitSink, SplitStream};
 use futures_util::{SinkExt, StreamExt};
 use rand::Rng;
 use serde_json::{Value, json};
-use tokio::net::TcpListener;
 use tokio::sync::Mutex;
 use tokio_tungstenite::tungstenite::handshake::client::generate_key;
 use tokio_tungstenite::tungstenite::http::Request;
@@ -40,9 +39,7 @@ fn tempfile_path(prefix: &str) -> PathBuf {
 }
 
 async fn spawn_daemon() -> (daemon::DaemonHandle, PathBuf) {
-    let probe = TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let port = probe.local_addr().unwrap().port();
-    drop(probe);
+    let port = 0;
     let sock = tempfile_path("bsk-test-tools");
     let handle = daemon::run(DaemonConfig::new(port), Some(sock.clone()))
         .await

--- a/crates/bsk-cli/tests/tools_m7_ipc.rs
+++ b/crates/bsk-cli/tests/tools_m7_ipc.rs
@@ -25,7 +25,6 @@ use futures_util::stream::{SplitSink, SplitStream};
 use futures_util::{SinkExt, StreamExt};
 use rand::Rng;
 use serde_json::{Value, json};
-use tokio::net::TcpListener;
 use tokio::sync::Mutex;
 use tokio_tungstenite::tungstenite::handshake::client::generate_key;
 use tokio_tungstenite::tungstenite::http::Request;
@@ -44,9 +43,7 @@ fn tempfile_path(prefix: &str) -> PathBuf {
 }
 
 async fn spawn_daemon() -> (daemon::DaemonHandle, PathBuf) {
-    let probe = TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let port = probe.local_addr().unwrap().port();
-    drop(probe);
+    let port = 0;
     let sock = tempfile_path("bsk-test-tools-m7");
     let handle = daemon::run(DaemonConfig::new(port), Some(sock.clone()))
         .await

--- a/crates/bsk-cli/tests/tools_m8_ipc.rs
+++ b/crates/bsk-cli/tests/tools_m8_ipc.rs
@@ -24,7 +24,6 @@ use futures_util::stream::{SplitSink, SplitStream};
 use futures_util::{SinkExt, StreamExt};
 use rand::Rng;
 use serde_json::Value;
-use tokio::net::TcpListener;
 use tokio::sync::Mutex;
 use tokio_tungstenite::tungstenite::handshake::client::generate_key;
 use tokio_tungstenite::tungstenite::http::Request;
@@ -43,9 +42,7 @@ fn tempfile_path(prefix: &str) -> PathBuf {
 }
 
 async fn spawn_daemon() -> (daemon::DaemonHandle, PathBuf) {
-    let probe = TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let port = probe.local_addr().unwrap().port();
-    drop(probe);
+    let port = 0;
     let sock = tempfile_path("bsk-test-tools-m8");
     let handle = daemon::run(DaemonConfig::new(port), Some(sock.clone()))
         .await

--- a/crates/bsk-cli/tests/tools_m9_ipc.rs
+++ b/crates/bsk-cli/tests/tools_m9_ipc.rs
@@ -30,7 +30,6 @@ use rand::Rng;
 use serde_json::{Value, json};
 #[cfg(unix)]
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
-use tokio::net::TcpListener;
 #[cfg(unix)]
 use tokio::net::UnixStream;
 use tokio::sync::Mutex;
@@ -53,9 +52,7 @@ fn tempfile_path(prefix: &str) -> PathBuf {
 }
 
 async fn spawn_daemon() -> (daemon::DaemonHandle, PathBuf) {
-    let probe = TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let port = probe.local_addr().unwrap().port();
-    drop(probe);
+    let port = 0;
     let sock = tempfile_path("bsk-test-tools-m9");
     let handle = daemon::run(DaemonConfig::new(port), Some(sock.clone()))
         .await

--- a/crates/bsk-cli/tests/ws_handshake.rs
+++ b/crates/bsk-cli/tests/ws_handshake.rs
@@ -8,7 +8,6 @@ use bsk::daemon::{self, DaemonConfig};
 use bsk_protocol::system::{HandshakeParams, HandshakeResult};
 use bsk_protocol::{BrowserPeerInfo, Method, RequestFrame, ResponseBody, ResponseFrame};
 use futures_util::{SinkExt, StreamExt};
-use tokio::net::TcpListener;
 use tokio_tungstenite::tungstenite::handshake::client::generate_key;
 use tokio_tungstenite::tungstenite::http::Request;
 use tokio_tungstenite::tungstenite::protocol::Message;
@@ -17,9 +16,7 @@ pub const TEST_EXT_ID: &str = "abcdefghijklmnopabcdefghijklmnop"; // 32 chars in
 
 pub async fn spawn_daemon() -> daemon::DaemonHandle {
     // Bind to any free TCP port.
-    let probe = TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let port = probe.local_addr().unwrap().port();
-    drop(probe);
+    let port = 0;
 
     let config = DaemonConfig::new(port);
     daemon::run(config, None).await.unwrap()


### PR DESCRIPTION
## What problem this solves

The extension previously implemented cancellation by racing every tool handler against a promise that rejected as soon as an AbortSignal fired. That made the RPC appear cancelled immediately, but it did not stop the handler that lost the race.

For read-only work this wasted CDP work and could corrupt later state: a cancelled snapshot could finish after a newer snapshot and replace the session RefStore with stale element ids. For mutating work the impact was more visible. Cancelling `tool.session_start` while `chrome.windows.create` was pending caused the daemon to discard its reservation, but the unresolved handler later created and registered an Agent Window that the daemon did not know about.

Several tab handlers already contained abort checks and compensation logic, but the dispatcher did not pass their AbortSignal. The result was a cancellation protocol that acknowledged cancellation without establishing that the underlying browser operation had stopped or rolled back.

## How this fixes it

The dispatcher no longer uses `Promise.race` to manufacture an early cancelled response. It still acknowledges the separate `cancel` request immediately, but the original tool RPC now waits for its handler to observe the signal and finish any necessary compensation before sending its final response.

Cancellation is wired through the previously disconnected paths:

- `session_start` receives the AbortSignal;
- tab create, close, select, borrow, and return receive the AbortSignal;
- screenshot, console, get-html, and snapshot receive cancellation checks around their awaited browser/CDP work;
- navigation, interaction, evaluate, wait, and human-loop handlers retain their existing signal plumbing.

`SessionManager.start` now treats Agent Window creation as a transactional operation. If cancellation arrives after `windows.create`, or if active-tab initialization fails, it removes the incomplete window and does not register the session. The session handler maps this AbortError to the structured `cancelled` result.

Snapshot checks the signal before replacing RefStore contents. A cancelled older snapshot can therefore finish its underlying CDP request without overwriting refs produced by later work.

## Cancellation boundary

Some Chrome APIs are irreversible after dispatch, such as removing a tab that Chrome has already accepted. The fix does not pretend those operations can be rolled back. Instead, it guarantees that BrowserSkill does not send the original RPC response while a handler is still running invisibly. Handlers with a reversible side effect, such as creating a tab or Agent Window, perform compensation before returning cancelled.

## User impact

Cancelling a slow command no longer leaves hidden Agent Windows or silently mutates the element-ref state after the CLI has moved on. The cancel control remains responsive because its own acknowledgement is immediate, while the cancelled tool's final lifecycle is now truthful and deterministic.

The change also fixes a non-cancellation leak: if Agent Window active-tab setup fails after window creation, the partial window is removed.

## Validation

- `corepack pnpm --filter @browser-skill/extension test`
  - 35 test files passed
  - 376 tests passed
- `corepack pnpm --filter @browser-skill/extension compile`
- `corepack pnpm ext:build`
- `node --test scripts/*.test.mjs`
- `corepack pnpm exec stylelint "**/*.css"`
- `git diff --check`

Regression tests verify that:

- cancel acknowledgement is immediate but the original session-start RPC remains pending until cleanup finishes;
- the created Agent Window is removed and no SessionContext is registered;
- startup setup failures also remove incomplete windows;
- a snapshot cancelled during CDP capture leaves the previous RefStore untouched.

## CI Baseline Compatibility

This branch also carries the one-line Biome 2.4 formatter output for `apps/extension/vitest.config.ts`. The same formatting mismatch currently fails the Frontend job on `upstream/main`; this minimal compatibility commit is intentionally separate from the functional fix and lets this PR run the repository CI suite to completion.

## CI Reliability Follow-up

GitHub Actions exposed a pre-existing test-only port allocation race: integration helpers probed an ephemeral port, released it, and then asked the daemon to bind the same number, allowing another process to claim it in between. The resulting `Address already in use` failure was unrelated to the functional changes. The PR now lets each daemon bind port `0` directly and reads the assigned address from its handle, removing the TOCTOU window across all affected integration helpers.