### PR TITLE
fix(update): apply staged Windows replacement

### DIFF
--- a/apps/extension/vitest.config.ts
+++ b/apps/extension/vitest.config.ts
@@ -21,9 +21,7 @@ export default defineConfig({
   },
   define: {
     __BSK_EXT_VERSION__: JSON.stringify(pkg.version),
-    __BSK_DAEMON_WS_URL__: JSON.stringify(
-      process.env.BSK_DAEMON_WS_URL ?? "ws://127.0.0.1:52800",
-    ),
+    __BSK_DAEMON_WS_URL__: JSON.stringify(process.env.BSK_DAEMON_WS_URL ?? "ws://127.0.0.1:52800"),
   },
   resolve: {
     alias: {

--- a/crates/bsk-cli/src/cli/update.rs
+++ b/crates/bsk-cli/src/cli/update.rs
@@ -5,6 +5,11 @@ use std::io::{Cursor, Read, Write};
 use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime};
 
+#[cfg(windows)]
+use std::os::windows::process::CommandExt;
+#[cfg(windows)]
+use std::process::{Command, Stdio};
+
 use anyhow::{Context, Result, bail};
 use clap::Args;
 use flate2::read::GzDecoder;
@@ -246,20 +251,33 @@ fn run(args: UpdateArgs, format: Format) -> Result<()> {
         InstallAction::Replaced => "replaced",
         InstallAction::Staged => "staged",
     };
+    let (status, message) = match action {
+        InstallAction::Replaced => (
+            "updated",
+            format!(
+                "updated bsk from {} to {}",
+                candidate.current, candidate.latest
+            ),
+        ),
+        InstallAction::Staged => (
+            "staged",
+            format!(
+                "staged bsk {} for replacement after this command exits",
+                candidate.latest
+            ),
+        ),
+    };
 
     render_report(
         format,
         &UpdateReport {
-            status: "updated",
+            status,
             current_version: candidate.current.to_string(),
             latest_version: Some(candidate.latest.to_string()),
             release_url: candidate.release_url,
             asset_url: Some(candidate.asset.url),
             install_action: Some(action_label),
-            message: format!(
-                "updated bsk from {} to {}",
-                candidate.current, candidate.latest
-            ),
+            message,
         },
     )
 }
@@ -335,7 +353,7 @@ fn install_candidate_with_client(
         crate::daemon::start::run_stop().context("stop bsk daemon before update")?;
     }
 
-    let action = replace_binary_at_path(&target, &binary)?;
+    let action = replace_binary_for_update(&target, &binary, daemon_was_running)?;
 
     if daemon_was_running && matches!(action, InstallAction::Replaced) {
         crate::daemon::start::run_start(StartArgs::default())
@@ -502,9 +520,7 @@ fn render_report(format: Format, report: &UpdateReport) -> Result<()> {
                 println!("release: {release_url}");
             }
             if matches!(report.install_action, Some("staged")) {
-                println!(
-                    "restart your terminal and run `bsk --version` to verify the staged update"
-                );
+                println!("the detached update helper will apply the replacement after exit");
             }
         }
         Format::Json => {
@@ -525,13 +541,22 @@ pub fn extract_bsk_binary(archive_bytes: &[u8], kind: ArchiveKind) -> Result<Vec
 }
 
 pub fn replace_binary_at_path(target: &Path, binary: &[u8]) -> Result<InstallAction> {
+    replace_binary_for_update(target, binary, false)
+}
+
+fn replace_binary_for_update(
+    target: &Path,
+    binary: &[u8],
+    restart_daemon: bool,
+) -> Result<InstallAction> {
     #[cfg(windows)]
     {
-        stage_windows_replacement(target, binary)
+        stage_windows_replacement(target, binary, restart_daemon)
     }
 
     #[cfg(not(windows))]
     {
+        let _ = restart_daemon;
         replace_binary_atomically(target, binary)
     }
 }
@@ -574,15 +599,35 @@ fn replace_binary_atomically(target: &Path, binary: &[u8]) -> Result<InstallActi
 }
 
 #[cfg(windows)]
-fn stage_windows_replacement(target: &Path, binary: &[u8]) -> Result<InstallAction> {
+fn stage_windows_replacement(
+    target: &Path,
+    binary: &[u8],
+    restart_daemon: bool,
+) -> Result<InstallAction> {
     let paths = staged_replacement_paths(target, std::process::id())?;
     std::fs::write(&paths.binary_path, binary)
         .with_context(|| format!("write {}", paths.binary_path.display()))?;
     std::fs::write(
         &paths.script_path,
-        windows_replacement_script(target, &paths.binary_path),
+        windows_replacement_script(target, &paths.binary_path, restart_daemon),
     )
     .with_context(|| format!("write {}", paths.script_path.display()))?;
+
+    const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+    let command = format!("\"{}\"", paths.script_path.display());
+    if let Err(err) = Command::new("cmd.exe")
+        .args(["/D", "/S", "/C"])
+        .arg(command)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .creation_flags(CREATE_NO_WINDOW)
+        .spawn()
+    {
+        let _ = std::fs::remove_file(&paths.binary_path);
+        let _ = std::fs::remove_file(&paths.script_path);
+        return Err(err).context("launch detached Windows update helper");
+    }
     Ok(InstallAction::Staged)
 }
 
@@ -599,19 +644,26 @@ pub fn staged_replacement_paths(target: &Path, pid: u32) -> Result<StagedReplace
     })
 }
 
-#[cfg(windows)]
-fn windows_replacement_script(target: &Path, staged_binary: &Path) -> String {
+#[cfg(any(windows, test))]
+fn windows_replacement_script(target: &Path, staged_binary: &Path, restart_daemon: bool) -> String {
+    let target = target.display().to_string().replace('%', "%%");
+    let staged_binary = staged_binary.display().to_string().replace('%', "%%");
+    let restart = if restart_daemon {
+        format!("start \"\" /B \"{target}\" daemon start >nul 2>nul\r\n")
+    } else {
+        String::new()
+    };
     format!(
         "@echo off\r\n\
          setlocal\r\n\
          :retry\r\n\
-         move /Y \"{}\" \"{}\" >nul 2>nul\r\n\
+         move /Y \"{staged_binary}\" \"{target}\" >nul 2>nul\r\n\
          if errorlevel 1 (\r\n\
            timeout /t 1 /nobreak >nul\r\n\
            goto retry\r\n\
-         )\r\n",
-        staged_binary.display(),
-        target.display()
+         )\r\n\
+         {restart}\
+         del /F /Q \"%~f0\" >nul 2>nul\r\n"
     )
 }
 
@@ -796,6 +848,32 @@ mod tests {
             paths.script_path,
             std::path::Path::new("/tmp/bsk.exe.update-42.cmd")
         );
+    }
+
+    #[test]
+    fn windows_replacement_script_retries_restarts_and_cleans_itself() {
+        let script = windows_replacement_script(
+            Path::new(r"C:\Program Files\bsk.exe"),
+            Path::new(r"C:\Program Files\bsk.exe.update-42"),
+            true,
+        );
+
+        assert!(script.contains(":retry"));
+        assert!(script.contains("move /Y"));
+        assert!(script.contains(r#"start "" /B "C:\Program Files\bsk.exe" daemon start"#));
+        assert!(script.contains(r#"del /F /Q "%~f0""#));
+    }
+
+    #[test]
+    fn windows_replacement_script_omits_restart_when_daemon_was_not_running() {
+        let script = windows_replacement_script(
+            Path::new(r"C:\bsk.exe"),
+            Path::new(r"C:\bsk.exe.update-42"),
+            false,
+        );
+
+        assert!(!script.contains("daemon start"));
+        assert!(script.contains(r#"del /F /Q "%~f0""#));
     }
 
     #[test]

--- a/crates/bsk-cli/tests/browser_list_ordering.rs
+++ b/crates/bsk-cli/tests/browser_list_ordering.rs
@@ -16,7 +16,6 @@ use bsk_protocol::system::BrowserStatusEntry;
 use bsk_protocol::{ErrorCode, Method};
 use rand::Rng;
 use serde::Deserialize;
-use tokio::net::TcpListener;
 use tokio::sync::mpsc;
 
 fn tempfile_path(prefix: &str) -> PathBuf {
@@ -30,9 +29,7 @@ fn tempfile_path(prefix: &str) -> PathBuf {
 }
 
 async fn spawn_daemon() -> (daemon::DaemonHandle, PathBuf) {
-    let probe = TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let port = probe.local_addr().unwrap().port();
-    drop(probe);
+    let port = 0;
 
     let config = DaemonConfig::new(port);
     let sock = tempfile_path("bsk-test-browser-list");

--- a/crates/bsk-cli/tests/browser_wait.rs
+++ b/crates/bsk-cli/tests/browser_wait.rs
@@ -15,7 +15,6 @@ use bsk_protocol::system::{BrowserListParams, HandshakeParams, HandshakeResult, 
 use bsk_protocol::{BrowserPeerInfo, Method, RequestFrame, ResponseBody, ResponseFrame};
 use futures_util::{SinkExt, StreamExt};
 use rand::Rng;
-use tokio::net::TcpListener;
 use tokio_tungstenite::tungstenite::handshake::client::generate_key;
 use tokio_tungstenite::tungstenite::http::Request;
 use tokio_tungstenite::tungstenite::protocol::Message;
@@ -77,9 +76,7 @@ fn tempfile_path(prefix: &str) -> PathBuf {
 }
 
 async fn spawn_daemon() -> (daemon::DaemonHandle, PathBuf) {
-    let probe = TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let port = probe.local_addr().unwrap().port();
-    drop(probe);
+    let port = 0;
 
     let config = DaemonConfig::new(port);
     let sock = tempfile_path("bsk-test-browser-wait");

--- a/crates/bsk-cli/tests/cancel_forwarding.rs
+++ b/crates/bsk-cli/tests/cancel_forwarding.rs
@@ -20,7 +20,6 @@ use bsk_protocol::{
 use futures_util::{SinkExt, StreamExt};
 use rand::Rng;
 use serde_json::json;
-use tokio::net::TcpListener;
 use tokio_tungstenite::tungstenite::handshake::client::generate_key;
 use tokio_tungstenite::tungstenite::http::Request;
 use tokio_tungstenite::tungstenite::protocol::Message;
@@ -40,9 +39,7 @@ fn tempfile_path(prefix: &str) -> PathBuf {
 }
 
 async fn spawn_daemon() -> (daemon::DaemonHandle, PathBuf) {
-    let probe = TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let port = probe.local_addr().unwrap().port();
-    drop(probe);
+    let port = 0;
 
     let config = DaemonConfig::new(port);
     let sock = tempfile_path("bsk-test-cancel");

--- a/crates/bsk-cli/tests/handshake_compat.rs
+++ b/crates/bsk-cli/tests/handshake_compat.rs
@@ -10,7 +10,6 @@ use bsk_protocol::system::{HandshakeParams, HandshakeResult, StatusResult};
 use bsk_protocol::{BrowserPeerInfo, ErrorCode, Method, RequestFrame, ResponseBody, ResponseFrame};
 use futures_util::{SinkExt, StreamExt};
 use rand::Rng;
-use tokio::net::TcpListener;
 use tokio_tungstenite::tungstenite::handshake::client::generate_key;
 use tokio_tungstenite::tungstenite::http::Request;
 use tokio_tungstenite::tungstenite::protocol::Message;
@@ -28,9 +27,7 @@ fn tempfile_path(prefix: &str) -> PathBuf {
 }
 
 async fn spawn_daemon() -> (daemon::DaemonHandle, PathBuf) {
-    let probe = TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let port = probe.local_addr().unwrap().port();
-    drop(probe);
+    let port = 0;
 
     let config = DaemonConfig::new(port);
     let sock = tempfile_path("bsk-test-handshake");

--- a/crates/bsk-cli/tests/per_session_queue.rs
+++ b/crates/bsk-cli/tests/per_session_queue.rs
@@ -27,7 +27,6 @@ use futures_util::{SinkExt, StreamExt};
 use rand::Rng;
 use serde::Deserialize;
 use serde_json::json;
-use tokio::net::TcpListener;
 use tokio::sync::{Mutex, mpsc};
 use tokio_tungstenite::tungstenite::handshake::client::generate_key;
 use tokio_tungstenite::tungstenite::http::Request;
@@ -46,9 +45,7 @@ fn tempfile_path(prefix: &str) -> PathBuf {
 }
 
 async fn spawn_daemon() -> (daemon::DaemonHandle, PathBuf) {
-    let probe = TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let port = probe.local_addr().unwrap().port();
-    drop(probe);
+    let port = 0;
     let sock = tempfile_path("bsk-test-queue");
     let handle = daemon::run(DaemonConfig::new(port), Some(sock.clone()))
         .await

--- a/crates/bsk-cli/tests/session_user_interrupt.rs
+++ b/crates/bsk-cli/tests/session_user_interrupt.rs
@@ -26,7 +26,6 @@ use bsk_protocol::{
 use futures_util::{SinkExt, StreamExt};
 use rand::Rng;
 use serde_json::json;
-use tokio::net::TcpListener;
 use tokio_tungstenite::tungstenite::handshake::client::generate_key;
 use tokio_tungstenite::tungstenite::http::Request;
 use tokio_tungstenite::tungstenite::protocol::Message;
@@ -46,9 +45,7 @@ fn tempfile_path(prefix: &str) -> PathBuf {
 }
 
 async fn spawn_daemon() -> (daemon::DaemonHandle, PathBuf) {
-    let probe = TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let port = probe.local_addr().unwrap().port();
-    drop(probe);
+    let port = 0;
 
     let config = DaemonConfig::new(port);
     let sock = tempfile_path("bsk-test-user-interrupt");

--- a/crates/bsk-cli/tests/sessions_ipc.rs
+++ b/crates/bsk-cli/tests/sessions_ipc.rs
@@ -15,7 +15,6 @@ use bsk_protocol::tools::{SessionStartParams, SessionStartResult, SessionStopPar
 use bsk_protocol::{BrowserPeerInfo, Frame, Method, RequestFrame, ResponseBody, ResponseFrame};
 use futures_util::{SinkExt, StreamExt};
 use rand::Rng;
-use tokio::net::TcpListener;
 use tokio_tungstenite::tungstenite::handshake::client::generate_key;
 use tokio_tungstenite::tungstenite::http::Request;
 use tokio_tungstenite::tungstenite::protocol::Message;
@@ -39,9 +38,7 @@ async fn spawn_daemon() -> (daemon::DaemonHandle, PathBuf) {
 }
 
 async fn spawn_daemon_with_connect_wait(connect_wait: Duration) -> (daemon::DaemonHandle, PathBuf) {
-    let probe = TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let port = probe.local_addr().unwrap().port();
-    drop(probe);
+    let port = 0;
 
     let config = DaemonConfig::new(port).with_extension_connect_wait(connect_wait);
     let sock = tempfile_path("bsk-test-ipc");

--- a/crates/bsk-cli/tests/tools_ipc.rs
+++ b/crates/bsk-cli/tests/tools_ipc.rs
@@ -21,7 +21,6 @@ use futures_util::stream::{SplitSink, SplitStream};
 use futures_util::{SinkExt, StreamExt};
 use rand::Rng;
 use serde_json::{Value, json};
-use tokio::net::TcpListener;
 use tokio::sync::Mutex;
 use tokio_tungstenite::tungstenite::handshake::client::generate_key;
 use tokio_tungstenite::tungstenite::http::Request;
@@ -40,9 +39,7 @@ fn tempfile_path(prefix: &str) -> PathBuf {
 }
 
 async fn spawn_daemon() -> (daemon::DaemonHandle, PathBuf) {
-    let probe = TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let port = probe.local_addr().unwrap().port();
-    drop(probe);
+    let port = 0;
     let sock = tempfile_path("bsk-test-tools");
     let handle = daemon::run(DaemonConfig::new(port), Some(sock.clone()))
         .await

--- a/crates/bsk-cli/tests/tools_m7_ipc.rs
+++ b/crates/bsk-cli/tests/tools_m7_ipc.rs
@@ -25,7 +25,6 @@ use futures_util::stream::{SplitSink, SplitStream};
 use futures_util::{SinkExt, StreamExt};
 use rand::Rng;
 use serde_json::{Value, json};
-use tokio::net::TcpListener;
 use tokio::sync::Mutex;
 use tokio_tungstenite::tungstenite::handshake::client::generate_key;
 use tokio_tungstenite::tungstenite::http::Request;
@@ -44,9 +43,7 @@ fn tempfile_path(prefix: &str) -> PathBuf {
 }
 
 async fn spawn_daemon() -> (daemon::DaemonHandle, PathBuf) {
-    let probe = TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let port = probe.local_addr().unwrap().port();
-    drop(probe);
+    let port = 0;
     let sock = tempfile_path("bsk-test-tools-m7");
     let handle = daemon::run(DaemonConfig::new(port), Some(sock.clone()))
         .await

--- a/crates/bsk-cli/tests/tools_m8_ipc.rs
+++ b/crates/bsk-cli/tests/tools_m8_ipc.rs
@@ -24,7 +24,6 @@ use futures_util::stream::{SplitSink, SplitStream};
 use futures_util::{SinkExt, StreamExt};
 use rand::Rng;
 use serde_json::Value;
-use tokio::net::TcpListener;
 use tokio::sync::Mutex;
 use tokio_tungstenite::tungstenite::handshake::client::generate_key;
 use tokio_tungstenite::tungstenite::http::Request;
@@ -43,9 +42,7 @@ fn tempfile_path(prefix: &str) -> PathBuf {
 }
 
 async fn spawn_daemon() -> (daemon::DaemonHandle, PathBuf) {
-    let probe = TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let port = probe.local_addr().unwrap().port();
-    drop(probe);
+    let port = 0;
     let sock = tempfile_path("bsk-test-tools-m8");
     let handle = daemon::run(DaemonConfig::new(port), Some(sock.clone()))
         .await

--- a/crates/bsk-cli/tests/tools_m9_ipc.rs
+++ b/crates/bsk-cli/tests/tools_m9_ipc.rs
@@ -30,7 +30,6 @@ use rand::Rng;
 use serde_json::{Value, json};
 #[cfg(unix)]
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
-use tokio::net::TcpListener;
 #[cfg(unix)]
 use tokio::net::UnixStream;
 use tokio::sync::Mutex;
@@ -53,9 +52,7 @@ fn tempfile_path(prefix: &str) -> PathBuf {
 }
 
 async fn spawn_daemon() -> (daemon::DaemonHandle, PathBuf) {
-    let probe = TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let port = probe.local_addr().unwrap().port();
-    drop(probe);
+    let port = 0;
     let sock = tempfile_path("bsk-test-tools-m9");
     let handle = daemon::run(DaemonConfig::new(port), Some(sock.clone()))
         .await

--- a/crates/bsk-cli/tests/ws_handshake.rs
+++ b/crates/bsk-cli/tests/ws_handshake.rs
@@ -8,7 +8,6 @@ use bsk::daemon::{self, DaemonConfig};
 use bsk_protocol::system::{HandshakeParams, HandshakeResult};
 use bsk_protocol::{BrowserPeerInfo, Method, RequestFrame, ResponseBody, ResponseFrame};
 use futures_util::{SinkExt, StreamExt};
-use tokio::net::TcpListener;
 use tokio_tungstenite::tungstenite::handshake::client::generate_key;
 use tokio_tungstenite::tungstenite::http::Request;
 use tokio_tungstenite::tungstenite::protocol::Message;
@@ -17,9 +16,7 @@ pub const TEST_EXT_ID: &str = "abcdefghijklmnopabcdefghijklmnop"; // 32 chars in
 
 pub async fn spawn_daemon() -> daemon::DaemonHandle {
     // Bind to any free TCP port.
-    let probe = TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let port = probe.local_addr().unwrap().port();
-    drop(probe);
+    let port = 0;
 
     let config = DaemonConfig::new(port);
     daemon::run(config, None).await.unwrap()


### PR DESCRIPTION
## What Problem This Solves

On Windows, `bsk update` could report a successful update even though the installed executable was never replaced. The updater wrote a staged executable and a `.cmd` replacement script next to the running binary, then returned `InstallAction::Staged`, but nothing launched that script. The old executable therefore remained installed indefinitely.

This also created a daemon availability problem. The update flow stops a running daemon before replacing the binary. Because the staged replacement never ran—and because the Windows path did not preserve the previous daemon state—the command could leave users on the old version with their daemon stopped while still printing an update-style success message.

## How This Fix Works

- Launch the generated Windows replacement script as a detached, no-window `cmd.exe` process before the updater exits.
- Keep retrying the move until the currently running `bsk.exe` releases its file lock, then atomically replace the target from the staged executable.
- Carry the pre-update daemon state into the helper and restart the daemon only when it had been running before the update.
- Delete the helper script after a successful replacement so update artifacts do not accumulate beside the executable.
- Remove both staged files if the helper cannot be launched, and return an error instead of claiming that the update was staged successfully.
- Report staged updates with a distinct `staged` status and wording that accurately describes when the replacement will occur.
- Escape percent characters in generated paths so Windows environment-variable expansion cannot corrupt the helper commands.

## User Impact

Windows users can now run `bsk update` and have the staged version applied automatically after the command exits. A daemon that was running before the update comes back on the new binary, while an intentionally stopped daemon remains stopped. Failed helper launches are visible as failures rather than false-positive update reports.

## Validation

- `cargo fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- Added focused tests covering replacement retries, conditional daemon restart, helper self-cleanup, and the no-restart path.

The full local Rust workspace suite passed. A local GNU Windows cross-check was also attempted, but this macOS environment does not provide the `x86_64-w64-mingw32-gcc` toolchain required by the transitive `aws-lc-sys` build; GitHub CI remains the authoritative clean-environment build check for the PR.

## CI Baseline Compatibility

This branch also carries the one-line Biome 2.4 formatter output for `apps/extension/vitest.config.ts`. The same formatting mismatch currently fails the Frontend job on `upstream/main`; this minimal compatibility commit is intentionally separate from the functional fix and lets this PR run the repository CI suite to completion.

## CI Reliability Follow-up

GitHub Actions exposed a pre-existing test-only port allocation race: integration helpers probed an ephemeral port, released it, and then asked the daemon to bind the same number, allowing another process to claim it in between. The resulting `Address already in use` failure was unrelated to the functional changes. The PR now lets each daemon bind port `0` directly and reads the assigned address from its handle, removing the TOCTOU window across all affected integration helpers.