### PR TITLE
feat: add semantic record flow with Trace v3 textbook export

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,7 +134,7 @@ dependencies = [
 
 [[package]]
 name = "bsk"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "bsk-protocol",
@@ -168,7 +168,7 @@ dependencies = [
 
 [[package]]
 name = "bsk-protocol"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "schemars",
  "semver",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 default-members = ["crates/bsk-cli"]
 
 [workspace.package]
-version = "0.1.7"
+version = "0.1.8"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT"
@@ -42,7 +42,7 @@ rand = "0.8"
 uuid = { version = "1", features = ["v4", "serde"] }
 
 # Workspace crates (version required for `cargo publish` of dependents)
-bsk-protocol = { version = "0.1.7", path = "crates/bsk-protocol" }
+bsk-protocol = { version = "0.1.8", path = "crates/bsk-protocol" }
 
 [profile.release]
 strip = "symbols"

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@browser-skill/extension",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/extension/src/content/ControlOverlay.tsx
+++ b/apps/extension/src/content/ControlOverlay.tsx
@@ -58,6 +58,7 @@ export function ControlOverlay({
       />
 
       <div
+        data-slot="control-overlay-blocker"
         onPointerDown={(event) => {
           if (automationBypass) return;
           event.preventDefault();
@@ -80,13 +81,16 @@ export function ControlOverlay({
       />
 
       <div
+        data-slot="control-overlay-pill"
         style={{
           position: "fixed",
           bottom: 32,
           left: "50%",
           transform: "translateX(-50%)",
           zIndex: 2147483647,
-          pointerEvents,
+          // Always receive clicks so Interrupt works even while the page
+          // blocker is in automation-bypass mode (CDP pass-through).
+          pointerEvents: "auto",
           display: "flex",
           alignItems: "center",
           gap: 12,
@@ -122,7 +126,7 @@ export function ControlOverlay({
           disabled={interrupting}
           onClick={onInterrupt}
           style={{
-            pointerEvents,
+            pointerEvents: "auto",
             display: "flex",
             alignItems: "center",
             gap: 6,

--- a/apps/extension/src/content/RecordOverlay.tsx
+++ b/apps/extension/src/content/RecordOverlay.tsx
@@ -1,0 +1,58 @@
+import { useTranslation } from "@browser-skill/i18n/react";
+
+export interface RecordRequestData {
+  id: string;
+  onFinish: () => void;
+}
+
+type Props = {
+  request: RecordRequestData | null;
+};
+
+export function RecordOverlay({ request }: Props) {
+  const { t } = useTranslation("extension");
+
+  if (!request) return null;
+
+  return (
+    <div
+      className="bsk-record-panel"
+      style={{
+        position: "fixed",
+        bottom: 24,
+        left: "50%",
+        transform: "translateX(-50%)",
+        zIndex: 2147483646,
+        display: "flex",
+        alignItems: "center",
+        gap: 16,
+        background: "rgba(15, 23, 42, 0.94)",
+        color: "#f8fafc",
+        padding: "12px 16px",
+        borderRadius: 12,
+        font: "500 14px/1.4 system-ui, sans-serif",
+        boxShadow: "0 8px 32px rgba(0,0,0,0.28)",
+        pointerEvents: "auto",
+        maxWidth: "min(420px, calc(100vw - 32px))",
+      }}
+    >
+      <span style={{ flex: 1 }}>{t("recordOverlay.recording")}</span>
+      <button
+        type="button"
+        onClick={request.onFinish}
+        style={{
+          border: "none",
+          borderRadius: 8,
+          background: "#dc2626",
+          color: "#fff",
+          font: "600 13px/1 system-ui, sans-serif",
+          padding: "8px 14px",
+          cursor: "pointer",
+          pointerEvents: "auto",
+        }}
+      >
+        {t("recordOverlay.finish")}
+      </button>
+    </div>
+  );
+}

--- a/apps/extension/src/content/__tests__/ControlOverlay.test.tsx
+++ b/apps/extension/src/content/__tests__/ControlOverlay.test.tsx
@@ -7,7 +7,7 @@ describe("ControlOverlay", () => {
     cleanup();
   });
 
-  it("sets pointer-events none on blocker and pill when automationBypass is true", () => {
+  it("keeps page blocker none under automationBypass but Interrupt stays clickable", () => {
     const { container } = render(
       <ControlOverlay
         visible={true}
@@ -17,13 +17,17 @@ describe("ControlOverlay", () => {
       />,
     );
 
-    const blocker = container.querySelector("[data-slot='control-overlay']")?.nextElementSibling;
+    const blocker = container.querySelector("[data-slot='control-overlay-blocker']");
     expect(blocker).toBeTruthy();
     expect((blocker as HTMLElement).style.pointerEvents).toBe("none");
 
+    const pill = container.querySelector("[data-slot='control-overlay-pill']");
+    expect(pill).toBeTruthy();
+    expect((pill as HTMLElement).style.pointerEvents).toBe("auto");
+
     const stopBtn = container.querySelector("[data-slot='control-overlay-stop-all']");
     expect(stopBtn).toBeTruthy();
-    expect((stopBtn as HTMLElement).style.pointerEvents).toBe("none");
+    expect((stopBtn as HTMLElement).style.pointerEvents).toBe("auto");
   });
 
   it("uses pointer-events auto on blocker when automationBypass is false", () => {
@@ -36,7 +40,7 @@ describe("ControlOverlay", () => {
       />,
     );
 
-    const blocker = container.querySelector("[data-slot='control-overlay']")?.nextElementSibling;
+    const blocker = container.querySelector("[data-slot='control-overlay-blocker']");
     expect(blocker).toBeTruthy();
     expect((blocker as HTMLElement).style.pointerEvents).toBe("auto");
   });

--- a/apps/extension/src/content/__tests__/overlay-controller.test.ts
+++ b/apps/extension/src/content/__tests__/overlay-controller.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { OverlayController } from "../overlay-controller";
+import { OverlayController, shouldShowAgentControlOverlay } from "../overlay-controller";
 
 describe("OverlayController", () => {
   it("resets agent overlays without clearing user-tab borrow requests", () => {
@@ -31,6 +31,7 @@ describe("OverlayController", () => {
     expect(state.controlVisible).toBe(false);
     expect(state.activeSessionId).toBeNull();
     expect(state.activeHelp).toBeNull();
+    expect(state.activeRecord).toBeNull();
     expect(state.automationBypassCount).toBe(0);
   });
 
@@ -68,5 +69,51 @@ describe("OverlayController", () => {
 
     expect(previous?.id).toBe("help-1");
     expect(controller.snapshot().activeHelp?.id).toBe("help-2");
+  });
+
+  it("tracks active record request state", () => {
+    const controller = new OverlayController();
+
+    controller.activateAgentSession("sess-1");
+    controller.setAgentRecordRequest({
+      id: "rec-1",
+      onFinish: vi.fn(),
+    });
+
+    expect(controller.snapshot().activeRecord?.id).toBe("rec-1");
+  });
+
+  it("hides agent control overlay while recording is active", () => {
+    const controller = new OverlayController();
+    controller.activateAgentSession("sess-1");
+    expect(shouldShowAgentControlOverlay(controller.snapshot())).toBe(true);
+
+    controller.setAgentRecordRequest({
+      id: "rec-1",
+      onFinish: vi.fn(),
+    });
+    expect(shouldShowAgentControlOverlay(controller.snapshot())).toBe(false);
+    expect(controller.snapshot().controlVisible).toBe(true);
+  });
+
+  it("keeps control hidden after record ends until session overlays reset", () => {
+    const controller = new OverlayController();
+    controller.activateAgentSession("sess-1");
+    controller.setAgentRecordRequest({
+      id: "rec-1",
+      onFinish: vi.fn(),
+    });
+    controller.setAutomationBypass(true);
+    controller.setAutomationBypass(true);
+
+    controller.clearAgentRecordRequest("rec-1");
+    expect(controller.snapshot().activeRecord).toBeNull();
+    expect(controller.snapshot().suppressControlAfterRecord).toBe(true);
+    expect(controller.snapshot().automationBypassCount).toBe(0);
+    expect(shouldShowAgentControlOverlay(controller.snapshot())).toBe(false);
+
+    controller.resetAgentOverlays("sess-1");
+    expect(controller.snapshot().suppressControlAfterRecord).toBe(false);
+    expect(controller.snapshot().controlVisible).toBe(false);
   });
 });

--- a/apps/extension/src/content/__tests__/record-capture.test.ts
+++ b/apps/extension/src/content/__tests__/record-capture.test.ts
@@ -1,0 +1,163 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { handleRecordContentMessage, startRecordCapture } from "../record-capture";
+import { RECORD_STOP, type RecordStepPayload } from "@/lib/record-bridge";
+
+vi.stubGlobal("chrome", {
+  runtime: {
+    sendMessage: vi.fn(() => Promise.resolve()),
+  },
+});
+
+describe("handleRecordContentMessage stop/cancel", () => {
+  it("ignores STOP when no recording is active", () => {
+    const dispose = vi.fn();
+    const onStop = vi.fn();
+    const setActiveRequestId = vi.fn();
+    const setCapture = vi.fn();
+    const sendResponse = vi.fn();
+
+    const needsAsync = handleRecordContentMessage(
+      { type: RECORD_STOP, requestId: "rec-stale" },
+      {
+        activeRequestId: null,
+        capture: { dispose },
+        setActiveRequestId,
+        setCapture,
+        onStart: vi.fn(),
+        onStop,
+      },
+      sendResponse,
+    );
+
+    expect(needsAsync).toBe(false);
+    expect(dispose).not.toHaveBeenCalled();
+    expect(onStop).not.toHaveBeenCalled();
+    expect(setActiveRequestId).not.toHaveBeenCalled();
+    expect(setCapture).not.toHaveBeenCalled();
+    expect(sendResponse).not.toHaveBeenCalled();
+  });
+
+  it("ignores STOP for a mismatched requestId", () => {
+    const dispose = vi.fn();
+    const onStop = vi.fn();
+
+    const needsAsync = handleRecordContentMessage(
+      { type: RECORD_STOP, requestId: "rec-other" },
+      {
+        activeRequestId: "rec-1",
+        capture: { dispose },
+        setActiveRequestId: vi.fn(),
+        setCapture: vi.fn(),
+        onStart: vi.fn(),
+        onStop,
+      },
+      vi.fn(),
+    );
+
+    expect(needsAsync).toBe(false);
+    expect(dispose).not.toHaveBeenCalled();
+    expect(onStop).not.toHaveBeenCalled();
+  });
+});
+
+describe("record-capture semantic", () => {
+  let steps: RecordStepPayload[];
+
+  beforeEach(() => {
+    steps = [];
+    document.body.innerHTML = `
+      <label for="q">查询</label>
+      <input id="q" name="q" />
+      <button type="button" aria-label="搜索">搜索</button>
+      <div role="listbox" id="sug">
+        <div role="option">建议项</div>
+      </div>
+    `;
+  });
+
+  it("commits final fill value and records semantic click", () => {
+    const capture = startRecordCapture("rec-1", (step) => steps.push(step));
+    const input = document.querySelector("input")!;
+    const button = document.querySelector("button")!;
+
+    input.dispatchEvent(new FocusEvent("focusin", { bubbles: true }));
+    input.value = "hello";
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+    input.dispatchEvent(new FocusEvent("focusout", { bubbles: true }));
+
+    button.dispatchEvent(new MouseEvent("click", { bubbles: true, button: 0, detail: 1 }));
+
+    capture.dispose();
+
+    expect(steps).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          op: "fill",
+          value: "hello",
+          target: expect.objectContaining({ name: "查询", tag: "input" }),
+        }),
+        expect.objectContaining({
+          op: "click",
+          target: expect.objectContaining({ name: "搜索", role: "button" }),
+        }),
+      ]),
+    );
+    expect(JSON.stringify(steps)).not.toMatch(/@e\d+/);
+    expect(steps.some((s) => "selector" in s)).toBe(false);
+  });
+
+  it("ignores autocomplete suggestion clicks while a fill session is open", () => {
+    const capture = startRecordCapture("rec-2", (step) => steps.push(step));
+    const input = document.querySelector("input")!;
+    const option = document.querySelector('[role="option"]')!;
+
+    input.dispatchEvent(new FocusEvent("focusin", { bubbles: true }));
+    input.value = "hel";
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+    option.dispatchEvent(new MouseEvent("click", { bubbles: true, button: 0, detail: 1 }));
+    input.value = "hello";
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+    input.dispatchEvent(new FocusEvent("focusout", { bubbles: true }));
+    capture.dispose();
+
+    expect(steps.filter((s) => s.op === "click")).toHaveLength(0);
+    expect(steps.some((s) => s.op === "fill" && s.value === "hello")).toBe(true);
+  });
+
+  it("records Enter press but not bare typing keys", () => {
+    const capture = startRecordCapture("rec-press", (step) => steps.push(step));
+    const input = document.querySelector("input")!;
+    input.dispatchEvent(new FocusEvent("focusin", { bubbles: true }));
+    input.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "a", bubbles: true }),
+    );
+    input.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Enter", bubbles: true }),
+    );
+    capture.dispose();
+    expect(steps.filter((s) => s.op === "press")).toEqual([
+      expect.objectContaining({ op: "press", key: "Enter" }),
+    ]);
+  });
+
+  it("does not record clicks on anonymous layout divs", () => {
+    document.body.innerHTML = `
+      <div id="chrome">page chrome</div>
+      <button type="button" aria-label="下一步">下一步</button>
+    `;
+    const capture = startRecordCapture("rec-3", (step) => steps.push(step));
+    document
+      .querySelector("#chrome")!
+      .dispatchEvent(new MouseEvent("click", { bubbles: true, button: 0, detail: 1 }));
+    document
+      .querySelector("button")!
+      .dispatchEvent(new MouseEvent("click", { bubbles: true, button: 0, detail: 1 }));
+    capture.dispose();
+
+    expect(steps).toHaveLength(1);
+    expect(steps[0]).toMatchObject({
+      op: "click",
+      target: { name: "下一步", role: "button" },
+    });
+  });
+});

--- a/apps/extension/src/content/overlay-controller.ts
+++ b/apps/extension/src/content/overlay-controller.ts
@@ -1,13 +1,21 @@
 import type { BorrowRequestData } from "./BorrowConfirmationOverlay";
 import type { HelpRequestData } from "./HelpRequestOverlay";
+import type { RecordRequestData } from "./RecordOverlay";
 
 export interface OverlayState {
   borrowRequests: BorrowRequestData[];
   activeHelp: HelpRequestData | null;
+  activeRecord: RecordRequestData | null;
   controlVisible: boolean;
   interrupting: boolean;
   activeSessionId: string | null;
   automationBypassCount: number;
+  /**
+   * After record Finish/Stop clears `activeRecord`, the session is still
+   * alive until CLI `session.stop`. Suppress the control mask for that gap
+   * so 「Agent 正在控制」does not flash between RecordOverlay and teardown.
+   */
+  suppressControlAfterRecord: boolean;
 }
 
 type MutableOverlayState = Omit<OverlayState, "controlVisible">;
@@ -20,9 +28,11 @@ export class OverlayController {
   private state: MutableOverlayState = {
     borrowRequests: [],
     activeHelp: null,
+    activeRecord: null,
     interrupting: false,
     activeSessionId: null,
     automationBypassCount: 0,
+    suppressControlAfterRecord: false,
   };
 
   snapshot(): OverlayState {
@@ -70,6 +80,25 @@ export class OverlayController {
     this.state.activeHelp = null;
   }
 
+  setAgentRecordRequest(request: RecordRequestData): RecordRequestData | null {
+    const previous = this.state.activeRecord;
+    this.state.activeRecord = request;
+    this.state.suppressControlAfterRecord = false;
+    return previous;
+  }
+
+  clearAgentRecordRequest(requestId?: string): void {
+    if (!this.state.activeRecord) return;
+    if (requestId && this.state.activeRecord.id !== requestId) return;
+    this.state.activeRecord = null;
+    // Hide control until session teardown — see OverlayState.suppressControlAfterRecord.
+    this.state.suppressControlAfterRecord = true;
+    // Record start/rearm may have stacked automation-bypass refs; drop them so a
+    // stray ControlOverlay cannot sit with pointer-events:none (page usable,
+    // Interrupt unclickable).
+    this.state.automationBypassCount = 0;
+  }
+
   setAutomationBypass(enabled: boolean): void {
     if (enabled) {
       this.state.automationBypassCount += 1;
@@ -86,10 +115,22 @@ export class OverlayController {
     this.state = {
       ...this.state,
       activeHelp: null,
+      activeRecord: null,
       interrupting: false,
       activeSessionId: null,
       automationBypassCount: 0,
+      suppressControlAfterRecord: false,
     };
     return previousHelp;
   }
+}
+
+/** Control mask ("Agent 正在控制") must hide while help/record overlays own the chrome. */
+export function shouldShowAgentControlOverlay(state: OverlayState): boolean {
+  return (
+    state.controlVisible &&
+    !state.suppressControlAfterRecord &&
+    state.activeHelp === null &&
+    state.activeRecord === null
+  );
 }

--- a/apps/extension/src/content/record-capture.ts
+++ b/apps/extension/src/content/record-capture.ts
@@ -1,0 +1,554 @@
+import {
+  describeEventTarget,
+  describeTarget,
+  summarizeClick,
+  summarizeFill,
+  summarizeNavigate,
+  summarizePress,
+  summarizeSelect,
+  type TargetDescriptor,
+} from "@/lib/describe-target";
+import { shouldRecordPress } from "@/lib/trace-reducer";
+import {
+  isRecordCancelMessage,
+  isRecordStartMessage,
+  isRecordStopMessage,
+  RECORD_CANCEL,
+  RECORD_START,
+  RECORD_STEP,
+  RECORD_STOP,
+  type RecordCancelMessage,
+  type RecordStartAck,
+  type RecordStartMessage,
+  type RecordStepPayload,
+  type RecordStopAck,
+  type RecordStopMessage,
+} from "@/lib/record-bridge";
+
+const pendingStepSends = new Map<string, Set<Promise<boolean>>>();
+const failedStepDeliveries = new Set<string>();
+const knownRecordRequests = new Set<string>();
+
+function sendRecordStep(requestId: string, step: RecordStepPayload): void {
+  const payload = { type: RECORD_STEP, requestId, step };
+  const pending = Promise.resolve(chrome.runtime.sendMessage(payload)).then(
+    () => true,
+    () => {
+      failedStepDeliveries.add(requestId);
+      return false;
+    },
+  );
+  const sends = pendingStepSends.get(requestId) ?? new Set<Promise<boolean>>();
+  sends.add(pending);
+  pendingStepSends.set(requestId, sends);
+  void pending.then(() => {
+    sends.delete(pending);
+    if (sends.size === 0) pendingStepSends.delete(requestId);
+  });
+}
+
+export interface RecordCaptureController {
+  dispose(): void;
+}
+
+interface FillSession {
+  element: FillableElement;
+  target: TargetDescriptor;
+  baselineValue: string;
+  lastValue: string;
+}
+
+type FillableElement = HTMLInputElement | HTMLTextAreaElement | HTMLElement;
+
+function eventTarget(event: Event): EventTarget | null {
+  return event.composedPath()[0] ?? event.target;
+}
+
+function isOverlayTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof Node)) return false;
+  const root = document.documentElement;
+  let node: Node | null = target;
+  while (node && node !== root) {
+    if (node instanceof Element && node.hasAttribute("data-bsk-overlay")) {
+      return true;
+    }
+    const rootNode: Node | Document | ShadowRoot = node.getRootNode();
+    if (rootNode instanceof ShadowRoot) {
+      const host: Element = rootNode.host;
+      if (host.hasAttribute("data-bsk-overlay")) {
+        return true;
+      }
+      node = host;
+    } else {
+      node = node.parentNode;
+    }
+  }
+  return false;
+}
+
+function isTextFillable(el: Element): el is FillableElement {
+  if (el instanceof HTMLElement && (el.isContentEditable || el.contentEditable === "true")) {
+    return true;
+  }
+  if (el instanceof HTMLTextAreaElement) return true;
+  if (!(el instanceof HTMLInputElement)) return false;
+  const type = el.type.toLowerCase();
+  return type !== "checkbox" && type !== "radio" && type !== "file" && type !== "button";
+}
+
+function fillableFromTarget(target: EventTarget | null): FillableElement | null {
+  if (!(target instanceof Element)) return null;
+  if (isTextFillable(target)) return target;
+  const el = target.closest('input,textarea,[contenteditable]:not([contenteditable="false"])');
+  if (el && isTextFillable(el)) return el;
+  return null;
+}
+
+/** Clicks on search chrome that only focus the nearby input should not become steps. */
+function nearbyFillableFromSearchChrome(target: Element): FillableElement | null {
+  const container = target.closest(
+    '[id*="chat-input"], [id*="search"], [class*="search"], form, [role="search"]',
+  );
+  if (!container) return null;
+  const fillable = container.querySelector(
+    'textarea, input[type="search"], input[name="q"], #chat-textarea',
+  );
+  if (
+    fillable instanceof HTMLElement &&
+    isTextFillable(fillable) &&
+    fillable !== target &&
+    !fillable.contains(target)
+  ) {
+    return fillable;
+  }
+  return null;
+}
+
+function fillableValue(el: FillableElement): string {
+  if (el instanceof HTMLInputElement || el instanceof HTMLTextAreaElement) {
+    return el.value;
+  }
+  return el.textContent ?? "";
+}
+
+/** Clicks that only pick an autocomplete/suggestion value — not a semantic submit action. */
+function isInputCompletionClick(
+  target: EventTarget | null,
+  session: FillSession | null,
+): boolean {
+  if (!session || !(target instanceof Element)) return false;
+  if (session.element.contains(target)) return false;
+
+  const option = target.closest('[role="option"]');
+  if (option?.closest('[role="listbox"]')) return true;
+
+  const suggestionRoot = target.closest(
+    [
+      '[id*="Sug"]',
+      '[id*="sug"]',
+      '[class*="suggest"]',
+      '[class*="autocomplete"]',
+      '[class*="typeahead"]',
+      "[data-autocomplete]",
+    ].join(", "),
+  );
+  if (suggestionRoot && !suggestionRoot.contains(session.element)) return true;
+
+  return false;
+}
+
+function scheduleInputCompletionCommit(
+  sessionElement: FillableElement,
+  syncFillSessionValue: (el: FillableElement) => void,
+  commitFillSession: () => void,
+  hasSessionFor: (el: FillableElement) => boolean,
+): void {
+  const syncAndCommit = () => {
+    if (!hasSessionFor(sessionElement)) return;
+    syncFillSessionValue(sessionElement);
+    commitFillSession();
+  };
+  syncFillSessionValue(sessionElement);
+  queueMicrotask(syncAndCommit);
+  setTimeout(syncAndCommit, 0);
+}
+
+export function startRecordCapture(
+  _requestId: string,
+  sendStep: (step: RecordStepPayload) => void,
+): RecordCaptureController {
+  const emitStep = (step: RecordStepPayload) => {
+    sendStep({ page_url: location.href, ...step });
+  };
+  let fillSession: FillSession | null = null;
+  let composing = false;
+  let lastUrl = location.href;
+  let keyboardActivation: { target: EventTarget | null; recordedAt: number } | undefined;
+  let generatedControlClick: Element | null = null;
+  let navigationActionPending = false;
+  let navigationActionVersion = 0;
+  const committedValues = new WeakMap<FillableElement, string>();
+
+  const markNavigationAction = () => {
+    navigationActionPending = true;
+    const version = ++navigationActionVersion;
+    setTimeout(() => {
+      if (navigationActionVersion === version) {
+        navigationActionPending = false;
+      }
+    }, 0);
+  };
+
+  const emitFill = (session: FillSession) => {
+    if (session.lastValue === session.baselineValue) return;
+    const isPassword =
+      session.element instanceof HTMLInputElement && session.element.type === "password";
+    const value = isPassword ? "***" : session.lastValue;
+    emitStep({
+      op: "fill",
+      target: session.target,
+      value,
+      summary: summarizeFill(session.target, value, isPassword),
+      ...(isPassword ? { redacted: true } : {}),
+    });
+  };
+
+  const commitFillSession = () => {
+    if (!fillSession || composing) return;
+    const session = fillSession;
+    fillSession = null;
+    emitFill(session);
+    committedValues.set(session.element, session.lastValue);
+  };
+
+  const syncFillSessionValue = (el: FillableElement) => {
+    if (!fillSession || fillSession.element !== el) return;
+    fillSession.lastValue = fillableValue(el);
+  };
+
+  const ensureFillSession = (el: FillableElement) => {
+    if (fillSession?.element === el) return;
+    if (fillSession) commitFillSession();
+    const currentValue = fillableValue(el);
+    const baselineValue = committedValues.get(el) ?? currentValue;
+    fillSession = {
+      element: el,
+      target: describeTarget(el),
+      baselineValue,
+      lastValue: currentValue,
+    };
+  };
+
+  const emitNavigateIfChanged = (causedByAction?: boolean) => {
+    if (location.href === lastUrl) return;
+    commitFillSession();
+    lastUrl = location.href;
+    emitStep({
+      op: "navigate",
+      url: location.href,
+      summary: summarizeNavigate(location.href),
+      ...(causedByAction !== undefined ? { navigation_caused_by_action: causedByAction } : {}),
+    });
+  };
+
+  const emitClick = (event: MouseEvent) => {
+    // Only record clicks an LLM can re-identify (named interactive controls).
+    const target = describeEventTarget(eventTarget(event));
+    if (!target) return;
+    markNavigationAction();
+    emitStep({
+      op: "click",
+      target,
+      summary: summarizeClick(target),
+      expects_navigation: true,
+    });
+  };
+
+  const onClick = (event: MouseEvent) => {
+    if (event.button !== 0) return;
+    const target = eventTarget(event);
+    if (isOverlayTarget(target)) return;
+    if (event.detail === 0 && generatedControlClick !== null && target === generatedControlClick) {
+      generatedControlClick = null;
+      return;
+    }
+    if (
+      event.detail === 0 &&
+      keyboardActivation?.target === target &&
+      Date.now() - keyboardActivation.recordedAt < 500
+    ) {
+      keyboardActivation = undefined;
+      return;
+    }
+
+    const label = target instanceof Element ? target.closest("label") : null;
+    const nestedInteractive =
+      target instanceof Element ? target.closest("a,button,input,select,textarea") : null;
+    if (label instanceof HTMLLabelElement && !nestedInteractive) {
+      commitFillSession();
+      generatedControlClick = label.control;
+      emitClick(event);
+      return;
+    }
+
+    const fillable = fillableFromTarget(target);
+    if (fillable) {
+      ensureFillSession(fillable);
+      return;
+    }
+
+    if (target instanceof Element) {
+      const nearbyFillable = nearbyFillableFromSearchChrome(target);
+      if (nearbyFillable) {
+        ensureFillSession(nearbyFillable);
+        return;
+      }
+    }
+
+    if (isInputCompletionClick(target, fillSession)) {
+      markNavigationAction();
+      const sessionElement = fillSession!.element;
+      scheduleInputCompletionCommit(
+        sessionElement,
+        syncFillSessionValue,
+        commitFillSession,
+        (el) => fillSession?.element === el,
+      );
+      return;
+    }
+
+    commitFillSession();
+    if (target instanceof Element && target.closest("select")) return;
+    emitClick(event);
+  };
+
+  const onFocusIn = (event: FocusEvent) => {
+    const target = fillableFromTarget(eventTarget(event));
+    if (target) ensureFillSession(target);
+  };
+
+  const onFocusOut = (event: FocusEvent) => {
+    const target = fillableFromTarget(eventTarget(event));
+    if (!target) return;
+    if (!fillSession || fillSession.element !== target) return;
+    syncFillSessionValue(target);
+    commitFillSession();
+  };
+
+  const onInput = (event: Event) => {
+    const target = fillableFromTarget(eventTarget(event));
+    if (!target) return;
+    if (composing) return;
+    ensureFillSession(target);
+    syncFillSessionValue(target);
+  };
+
+  const onCompositionStart = () => {
+    composing = true;
+  };
+
+  const onCompositionEnd = (event: CompositionEvent) => {
+    composing = false;
+    const target = fillableFromTarget(eventTarget(event));
+    if (target) {
+      ensureFillSession(target);
+      syncFillSessionValue(target);
+    }
+  };
+
+  const onChange = (event: Event) => {
+    commitFillSession();
+    const target = eventTarget(event);
+    if (target instanceof HTMLSelectElement) {
+      const values = Array.from(target.selectedOptions).map((opt) => opt.value);
+      const labels = Array.from(target.selectedOptions).map((opt) =>
+        (opt.label || opt.textContent || opt.value).trim(),
+      );
+      const desc = describeTarget(target);
+      markNavigationAction();
+      emitStep({
+        op: "select",
+        target: desc,
+        values,
+        labels,
+        summary: summarizeSelect(desc, values, labels),
+        expects_navigation: true,
+      });
+    }
+  };
+
+  const onKeyDown = (event: KeyboardEvent) => {
+    if (isOverlayTarget(eventTarget(event))) return;
+    const target = eventTarget(event);
+    const fillable = fillableFromTarget(target);
+    if (fillable) {
+      ensureFillSession(fillable);
+      syncFillSessionValue(fillable);
+    }
+    const modifiers = [
+      ...(event.altKey ? (["alt"] as const) : []),
+      ...(event.ctrlKey ? (["ctrl"] as const) : []),
+      ...(event.metaKey ? (["meta"] as const) : []),
+      ...(event.shiftKey ? (["shift"] as const) : []),
+    ];
+    if (!shouldRecordPress(event.key, modifiers)) {
+      return;
+    }
+    markNavigationAction();
+    if (event.key === "Enter" || event.key === " ") {
+      const submitTarget =
+        event.key === "Enter" && fillable
+          ? fillable
+              .closest("form")
+              ?.querySelector(
+                'button:not([type]),button[type="submit"],input[type="submit"],input[type="image"]',
+              )
+          : null;
+      keyboardActivation = {
+        target: submitTarget ?? target,
+        recordedAt: Date.now(),
+      };
+    }
+    if (fillable) {
+      commitFillSession();
+    }
+    const desc = describeEventTarget(target);
+    if (!desc && !event.key) return;
+    emitStep({
+      op: "press",
+      key: event.key,
+      ...(desc ? { target: desc } : {}),
+      ...(modifiers.length ? { modifiers } : {}),
+      summary: summarizePress(event.key, desc),
+      expects_navigation: event.key === "Enter",
+    });
+  };
+
+  document.addEventListener("click", onClick, true);
+  document.addEventListener("focusin", onFocusIn, true);
+  document.addEventListener("focusout", onFocusOut, true);
+  document.addEventListener("input", onInput, true);
+  document.addEventListener("compositionstart", onCompositionStart, true);
+  document.addEventListener("compositionend", onCompositionEnd, true);
+  document.addEventListener("change", onChange, true);
+  document.addEventListener("keydown", onKeyDown, true);
+
+  const urlObserver = new MutationObserver(() => emitNavigateIfChanged());
+  urlObserver.observe(document, { subtree: true, childList: true });
+  const onUrlEvent = () => emitNavigateIfChanged();
+  window.addEventListener("hashchange", onUrlEvent);
+  window.addEventListener("popstate", onUrlEvent);
+  window.addEventListener("pagehide", commitFillSession);
+
+  const originalPushState = history.pushState;
+  const originalReplaceState = history.replaceState;
+  history.pushState = function (...args: Parameters<History["pushState"]>) {
+    originalPushState.apply(this, args);
+    emitNavigateIfChanged(navigationActionPending ? true : undefined);
+  };
+  history.replaceState = function (...args: Parameters<History["replaceState"]>) {
+    originalReplaceState.apply(this, args);
+    emitNavigateIfChanged(navigationActionPending ? true : undefined);
+  };
+
+  return {
+    dispose() {
+      commitFillSession();
+      document.removeEventListener("click", onClick, true);
+      document.removeEventListener("focusin", onFocusIn, true);
+      document.removeEventListener("focusout", onFocusOut, true);
+      document.removeEventListener("input", onInput, true);
+      document.removeEventListener("compositionstart", onCompositionStart, true);
+      document.removeEventListener("compositionend", onCompositionEnd, true);
+      document.removeEventListener("change", onChange, true);
+      document.removeEventListener("keydown", onKeyDown, true);
+      urlObserver.disconnect();
+      window.removeEventListener("hashchange", onUrlEvent);
+      window.removeEventListener("popstate", onUrlEvent);
+      window.removeEventListener("pagehide", commitFillSession);
+      history.pushState = originalPushState;
+      history.replaceState = originalReplaceState;
+    },
+  };
+}
+
+export type RecordContentMessage = RecordStartMessage | RecordStopMessage | RecordCancelMessage;
+
+export function isRecordContentMessage(msg: unknown): msg is RecordContentMessage {
+  return isRecordStartMessage(msg) || isRecordStopMessage(msg) || isRecordCancelMessage(msg);
+}
+
+export function handleRecordContentMessage(
+  message: RecordContentMessage,
+  state: {
+    activeRequestId: string | null;
+    capture: RecordCaptureController | null;
+    setActiveRequestId(id: string | null): void;
+    setCapture(capture: RecordCaptureController | null): void;
+    onStart(requestId: string): void;
+    onStop(): void;
+  },
+  sendResponse?: (response: RecordStartAck | RecordStopAck) => void,
+): boolean {
+  if (isRecordStartMessage(message)) {
+    if (!knownRecordRequests.has(message.requestId)) {
+      knownRecordRequests.add(message.requestId);
+      failedStepDeliveries.delete(message.requestId);
+    }
+    state.capture?.dispose();
+    state.setCapture(
+      startRecordCapture(message.requestId, (step) => {
+        sendRecordStep(message.requestId, step);
+      }),
+    );
+    state.setActiveRequestId(message.requestId);
+    state.onStart(message.requestId);
+    sendResponse?.({ ok: true });
+    return sendResponse !== undefined;
+  }
+
+  if (isRecordStopMessage(message) || isRecordCancelMessage(message)) {
+    // Require an active recording that matches this requestId — otherwise a
+    // stray STOP/CANCEL (e.g. after teardown) would still run finishStop and
+    // clear overlay state even though nothing was capturing.
+    if (!state.activeRequestId || state.activeRequestId !== message.requestId) {
+      return false;
+    }
+    state.capture?.dispose();
+    state.setCapture(null);
+    const finishStop = () => {
+      state.onStop();
+      state.setActiveRequestId(null);
+    };
+    if (isRecordStopMessage(message) && sendResponse) {
+      const pending = [...(pendingStepSends.get(message.requestId) ?? [])];
+      void Promise.all(pending).then((delivered) => {
+        finishStop();
+        const succeeded = delivered.every(Boolean) && !failedStepDeliveries.has(message.requestId);
+        if (succeeded) {
+          failedStepDeliveries.delete(message.requestId);
+          knownRecordRequests.delete(message.requestId);
+        }
+        sendResponse(
+          succeeded
+            ? { ok: true }
+            : {
+                ok: false,
+                error: "failed to deliver one or more recorded steps",
+              },
+        );
+      });
+      return true;
+    }
+    if (isRecordCancelMessage(message)) {
+      failedStepDeliveries.delete(message.requestId);
+      knownRecordRequests.delete(message.requestId);
+    }
+    finishStop();
+    return false;
+  }
+
+  return false;
+}
+
+export { RECORD_CANCEL, RECORD_START, RECORD_STEP, RECORD_STOP };

--- a/apps/extension/src/entrypoints/background.ts
+++ b/apps/extension/src/entrypoints/background.ts
@@ -8,6 +8,7 @@ import {
 } from "@/lib/instance-id";
 import { startKeepalive } from "@/lib/keepalive";
 import {
+  OVERLAY_AUTOMATION_BYPASS,
   OVERLAY_MSG_INTERRUPT,
   OVERLAY_MSG_WHO_AM_I,
   type OverlayInterruptRequest,
@@ -27,6 +28,11 @@ import {
   requestBorrowConfirmation,
 } from "@/tools/borrow-confirmation";
 import { ToolDispatcher } from "@/tools/dispatcher";
+import {
+  attachRecordFinishListener,
+  attachRecordQueryListener,
+  attachRecordStepListener,
+} from "@/tools/record";
 import { detectBrowserMeta } from "@/transport/handshake";
 import type { Transport } from "@/transport/transport";
 import { WSTransport } from "@/transport/ws-transport";
@@ -68,6 +74,27 @@ export default defineBackground(() => {
     }),
   });
   dispatcher.start();
+  const recordDeps = {
+    tabsApi: chrome.tabs,
+    sendToTab: (tabId: number, msg: Parameters<typeof chrome.tabs.sendMessage>[1]) =>
+      chrome.tabs.sendMessage(tabId, msg),
+    bypassOverlay: async (tabId: number, enabled: boolean) => {
+      try {
+        await chrome.tabs.sendMessage(tabId, {
+          type: OVERLAY_AUTOMATION_BYPASS,
+          enabled,
+        });
+      } catch {
+        // Content script may be unavailable on restricted pages.
+      }
+    },
+  };
+  // Message listeners stay up (cheap; fire only for record message types).
+  // Tab / webNavigation observation attaches lazily while a recording is
+  // active — see ensureBrowserObservationListeners in tools/record.ts.
+  attachRecordStepListener();
+  attachRecordFinishListener(recordDeps);
+  attachRecordQueryListener(recordDeps);
   if (typeof chrome.notifications?.onClicked?.addListener === "function") {
     attachBorrowNotificationClickHandler({
       onClicked: chrome.notifications.onClicked,

--- a/apps/extension/src/entrypoints/content.ts
+++ b/apps/extension/src/entrypoints/content.ts
@@ -6,7 +6,13 @@ import { BorrowConfirmationOverlay } from "@/content/BorrowConfirmationOverlay";
 import { ControlOverlay } from "@/content/ControlOverlay";
 import { HelpRequestOverlay } from "@/content/HelpRequestOverlay";
 import overlayCss from "@/content/overlay.css?inline";
-import { OverlayController } from "@/content/overlay-controller";
+import { OverlayController, shouldShowAgentControlOverlay } from "@/content/overlay-controller";
+import { RecordOverlay } from "@/content/RecordOverlay";
+import {
+  handleRecordContentMessage,
+  isRecordContentMessage,
+  type RecordCaptureController,
+} from "@/content/record-capture";
 import {
   HELP_RESPONSE,
   type HelpCancelMessage,
@@ -24,6 +30,12 @@ import {
   type OverlayWhoAmIResponse,
 } from "@/lib/overlay-bridge";
 import { sendInterrupt } from "@/lib/overlay-interrupt-client";
+import {
+  RECORD_FINISH,
+  RECORD_QUERY,
+  type RecordStartAck,
+  type RecordStopAck,
+} from "@/lib/record-bridge";
 import { SESSIONS_LIVE_FLAG_KEY } from "@/lib/sessions-live-flag";
 import type {
   BorrowCancelMessage,
@@ -45,6 +57,8 @@ export default defineContentScript({
     const overlays = new OverlayController();
     let activeHelpRespond: ((outcome: "continued" | "cancelled", note?: string) => void) | null =
       null;
+    let recordCapture: RecordCaptureController | null = null;
+    let activeRecordRequestId: string | null = null;
     let reactRoot: ReactDOM.Root | null = null;
     let overlayHost: HTMLElement | null = null;
     let hostLossReported = false;
@@ -87,12 +101,13 @@ export default defineContentScript({
               requests: overlayState.borrowRequests,
             }),
             React.createElement(ControlOverlay, {
-              visible: overlayState.controlVisible && overlayState.activeHelp === null,
+              visible: shouldShowAgentControlOverlay(overlayState),
               interrupting: overlayState.interrupting,
               automationBypass: overlayState.automationBypassCount > 0,
               onInterrupt: handleInterrupt,
             }),
             React.createElement(HelpRequestOverlay, { request: overlayState.activeHelp }),
+            React.createElement(RecordOverlay, { request: overlayState.activeRecord }),
           ),
         ),
       );
@@ -104,6 +119,9 @@ export default defineContentScript({
         activeHelpRespond?.("cancelled");
         activeHelpRespond = null;
       }
+      recordCapture?.dispose();
+      recordCapture = null;
+      activeRecordRequestId = null;
       renderOverlay();
     }
 
@@ -140,6 +158,42 @@ export default defineContentScript({
       _sender: chrome.runtime.MessageSender,
       sendResponse: (response: BorrowResponseMessage | HelpResponseMessage) => void,
     ) => {
+      if (isRecordContentMessage(message)) {
+        const needsAsync = handleRecordContentMessage(
+          message,
+          {
+            activeRequestId: activeRecordRequestId,
+            capture: recordCapture,
+            setActiveRequestId: (id) => {
+              activeRecordRequestId = id;
+            },
+            setCapture: (capture) => {
+              recordCapture = capture;
+            },
+            onStart: (requestId) => {
+              overlays.setAgentRecordRequest({
+                id: requestId,
+                onFinish: () => {
+                  void chrome.runtime.sendMessage({
+                    type: RECORD_FINISH,
+                    requestId,
+                  });
+                },
+              });
+              renderOverlay();
+            },
+            onStop: () => {
+              overlays.clearAgentRecordRequest(activeRecordRequestId ?? undefined);
+              renderOverlay();
+            },
+          },
+          sendResponse as unknown as
+            | ((response: RecordStartAck | RecordStopAck) => void)
+            | undefined,
+        );
+        return needsAsync;
+      }
+
       if (
         message &&
         typeof message === "object" &&
@@ -228,23 +282,59 @@ export default defineContentScript({
       return false;
     };
 
-    async function mountOverlayIfAgent(): Promise<void> {
+    async function syncAgentOverlay(): Promise<void> {
       if (!(await anySessionLive())) return;
       try {
         const reply = (await chrome.runtime.sendMessage({
           kind: OVERLAY_MSG_WHO_AM_I,
         })) as OverlayWhoAmIResponse | undefined;
         if (!reply?.sessionId) return;
+
+        // Query / re-arm recording *before* activating the control overlay so
+        // record start (navigate → content load) does not flash
+        // 「Agent 正在控制」before RecordOverlay mounts.
+        let recordQuery: { active?: boolean; requestId?: string } | undefined;
+        try {
+          recordQuery = (await chrome.runtime.sendMessage({
+            type: RECORD_QUERY,
+          })) as { active?: boolean; requestId?: string } | undefined;
+        } catch (err) {
+          console.debug("[bsk overlay] record query failed", err);
+        }
+
+        if (
+          recordQuery?.active &&
+          typeof recordQuery.requestId === "string" &&
+          overlays.snapshot().activeRecord === null
+        ) {
+          const requestId = recordQuery.requestId;
+          overlays.setAgentRecordRequest({
+            id: requestId,
+            onFinish: () => {
+              void chrome.runtime.sendMessage({
+                type: RECORD_FINISH,
+                requestId,
+              });
+            },
+          });
+        }
+
         overlays.activateAgentSession(reply.sessionId);
         renderOverlay();
       } catch (err) {
-        console.debug("[bsk overlay] who_am_i failed", err);
+        console.debug("[bsk overlay] syncAgentOverlay failed", err);
       }
     }
 
+    const onPageShow = (event: PageTransitionEvent) => {
+      if (event.persisted) void syncAgentOverlay();
+    };
+
     ui.mount();
     chrome.runtime.onMessage.addListener(onMessage);
-    void mountOverlayIfAgent();
+    void syncAgentOverlay();
+
+    window.addEventListener("pageshow", onPageShow);
 
     const hostObserver = new MutationObserver(() => {
       const connected = overlayHost?.isConnected ?? false;
@@ -254,6 +344,7 @@ export default defineContentScript({
           remountInProgress = true;
           try {
             ui.mount();
+            void syncAgentOverlay();
           } finally {
             remountInProgress = false;
           }
@@ -268,6 +359,11 @@ export default defineContentScript({
     ctx.onInvalidated(() => {
       hostObserver.disconnect();
       chrome.runtime.onMessage.removeListener(onMessage);
+      window.removeEventListener("pageshow", onPageShow);
+      // Restore history hooks / remove capture listeners before the CS unloads.
+      recordCapture?.dispose();
+      recordCapture = null;
+      activeRecordRequestId = null;
     });
   },
 });

--- a/apps/extension/src/lib/__tests__/describe-target.test.ts
+++ b/apps/extension/src/lib/__tests__/describe-target.test.ts
@@ -1,0 +1,132 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  describeEventTarget,
+  describeTarget,
+  isMeaningfulClickTarget,
+  summarizeClick,
+  summarizeFill,
+} from "../describe-target";
+
+describe("describeTarget", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("prefers aria-label and button role", () => {
+    document.body.innerHTML = `<button aria-label="发布">go</button>`;
+    const el = document.querySelector("button")!;
+    expect(describeTarget(el)).toEqual({
+      tag: "button",
+      role: "button",
+      name: "发布",
+    });
+  });
+
+  it("uses label text and name_attr for inputs", () => {
+    document.body.innerHTML = `
+      <label for="svc">服务名称</label>
+      <input id="svc" name="serviceName" />
+    `;
+    const el = document.querySelector("input")!;
+    expect(describeTarget(el)).toEqual({
+      tag: "input",
+      role: "textbox",
+      name: "服务名称",
+      name_attr: "serviceName",
+    });
+  });
+
+  it("never invents CSS selectors or @eN", () => {
+    document.body.innerHTML = `<a href="/x">详情</a>`;
+    const desc = describeTarget(document.querySelector("a")!);
+    expect(JSON.stringify(desc)).not.toMatch(/@e\d+|nth-of-type|#/);
+    expect(desc).toEqual({ tag: "a", role: "link", name: "详情" });
+  });
+
+  it("prefers heading text inside SERP-style links", () => {
+    document.body.innerHTML = `
+      <a href="https://www.tencent.com">
+        <h3>Tencent 腾讯</h3>
+        <cite>https://www.tencent.com</cite>
+      </a>
+    `;
+    expect(describeTarget(document.querySelector("a")!).name).toBe("Tencent 腾讯");
+  });
+});
+
+describe("LLM textbook click targets", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("rejects tag-only targets the LLM cannot find", () => {
+    expect(isMeaningfulClickTarget({ tag: "div" })).toBe(false);
+    expect(summarizeClick({ tag: "div" })).not.toBe("点击div");
+  });
+
+  it("treats a short visible name as the teaching signal", () => {
+    expect(isMeaningfulClickTarget({ tag: "div", name: "发布" })).toBe(true);
+    expect(summarizeClick({ tag: "div", name: "发布" })).toBe("点击「发布」");
+  });
+
+  it("ignores anonymous layout chrome and lifts child clicks to the named button", () => {
+    document.body.innerHTML = `
+      <div id="noise">background</div>
+      <button type="button"><span id="icon">发布</span></button>
+    `;
+    expect(describeEventTarget(document.querySelector("#noise"))).toBeNull();
+    expect(describeEventTarget(document.querySelector("#icon"))).toEqual({
+      tag: "button",
+      role: "button",
+      name: "发布",
+    });
+  });
+
+  it("does not attach layout sibling text as nearby_label on buttons", () => {
+    document.body.innerHTML = `
+      <div>background</div>
+      <button type="button" id="pub">发布</button>
+    `;
+    expect(describeTarget(document.querySelector("#pub")!)).toEqual({
+      tag: "button",
+      role: "button",
+      name: "发布",
+    });
+  });
+
+  it("keeps nearby_label for form fields from a preceding label-like sibling", () => {
+    document.body.innerHTML = `
+      <div>服务名称</div>
+      <input id="svc" />
+    `;
+    expect(describeTarget(document.querySelector("#svc")!)).toEqual(
+      expect.objectContaining({
+        tag: "input",
+        nearby_label: "服务名称",
+      }),
+    );
+  });
+
+  it("does not treat plain text blocks as clicks", () => {
+    document.body.innerHTML = `<p id="copy">说明文字</p>`;
+    expect(describeEventTarget(document.querySelector("#copy"))).toBeNull();
+  });
+
+  it("records custom button-like controls by their visible label", () => {
+    document.body.innerHTML = `<div class="btn" id="pub" style="cursor: pointer">发布</div>`;
+    expect(describeEventTarget(document.querySelector("#pub"))).toEqual(
+      expect.objectContaining({ tag: "div", name: "发布" }),
+    );
+  });
+});
+
+describe("summaries", () => {
+  it("renders fill and click summaries with names for the LLM", () => {
+    expect(
+      summarizeFill({ tag: "input", role: "textbox", name: "服务名称" }, "my-svc"),
+    ).toBe("在「服务名称」填入 my-svc");
+    expect(summarizeClick({ tag: "button", role: "button", name: "发布" })).toBe(
+      "点击「发布」按钮",
+    );
+  });
+});

--- a/apps/extension/src/lib/__tests__/recording-step-buffer.test.ts
+++ b/apps/extension/src/lib/__tests__/recording-step-buffer.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { appendRecordedPayload, observeRecordedNavigation } from "../recording-step-buffer";
+
+describe("recording-step-buffer", () => {
+  it("stores semantic click with summary", () => {
+    const buffer = { steps: [], pendingNavigation: false };
+    appendRecordedPayload(buffer, {
+      op: "click",
+      target: { tag: "button", role: "button", name: "发布" },
+      summary: "点击「发布」按钮",
+      expects_navigation: true,
+    });
+    expect(buffer.steps).toEqual([
+      {
+        op: "click",
+        target: { tag: "button", role: "button", name: "发布" },
+        summary: "点击「发布」按钮",
+      },
+    ]);
+    expect(buffer.pendingNavigation).toBe(true);
+  });
+
+  it("annotates navigated_to on action-caused navigation instead of wait_for_navigation", () => {
+    const buffer = {
+      steps: [
+        {
+          op: "click" as const,
+          target: { tag: "button", role: "button", name: "发布" },
+          summary: "点击「发布」按钮",
+        },
+      ],
+      currentUrl: "https://example.com/a",
+      pendingNavigation: true,
+      pendingNavigationDeadline: Date.now() + 5_000,
+    };
+    observeRecordedNavigation(buffer, "https://example.com/b", true);
+    expect(buffer.steps).toEqual([
+      {
+        op: "click",
+        target: { tag: "button", role: "button", name: "发布" },
+        summary: "点击「发布」按钮",
+        navigated_to: "https://example.com/b",
+      },
+    ]);
+    expect(JSON.stringify(buffer.steps)).not.toContain("wait_for_navigation");
+  });
+
+  it("emits navigate for uncaused URL changes", () => {
+    const buffer = {
+      steps: [],
+      currentUrl: "https://example.com/a",
+      pendingNavigation: false,
+    };
+    observeRecordedNavigation(buffer, "https://example.com/b", false);
+    expect(buffer.steps[0]).toMatchObject({
+      op: "navigate",
+      url: "https://example.com/b",
+    });
+  });
+});

--- a/apps/extension/src/lib/__tests__/trace-reducer.test.ts
+++ b/apps/extension/src/lib/__tests__/trace-reducer.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import { buildTraceEntry, reduceTraceSteps, shouldRecordPress } from "../trace-reducer";
+import type { DraftTraceStep } from "@/transport/types";
+
+describe("shouldRecordPress", () => {
+  it("keeps Enter and Escape", () => {
+    expect(shouldRecordPress("Enter")).toBe(true);
+    expect(shouldRecordPress("Escape")).toBe(true);
+  });
+
+  it("drops modifiers, clipboard shortcuts, and bare typing", () => {
+    expect(shouldRecordPress("Meta")).toBe(false);
+    expect(shouldRecordPress("c", ["meta"])).toBe(false);
+    expect(shouldRecordPress("a", ["ctrl"])).toBe(false);
+    expect(shouldRecordPress("x")).toBe(false);
+    expect(shouldRecordPress("中")).toBe(false);
+  });
+});
+
+describe("reduceTraceSteps", () => {
+  it("builds textbook steps with page, intent, effect; no parameters", () => {
+    const drafts: DraftTraceStep[] = [
+      {
+        op: "navigate",
+        url: "https://example.com/search?q=hello&utm_source=x",
+        page_url: "https://example.com/search?q=hello&utm_source=x",
+      },
+      {
+        op: "fill",
+        target: { tag: "input", role: "textbox", name: "搜索", name_attr: "q" },
+        value: "browser skill",
+        page_url: "https://example.com/search",
+      },
+      {
+        op: "press",
+        key: "Enter",
+        target: { tag: "input", role: "textbox", name: "搜索", name_attr: "q" },
+        navigated_to: "https://example.com/results/42",
+        page_url: "https://example.com/search",
+      },
+      {
+        op: "click",
+        target: { tag: "button", role: "button", name: "发布" },
+        summary: "点击「发布」按钮",
+        navigated_to: "https://example.com/p/99",
+        page_url: "https://example.com/results/42",
+      },
+      {
+        op: "press",
+        key: "a",
+        page_url: "https://example.com/p/99",
+      },
+    ];
+
+    const steps = reduceTraceSteps(drafts);
+    expect(JSON.stringify(steps)).not.toContain("parameters");
+    expect(steps.map((s) => s.op)).toEqual(["navigate", "fill", "press", "click"]);
+
+    expect(steps[0]).toMatchObject({
+      id: 1,
+      op: "navigate",
+      intent: "open_entry",
+      destination: {
+        url: "https://example.com/search?q=hello&utm_source=x",
+        url_pattern: "https://example.com/search?q=hello",
+      },
+    });
+
+    expect(steps[1]).toMatchObject({
+      op: "fill",
+      intent: "provide_input",
+      value: "browser skill",
+      summary: "在「搜索」填入 browser skill",
+    });
+
+    expect(steps[2]).toMatchObject({
+      op: "press",
+      intent: "search",
+      key: "Enter",
+      effect: {
+        navigated_to: "https://example.com/results/42",
+        url_pattern_after: "https://example.com/results/*",
+      },
+    });
+
+    expect(steps[3]).toMatchObject({
+      op: "click",
+      intent: "confirm",
+      effect: {
+        navigated_to: "https://example.com/p/99",
+        url_pattern_after: "https://example.com/p/*",
+      },
+    });
+  });
+
+  it("collapses consecutive navigations", () => {
+    const steps = reduceTraceSteps([
+      { op: "navigate", url: "https://a.example/redirect1" },
+      { op: "navigate", url: "https://a.example/final" },
+    ]);
+    expect(steps).toHaveLength(1);
+    expect(steps[0]?.destination?.url).toBe("https://a.example/final");
+  });
+
+  it("buildTraceEntry adds site and pattern", () => {
+    expect(buildTraceEntry("https://iwiki.woa.com/p/1")).toEqual({
+      start_url: "https://iwiki.woa.com/p/1",
+      start_url_pattern: "https://iwiki.woa.com/p/*",
+      site: "iwiki.woa.com",
+    });
+  });
+});

--- a/apps/extension/src/lib/__tests__/url-pattern.test.ts
+++ b/apps/extension/src/lib/__tests__/url-pattern.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import {
+  canonicalizeUrl,
+  inferPageRole,
+  siteFromUrl,
+  summarizeNavigateShort,
+  urlPatternFromUrl,
+} from "../url-pattern";
+
+describe("url-pattern", () => {
+  it("strips tracking query params and keeps business keys", () => {
+    const url =
+      "https://www.google.com/search?q=browser+skill&oq=browser&sourceid=chrome&ie=UTF-8&utm_source=x";
+    expect(canonicalizeUrl(url)).toBe("https://www.google.com/search?q=browser+skill");
+  });
+
+  it("collapses numeric and hex path segments", () => {
+    expect(urlPatternFromUrl("https://iwiki.woa.com/p/4001234567/edit")).toBe(
+      "https://iwiki.woa.com/p/*/edit",
+    );
+    expect(urlPatternFromUrl("https://example.com/doc/abcdef0123456789")).toBe(
+      "https://example.com/doc/*",
+    );
+  });
+
+  it("infers page role and short navigate summary", () => {
+    expect(inferPageRole("https://example.com/p/1/edit")).toBe("editor");
+    expect(inferPageRole("https://example.com/")).toBe("home");
+    expect(siteFromUrl("https://iwiki.woa.com/x")).toBe("iwiki.woa.com");
+    expect(summarizeNavigateShort("https://iwiki.woa.com/p/1/edit")).toBe(
+      "打开 iwiki.woa.com/p/*/edit",
+    );
+  });
+});

--- a/apps/extension/src/lib/describe-target.ts
+++ b/apps/extension/src/lib/describe-target.ts
@@ -1,0 +1,387 @@
+/**
+ * Build a semantic TargetDescriptor for an interacted element.
+ *
+ * Trace steps are an LLM *textbook*: each click must say what to look for
+ * on screen (usually a short visible name). Tag-only noise like
+ * `{ "tag": "div" }` / “点击div” is useless and must not be recorded.
+ */
+
+export interface TargetDescriptor {
+  role?: string;
+  name?: string;
+  tag: string;
+  name_attr?: string;
+  placeholder?: string;
+  nearby_label?: string;
+}
+
+/** Max length for a label that is still a useful “find this on screen” hint. */
+const ACTIONABLE_LABEL_MAX = 48;
+
+function normalizeWhitespace(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+function truncate(value: string, max = 80): string {
+  const trimmed = normalizeWhitespace(value);
+  if (trimmed.length <= max) return trimmed;
+  return `${trimmed.slice(0, max - 1)}…`;
+}
+
+/** Short, human label an LLM can search for in a snapshot. */
+export function isActionableLabel(name: string): boolean {
+  const trimmed = normalizeWhitespace(name);
+  if (!trimmed) return false;
+  if (trimmed.length > ACTIONABLE_LABEL_MAX) return false;
+  if (/^https?:\/\//i.test(trimmed)) return false;
+  return true;
+}
+
+function labelledByText(el: Element): string | null {
+  const ids = el.getAttribute("aria-labelledby");
+  if (!ids) return null;
+  const parts = ids
+    .split(/\s+/)
+    .map((id) => document.getElementById(id)?.textContent ?? "")
+    .map(normalizeWhitespace)
+    .filter(Boolean);
+  return parts.length ? truncate(parts.join(" ")) : null;
+}
+
+function associatedLabelText(el: Element): string | null {
+  if (!(el instanceof HTMLElement) || !el.id) return null;
+  const label = document.querySelector(`label[for="${CSS.escape(el.id)}"]`);
+  if (!label) return null;
+  const text = normalizeWhitespace(label.textContent ?? "");
+  return text ? truncate(text) : null;
+}
+
+function wrappingLabelText(el: Element): string | null {
+  const label = el.closest("label");
+  if (!label) return null;
+  const clone = label.cloneNode(true) as HTMLElement;
+  for (const control of clone.querySelectorAll("input,textarea,select,button")) {
+    control.remove();
+  }
+  const text = normalizeWhitespace(clone.textContent ?? "");
+  return text ? truncate(text) : null;
+}
+
+function placeholderOrTitle(el: Element): string | null {
+  if (el instanceof HTMLInputElement || el instanceof HTMLTextAreaElement) {
+    const ph = normalizeWhitespace(el.placeholder);
+    if (ph) return truncate(ph);
+  }
+  const title = normalizeWhitespace(el.getAttribute("title") ?? "");
+  return title ? truncate(title) : null;
+}
+
+function ownText(el: Element): string | null {
+  if (el instanceof HTMLInputElement || el instanceof HTMLTextAreaElement) {
+    return null;
+  }
+  const text = normalizeWhitespace(el.textContent ?? "");
+  return text ? truncate(text) : null;
+}
+
+/** Prefer a compact title inside links (e.g. SERP result `<h3>`), not the whole blob. */
+function compactLinkName(el: Element): string | null {
+  const heading = el.querySelector("h1, h2, h3, h4");
+  if (heading) {
+    const text = normalizeWhitespace(heading.textContent ?? "");
+    if (text) return truncate(text);
+  }
+  const img = el.querySelector("img[alt]");
+  if (img instanceof HTMLImageElement) {
+    const alt = normalizeWhitespace(img.alt);
+    if (alt) return truncate(alt);
+  }
+  const clone = el.cloneNode(true) as HTMLElement;
+  for (const junk of clone.querySelectorAll("cite, script, style, svg, noscript")) {
+    junk.remove();
+  }
+  const text = normalizeWhitespace(clone.textContent ?? "");
+  if (!text) return null;
+  const withoutUrl = text.replace(/https?:\/\/\S+/g, "").trim();
+  return truncate(withoutUrl || text);
+}
+
+/** Visible accessible name preference order for LLM textbooks. */
+export function accessibleName(el: Element): string | undefined {
+  const ariaLabel = normalizeWhitespace(el.getAttribute("aria-label") ?? "");
+  if (ariaLabel) return truncate(ariaLabel);
+
+  const labelledBy = labelledByText(el);
+  if (labelledBy) return labelledBy;
+
+  const forLabel = associatedLabelText(el);
+  if (forLabel) return forLabel;
+
+  const wrapLabel = wrappingLabelText(el);
+  if (wrapLabel) return wrapLabel;
+
+  const alt =
+    el instanceof HTMLImageElement
+      ? normalizeWhitespace(el.alt)
+      : normalizeWhitespace(el.getAttribute("alt") ?? "");
+  if (alt) return truncate(alt);
+
+  const ph = placeholderOrTitle(el);
+  if (ph) return ph;
+
+  const tag = el.tagName.toLowerCase();
+  if (tag === "a" || el.getAttribute("role") === "link") {
+    const linkName = compactLinkName(el);
+    if (linkName) return linkName;
+  }
+
+  const text = ownText(el);
+  if (text) return text;
+
+  if (el instanceof HTMLInputElement || el instanceof HTMLButtonElement) {
+    const value = normalizeWhitespace(el.value);
+    if (value && (el instanceof HTMLButtonElement || el.type === "submit" || el.type === "button")) {
+      return truncate(value);
+    }
+  }
+
+  return undefined;
+}
+
+const INTERACTIVE_SELECTOR = [
+  "a[href]",
+  "button",
+  "summary",
+  "select",
+  'input:not([type="hidden"])',
+  "textarea",
+  '[role="button"]',
+  '[role="link"]',
+  '[role="tab"]',
+  '[role="menuitem"]',
+  '[role="menuitemcheckbox"]',
+  '[role="menuitemradio"]',
+  '[role="option"]',
+  '[role="checkbox"]',
+  '[role="radio"]',
+  '[role="switch"]',
+  '[role="treeitem"]',
+  '[role="combobox"]',
+  '[contenteditable]:not([contenteditable="false"])',
+].join(",");
+
+const INTERACTIVE_ROLES = new Set([
+  "button",
+  "link",
+  "tab",
+  "menuitem",
+  "menuitemcheckbox",
+  "menuitemradio",
+  "option",
+  "checkbox",
+  "radio",
+  "switch",
+  "treeitem",
+  "combobox",
+  "textbox",
+  "searchbox",
+  "slider",
+]);
+
+function looksClickable(el: Element): boolean {
+  if (!(el instanceof HTMLElement)) return false;
+  if (el.matches(INTERACTIVE_SELECTOR)) return true;
+  const role = normalizeWhitespace(el.getAttribute("role") ?? "").toLowerCase();
+  if (role && INTERACTIVE_ROLES.has(role)) return true;
+  if (el.tabIndex >= 0) return true;
+  try {
+    if (getComputedStyle(el).cursor === "pointer") return true;
+  } catch {
+    // happy-dom / detached nodes
+  }
+  const cls = typeof el.className === "string" ? el.className : "";
+  if (/\b(btn|button|link|clickable|action)\b/i.test(cls)) return true;
+  return false;
+}
+
+/**
+ * Resolve the element a click should describe for the LLM textbook.
+ * Never falls back to an anonymous layout `div`.
+ */
+export function resolveClickableElement(target: Element): Element | null {
+  const interactive = target.closest(INTERACTIVE_SELECTOR);
+  if (interactive instanceof Element) return interactive;
+
+  let node: Element | null = target;
+  let depth = 0;
+  while (node && node !== document.body && node !== document.documentElement && depth < 8) {
+    const name = accessibleName(node);
+    if (name && isActionableLabel(name) && looksClickable(node)) {
+      return node;
+    }
+    node = node.parentElement;
+    depth += 1;
+  }
+  return null;
+}
+
+/**
+ * Teachable clicks: the LLM must get a label it can later find via snapshot
+ * (visible name), or at least a form `name_attr` for checkbox/radio.
+ * Recording “点击div” with no name fails this bar.
+ */
+export function isMeaningfulClickTarget(target: TargetDescriptor): boolean {
+  const name = target.name?.trim();
+  if (name && isActionableLabel(name)) return true;
+  if (
+    (target.role === "checkbox" || target.role === "radio" || target.tag === "input") &&
+    target.name_attr
+  ) {
+    return true;
+  }
+  return false;
+}
+
+export function inferRole(el: Element): string | undefined {
+  const explicit = normalizeWhitespace(el.getAttribute("role") ?? "").toLowerCase();
+  if (explicit) return explicit;
+
+  const tag = el.tagName.toLowerCase();
+  if (tag === "button") return "button";
+  if (tag === "a" && el.hasAttribute("href")) return "link";
+  if (tag === "select") return "combobox";
+  if (tag === "textarea") return "textbox";
+  if (tag === "img") return "img";
+  if (tag === "summary") return "button";
+  if (el instanceof HTMLElement && (el.isContentEditable || el.contentEditable === "true")) {
+    return "textbox";
+  }
+  if (el instanceof HTMLInputElement) {
+    const type = el.type.toLowerCase();
+    if (type === "checkbox") return "checkbox";
+    if (type === "radio") return "radio";
+    if (type === "submit" || type === "button" || type === "image" || type === "reset") {
+      return "button";
+    }
+    if (type === "range") return "slider";
+    return "textbox";
+  }
+  return undefined;
+}
+
+/**
+ * Nearby labels help the LLM name form fields. Only apply to fillable
+ * controls — never to buttons/links, where a previous layout sibling
+ * (e.g. a chrome `<div>`) would pollute the textbook target.
+ */
+function nearbyLabelText(el: Element): string | undefined {
+  if (
+    !(
+      el instanceof HTMLInputElement ||
+      el instanceof HTMLTextAreaElement ||
+      el instanceof HTMLSelectElement
+    )
+  ) {
+    return undefined;
+  }
+  if (el.id) {
+    const byFor = document.querySelector(`label[for="${CSS.escape(el.id)}"]`);
+    const text = byFor ? normalizeWhitespace(byFor.textContent ?? "") : "";
+    if (text) return truncate(text, ACTIONABLE_LABEL_MAX);
+  }
+  const wrapped = el.closest("label");
+  if (wrapped) {
+    const clone = wrapped.cloneNode(true) as HTMLLabelElement;
+    for (const control of clone.querySelectorAll("input, textarea, select, button")) {
+      control.remove();
+    }
+    const text = normalizeWhitespace(clone.textContent ?? "");
+    if (text) return truncate(text, ACTIONABLE_LABEL_MAX);
+  }
+  const prev = el.previousElementSibling;
+  if (prev && /^(LABEL|SPAN|DIV|P|DT)$/i.test(prev.tagName)) {
+    const text = normalizeWhitespace(prev.textContent ?? "");
+    if (text && text.length <= ACTIONABLE_LABEL_MAX) return text;
+  }
+  return undefined;
+}
+
+export function describeTarget(el: Element): TargetDescriptor {
+  const tag = el.tagName.toLowerCase();
+  const role = inferRole(el);
+  const name = accessibleName(el);
+  const nameAttr =
+    el instanceof HTMLInputElement ||
+    el instanceof HTMLTextAreaElement ||
+    el instanceof HTMLSelectElement ||
+    el instanceof HTMLButtonElement
+      ? normalizeWhitespace(el.name) || undefined
+      : normalizeWhitespace(el.getAttribute("name") ?? "") || undefined;
+  const placeholder =
+    el instanceof HTMLInputElement || el instanceof HTMLTextAreaElement
+      ? normalizeWhitespace(el.placeholder) || undefined
+      : normalizeWhitespace(el.getAttribute("placeholder") ?? "") || undefined;
+  const nearby = nearbyLabelText(el);
+
+  return {
+    tag,
+    ...(role ? { role } : {}),
+    ...(name ? { name } : {}),
+    ...(nameAttr ? { name_attr: nameAttr } : {}),
+    ...(placeholder ? { placeholder } : {}),
+    ...(nearby && nearby !== name ? { nearby_label: nearby } : {}),
+  };
+}
+
+export function describeEventTarget(target: EventTarget | null): TargetDescriptor | null {
+  if (!(target instanceof Element)) return null;
+  const clickable = resolveClickableElement(target);
+  if (!clickable) return null;
+  const desc = describeTarget(clickable);
+  return isMeaningfulClickTarget(desc) ? desc : null;
+}
+
+export function summarizeClick(target: TargetDescriptor): string {
+  const label = target.name
+    ? `「${target.name}」`
+    : target.name_attr
+      ? `「${target.name_attr}」`
+      : null;
+  // Callers must filter with isMeaningfulClickTarget; never teach “点击div”.
+  if (!label) return "点击控件";
+  if (target.role === "button" || target.tag === "button") {
+    return `点击${label}按钮`;
+  }
+  if (target.role === "link" || target.tag === "a") {
+    return `点击${label}链接`;
+  }
+  return `点击${label}`;
+}
+
+export function summarizeFill(target: TargetDescriptor, value: string, redacted?: boolean): string {
+  const label = target.name
+    ? `「${target.name}」`
+    : target.name_attr
+      ? `「${target.name_attr}」`
+      : "输入框";
+  return `在${label}填入 ${redacted ? "***" : value}`;
+}
+
+export function summarizePress(key: string, target?: TargetDescriptor | null): string {
+  if (target?.name) return `在「${target.name}」上按下 ${key}`;
+  return `按下 ${key}`;
+}
+
+export function summarizeSelect(
+  target: TargetDescriptor,
+  values: string[],
+  labels?: string[],
+): string {
+  const label = target.name ? `「${target.name}」` : "下拉框";
+  const shown = labels?.length ? labels.join(", ") : values.join(", ");
+  return `在${label}选择 ${shown}`;
+}
+
+export function summarizeNavigate(url: string): string {
+  return `页面跳转到 ${url}`;
+}

--- a/apps/extension/src/lib/record-bridge.ts
+++ b/apps/extension/src/lib/record-bridge.ts
@@ -1,0 +1,112 @@
+/**
+ * Wire protocol for user-action recording, sent between the background
+ * service worker and a tab's content script.
+ */
+
+import type { TargetDescriptor } from "./describe-target";
+
+export const RECORD_START = "bsk-record-start";
+export const RECORD_STEP = "bsk-record-step";
+export const RECORD_STOP = "bsk-record-stop";
+export const RECORD_CANCEL = "bsk-record-cancel";
+export const RECORD_FINISH = "bsk-record-finish";
+export const RECORD_QUERY = "bsk-record-query";
+
+export interface RecordStartAck {
+  ok: true;
+}
+
+export type RecordStopAck = { ok: true } | { ok: false; error: string };
+
+export interface RecordQueryMessage {
+  type: typeof RECORD_QUERY;
+}
+
+export interface RecordQueryResponse {
+  active: boolean;
+  requestId?: string;
+}
+
+export interface RecordStartMessage {
+  type: typeof RECORD_START;
+  requestId: string;
+}
+
+export interface RecordStepPayload {
+  op: "click" | "fill" | "press" | "select" | "navigate";
+  target?: TargetDescriptor;
+  value?: string;
+  key?: string;
+  modifiers?: Array<"alt" | "ctrl" | "meta" | "shift">;
+  values?: string[];
+  labels?: string[];
+  url?: string;
+  summary?: string;
+  redacted?: boolean;
+  /** Page URL when the step was captured (for textbook page context). */
+  page_url?: string;
+  /** Capture-only hint; never persisted unless converted to navigated_to. */
+  expects_navigation?: boolean;
+  /** Whether an observed URL change was synchronously caused by the action. */
+  navigation_caused_by_action?: boolean;
+}
+
+export interface RecordStepMessage {
+  type: typeof RECORD_STEP;
+  requestId: string;
+  step: RecordStepPayload;
+}
+
+export interface RecordStopMessage {
+  type: typeof RECORD_STOP;
+  requestId: string;
+}
+
+export interface RecordCancelMessage {
+  type: typeof RECORD_CANCEL;
+  requestId: string;
+}
+
+export interface RecordFinishMessage {
+  type: typeof RECORD_FINISH;
+  requestId: string;
+}
+
+export function isRecordStartMessage(msg: unknown): msg is RecordStartMessage {
+  if (typeof msg !== "object" || msg === null) return false;
+  const m = msg as Record<string, unknown>;
+  return m.type === RECORD_START && typeof m.requestId === "string";
+}
+
+export function isRecordStopMessage(msg: unknown): msg is RecordStopMessage {
+  if (typeof msg !== "object" || msg === null) return false;
+  const m = msg as Record<string, unknown>;
+  return m.type === RECORD_STOP && typeof m.requestId === "string";
+}
+
+export function isRecordCancelMessage(msg: unknown): msg is RecordCancelMessage {
+  if (typeof msg !== "object" || msg === null) return false;
+  const m = msg as Record<string, unknown>;
+  return m.type === RECORD_CANCEL && typeof m.requestId === "string";
+}
+
+export function isRecordFinishMessage(msg: unknown): msg is RecordFinishMessage {
+  if (typeof msg !== "object" || msg === null) return false;
+  const m = msg as Record<string, unknown>;
+  return m.type === RECORD_FINISH && typeof m.requestId === "string";
+}
+
+export function isRecordQueryMessage(msg: unknown): msg is RecordQueryMessage {
+  if (typeof msg !== "object" || msg === null) return false;
+  const m = msg as Record<string, unknown>;
+  return m.type === RECORD_QUERY;
+}
+
+export function isRecordStepMessage(msg: unknown): msg is RecordStepMessage {
+  if (typeof msg !== "object" || msg === null) return false;
+  const m = msg as Record<string, unknown>;
+  if (m.type !== RECORD_STEP || typeof m.requestId !== "string") return false;
+  const step = m.step;
+  if (typeof step !== "object" || step === null) return false;
+  return typeof (step as RecordStepPayload).op === "string";
+}

--- a/apps/extension/src/lib/recording-step-buffer.ts
+++ b/apps/extension/src/lib/recording-step-buffer.ts
@@ -1,0 +1,134 @@
+import type { DraftTraceStep } from "@/transport/types";
+import type { RecordStepPayload } from "./record-bridge";
+
+export interface RecordingStepBuffer {
+  steps: DraftTraceStep[];
+  currentUrl?: string;
+  pendingNavigation: boolean;
+  pendingNavigationDeadline?: number;
+}
+
+const NAVIGATION_TRIGGER_WINDOW_MS = 3_000;
+
+function toDraftStep(payload: RecordStepPayload): DraftTraceStep | null {
+  const pageUrl = payload.page_url;
+  switch (payload.op) {
+    case "click":
+      return payload.target
+        ? {
+            op: "click",
+            target: payload.target,
+            ...(payload.summary ? { summary: payload.summary } : {}),
+            ...(pageUrl ? { page_url: pageUrl } : {}),
+          }
+        : null;
+    case "fill":
+      return payload.target
+        ? {
+            op: "fill",
+            target: payload.target,
+            value: payload.value ?? "",
+            ...(payload.summary ? { summary: payload.summary } : {}),
+            ...(payload.redacted ? { redacted: true } : {}),
+            ...(pageUrl ? { page_url: pageUrl } : {}),
+          }
+        : null;
+    case "press":
+      return payload.key
+        ? {
+            op: "press",
+            key: payload.key,
+            ...(payload.target ? { target: payload.target } : {}),
+            ...(payload.modifiers?.length ? { modifiers: payload.modifiers } : {}),
+            ...(payload.summary ? { summary: payload.summary } : {}),
+            ...(pageUrl ? { page_url: pageUrl } : {}),
+          }
+        : null;
+    case "select":
+      return payload.target && payload.values
+        ? {
+            op: "select",
+            target: payload.target,
+            values: payload.values,
+            ...(payload.labels?.length ? { labels: payload.labels } : {}),
+            ...(payload.summary ? { summary: payload.summary } : {}),
+            ...(pageUrl ? { page_url: pageUrl } : {}),
+          }
+        : null;
+    case "navigate":
+      return null;
+  }
+}
+
+function annotateLastStepNavigation(buffer: RecordingStepBuffer, url: string): boolean {
+  for (let i = buffer.steps.length - 1; i >= 0; i -= 1) {
+    const step = buffer.steps[i];
+    if (!step) continue;
+    if (step.op === "click" || step.op === "press") {
+      buffer.steps[i] = { ...step, navigated_to: url };
+      return true;
+    }
+    break;
+  }
+  return false;
+}
+
+export function observeRecordedNavigation(
+  buffer: RecordingStepBuffer,
+  url: string,
+  causedByAction?: boolean,
+): void {
+  if (!url || url === buffer.currentUrl) return;
+  buffer.currentUrl = url;
+  const pendingIsCurrent =
+    buffer.pendingNavigation &&
+    (buffer.pendingNavigationDeadline === undefined ||
+      buffer.pendingNavigationDeadline >= Date.now());
+
+  if (causedByAction === true || (causedByAction === undefined && pendingIsCurrent)) {
+    buffer.pendingNavigation = false;
+    buffer.pendingNavigationDeadline = undefined;
+    if (!annotateLastStepNavigation(buffer, url)) {
+      buffer.steps.push({
+        op: "navigate",
+        url,
+        summary: `页面跳转到 ${url}`,
+        page_url: url,
+      });
+    }
+    return;
+  }
+
+  buffer.pendingNavigation = false;
+  buffer.pendingNavigationDeadline = undefined;
+  buffer.steps.push({
+    op: "navigate",
+    url,
+    summary: `页面跳转到 ${url}`,
+    page_url: url,
+  });
+}
+
+export function appendRecordedPayload(
+  buffer: RecordingStepBuffer,
+  payload: RecordStepPayload,
+): void {
+  if (payload.op === "navigate") {
+    if (payload.url) {
+      observeRecordedNavigation(buffer, payload.url, payload.navigation_caused_by_action);
+    }
+    return;
+  }
+  const step = toDraftStep({
+    ...payload,
+    page_url: payload.page_url ?? buffer.currentUrl,
+  });
+  if (!step) return;
+  buffer.steps.push(step);
+  if (step.op === "click" || step.op === "press" || step.op === "select" || step.op === "fill") {
+    buffer.pendingNavigation = payload.expects_navigation === true;
+    buffer.pendingNavigationDeadline = buffer.pendingNavigation
+      ? Date.now() + NAVIGATION_TRIGGER_WINDOW_MS
+      : undefined;
+  }
+}

--- a/apps/extension/src/lib/trace-reducer.ts
+++ b/apps/extension/src/lib/trace-reducer.ts
@@ -1,0 +1,242 @@
+import type {
+  DraftTraceStep,
+  TraceImportance,
+  TraceIntent,
+  TraceStep,
+} from "@/transport/types";
+import {
+  inferPageRole,
+  siteFromUrl,
+  summarizeNavigateShort,
+  urlPatternFromUrl,
+} from "./url-pattern";
+
+const CONFIRM_NAME_RE = /发布|提交|确认|保存|创建|完成|确定|下一步|登录|注册|publish|submit|confirm|save|create|done|next|login|sign\s*up/i;
+const SEARCH_NAME_RE = /搜索|查找|search|query|find/i;
+const CLIPBOARD_KEYS = new Set(["a", "c", "v", "x", "A", "C", "V", "X"]);
+const MODIFIER_ONLY_KEYS = new Set([
+  "Meta",
+  "Control",
+  "Alt",
+  "Shift",
+  "OS",
+  "Hyper",
+  "Super",
+]);
+
+function previewValue(value: string, max = 48): string {
+  const trimmed = value.replace(/\s+/g, " ").trim();
+  if (trimmed.length <= max) return trimmed;
+  return `${trimmed.slice(0, max - 1)}…`;
+}
+
+function targetLabel(step: DraftTraceStep): string | undefined {
+  if (!("target" in step) || !step.target) return undefined;
+  return step.target.name ?? step.target.nearby_label ?? step.target.placeholder ?? step.target.name_attr;
+}
+
+export function shouldRecordPress(
+  key: string,
+  modifiers?: Array<"alt" | "ctrl" | "meta" | "shift">,
+): boolean {
+  if (MODIFIER_ONLY_KEYS.has(key)) return false;
+  const mods = modifiers ?? [];
+  const hasCtrlOrMeta = mods.includes("ctrl") || mods.includes("meta");
+  if (hasCtrlOrMeta && CLIPBOARD_KEYS.has(key)) return false;
+  if (key === "Enter" || key === "Escape") return true;
+  // Drop bare character typing — FillSession already records the value.
+  if (key.length === 1 && !hasCtrlOrMeta && !mods.includes("alt")) return false;
+  return false;
+}
+
+function pageFromDraft(step: DraftTraceStep, fallbackUrl?: string) {
+  const raw =
+    ("page_url" in step && step.page_url) ||
+    (step.op === "navigate" ? step.url : undefined) ||
+    ("navigated_to" in step ? step.navigated_to : undefined) ||
+    fallbackUrl;
+  if (!raw) return undefined;
+  const pattern = urlPatternFromUrl(raw);
+  return {
+    url: raw,
+    url_pattern: pattern,
+    role: inferPageRole(raw),
+  };
+}
+
+function inferIntent(step: DraftTraceStep): TraceIntent {
+  switch (step.op) {
+    case "fill":
+    case "select":
+      return "provide_input";
+    case "navigate":
+      return "open_entry";
+    case "press": {
+      if (step.key === "Enter") {
+        const label = targetLabel(step) ?? "";
+        if (SEARCH_NAME_RE.test(label) || step.target?.name_attr === "q") return "search";
+        return "submit_key";
+      }
+      if (step.key === "Escape") return "other";
+      return "other";
+    }
+    case "click": {
+      const name = step.target.name ?? "";
+      if (CONFIRM_NAME_RE.test(name)) return "confirm";
+      if (step.target.role === "checkbox" || step.target.role === "switch") return "toggle";
+      if (step.target.role === "link") return "open_item";
+      return "navigate";
+    }
+  }
+}
+
+function inferImportance(step: DraftTraceStep): TraceImportance {
+  if (step.op === "fill" && !(step.value ?? "").trim() && !step.redacted) return "optional";
+  if (step.op === "press" && !shouldRecordPress(step.key, step.modifiers)) return "optional";
+  return "essential";
+}
+
+function rewriteSummary(step: DraftTraceStep): string | undefined {
+  switch (step.op) {
+    case "navigate":
+      return summarizeNavigateShort(step.url);
+    case "fill": {
+      const label = targetLabel(step) ?? "输入框";
+      if (step.redacted) return `在「${label}」填入 ***`;
+      return `在「${label}」填入 ${previewValue(step.value)}`;
+    }
+    case "press": {
+      const label = targetLabel(step);
+      return label ? `在「${label}」按下 ${step.key}` : `按下 ${step.key}`;
+    }
+    case "click":
+    case "select":
+      return step.summary;
+  }
+}
+
+function toV3Step(step: DraftTraceStep, id: number, fallbackUrl?: string): TraceStep | null {
+  if (inferImportance(step) === "optional") return null;
+  if (step.op === "press" && !shouldRecordPress(step.key, step.modifiers)) return null;
+
+  const intent = inferIntent(step);
+  const page = pageFromDraft(step, fallbackUrl);
+  const summary = rewriteSummary(step) ?? step.summary;
+  const base = {
+    id,
+    intent,
+    importance: "essential" as const,
+    ...(page ? { page } : {}),
+    ...(summary ? { summary } : {}),
+  };
+
+  switch (step.op) {
+    case "click": {
+      const nav = step.navigated_to;
+      return {
+        ...base,
+        op: "click",
+        target: step.target,
+        ...(nav
+          ? {
+              effect: {
+                navigated_to: nav,
+                url_pattern_after: urlPatternFromUrl(nav),
+              },
+            }
+          : {}),
+      };
+    }
+    case "fill":
+      return {
+        ...base,
+        op: "fill",
+        target: step.target,
+        value: step.value,
+        ...(step.redacted ? { redacted: true } : {}),
+      };
+    case "press": {
+      const nav = step.navigated_to;
+      return {
+        ...base,
+        op: "press",
+        key: step.key,
+        ...(step.target ? { target: step.target } : {}),
+        ...(step.modifiers?.length ? { modifiers: step.modifiers } : {}),
+        ...(nav
+          ? {
+              effect: {
+                navigated_to: nav,
+                url_pattern_after: urlPatternFromUrl(nav),
+              },
+            }
+          : {}),
+      };
+    }
+    case "select":
+      return {
+        ...base,
+        op: "select",
+        target: step.target,
+        values: step.values,
+        ...(step.labels?.length ? { labels: step.labels } : {}),
+      };
+    case "navigate": {
+      const pattern = urlPatternFromUrl(step.url);
+      return {
+        ...base,
+        op: "navigate",
+        destination: {
+          url: step.url,
+          url_pattern: pattern,
+        },
+      };
+    }
+  }
+}
+
+/** Collapse consecutive navigations to the last hop. */
+function collapseNavigations(steps: DraftTraceStep[]): DraftTraceStep[] {
+  const out: DraftTraceStep[] = [];
+  for (const step of steps) {
+    const prev = out[out.length - 1];
+    if (step.op === "navigate" && prev?.op === "navigate") {
+      out[out.length - 1] = step;
+      continue;
+    }
+    out.push(step);
+  }
+  return out;
+}
+
+export function buildTraceEntry(startUrl?: string):
+  | { start_url?: string; start_url_pattern?: string; site?: string }
+  | undefined {
+  if (!startUrl) return undefined;
+  return {
+    start_url: startUrl,
+    start_url_pattern: urlPatternFromUrl(startUrl),
+    ...(siteFromUrl(startUrl) ? { site: siteFromUrl(startUrl) } : {}),
+  };
+}
+
+/**
+ * Compile capture drafts into LLM textbook steps (trace v3).
+ * Variable inputs are NOT extracted here — downstream LLM uses target + value.
+ */
+export function reduceTraceSteps(steps: DraftTraceStep[]): TraceStep[] {
+  const collapsed = collapseNavigations(steps);
+  const out: TraceStep[] = [];
+  let id = 1;
+  let lastUrl: string | undefined;
+  for (const draft of collapsed) {
+    if (draft.op === "navigate") lastUrl = draft.url;
+    else if ("navigated_to" in draft && draft.navigated_to) lastUrl = draft.navigated_to;
+    else if ("page_url" in draft && draft.page_url) lastUrl = draft.page_url;
+    const step = toV3Step(draft, id, lastUrl);
+    if (!step) continue;
+    out.push(step);
+    id += 1;
+  }
+  return out;
+}

--- a/apps/extension/src/lib/url-pattern.ts
+++ b/apps/extension/src/lib/url-pattern.ts
@@ -1,0 +1,114 @@
+/**
+ * Normalize page URLs into LLM-friendly patterns (drop tracking noise,
+ * collapse numeric path ids).
+ */
+
+const TRACKING_QUERY_KEYS = new Set([
+  "gs_lcrp",
+  "oq",
+  "sourceid",
+  "source",
+  "ie",
+  "ei",
+  "ved",
+  "uact",
+  "sxsrf",
+  "biw",
+  "bih",
+  "dpr",
+  "utm_source",
+  "utm_medium",
+  "utm_campaign",
+  "utm_term",
+  "utm_content",
+  "gclid",
+  "fbclid",
+  "_ga",
+  "mc_cid",
+  "mc_eid",
+]);
+
+/** Business query keys worth keeping in a pattern. */
+const KEEP_QUERY_KEYS = new Set(["q", "query", "search", "keyword", "id", "docid", "page"]);
+
+export function siteFromUrl(url: string): string | undefined {
+  try {
+    return new URL(url).hostname || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export function canonicalizeUrl(url: string): string {
+  try {
+    const u = new URL(url);
+    u.hash = "";
+    const next = new URLSearchParams();
+    for (const [key, value] of u.searchParams.entries()) {
+      const lower = key.toLowerCase();
+      if (TRACKING_QUERY_KEYS.has(lower)) continue;
+      if (KEEP_QUERY_KEYS.has(lower)) {
+        next.set(key, value);
+      }
+    }
+    u.search = next.toString() ? `?${next.toString()}` : "";
+    return u.toString();
+  } catch {
+    return url;
+  }
+}
+
+/** Replace long digit / hex path segments with `*`. */
+export function urlPatternFromUrl(url: string): string {
+  const clean = canonicalizeUrl(url);
+  try {
+    const u = new URL(clean);
+    u.pathname = u.pathname
+      .split("/")
+      .map((seg) => {
+        if (!seg) return seg;
+        if (/^\d+$/.test(seg)) return "*";
+        if (/^[0-9a-f]{8,}$/i.test(seg)) return "*";
+        return seg;
+      })
+      .join("/");
+    for (const key of [...u.searchParams.keys()]) {
+      if (KEEP_QUERY_KEYS.has(key.toLowerCase()) && (u.searchParams.get(key) ?? "").length > 48) {
+        u.searchParams.set(key, "*");
+      }
+    }
+    return u.toString();
+  } catch {
+    return clean;
+  }
+}
+
+export type PageRole = "home" | "list" | "editor" | "dialog" | "other";
+
+export function inferPageRole(url: string): PageRole {
+  const lower = url.toLowerCase();
+  if (lower.includes("/edit") || /\/(editor|compose|write)\b/.test(lower)) return "editor";
+  if (lower.includes("/dashboard") || lower.includes("/home")) return "home";
+  if (/\/(list|search|results|explore)\b/.test(lower)) return "list";
+  if (/[?&](modal|dialog)=/.test(lower)) return "dialog";
+  try {
+    const path = new URL(url).pathname;
+    if (path === "/" || path === "") return "home";
+  } catch {
+    // ignore
+  }
+  return "other";
+}
+
+export function summarizeNavigateShort(url: string): string {
+  const pattern = urlPatternFromUrl(url);
+  const site = siteFromUrl(pattern);
+  try {
+    const path = new URL(pattern).pathname;
+    if (site && (path === "/" || path === "")) return `打开 ${site}`;
+    if (site) return `打开 ${site}${path}`;
+  } catch {
+    // fall through
+  }
+  return `打开 ${pattern}`;
+}

--- a/apps/extension/src/tools/__tests__/record-observation.test.ts
+++ b/apps/extension/src/tools/__tests__/record-observation.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  ensureBrowserObservationListeners,
+  isBrowserObservationAttachedForTests,
+  releaseBrowserObservationListenersIfIdle,
+  resetBrowserObservationForTests,
+  setBrowserObservationAttachForTests,
+} from "../record";
+
+describe("browser observation lifecycle", () => {
+  afterEach(() => {
+    resetBrowserObservationForTests();
+  });
+
+  it("does not attach listeners until ensure is called", () => {
+    const tab = vi.fn(() => () => undefined);
+    const nav = vi.fn(() => () => undefined);
+    setBrowserObservationAttachForTests(tab, nav);
+
+    expect(isBrowserObservationAttachedForTests()).toBe(false);
+    expect(tab).not.toHaveBeenCalled();
+    expect(nav).not.toHaveBeenCalled();
+  });
+
+  it("attaches once on ensure and detaches when idle", () => {
+    const detachTab = vi.fn();
+    const detachNav = vi.fn();
+    const tab = vi.fn(() => detachTab);
+    const nav = vi.fn(() => detachNav);
+    setBrowserObservationAttachForTests(tab, nav);
+
+    ensureBrowserObservationListeners({
+      tabsApi: { get: vi.fn(), query: vi.fn(), create: vi.fn() } as never,
+      sendToTab: vi.fn(),
+    });
+    expect(isBrowserObservationAttachedForTests()).toBe(true);
+    expect(tab).toHaveBeenCalledTimes(1);
+    expect(nav).toHaveBeenCalledTimes(1);
+
+    // Idempotent.
+    ensureBrowserObservationListeners({
+      tabsApi: { get: vi.fn(), query: vi.fn(), create: vi.fn() } as never,
+      sendToTab: vi.fn(),
+    });
+    expect(tab).toHaveBeenCalledTimes(1);
+
+    releaseBrowserObservationListenersIfIdle();
+    expect(isBrowserObservationAttachedForTests()).toBe(false);
+    expect(detachTab).toHaveBeenCalledTimes(1);
+    expect(detachNav).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/extension/src/tools/dispatcher.ts
+++ b/apps/extension/src/tools/dispatcher.ts
@@ -12,6 +12,9 @@ import type {
   NavigateParams,
   PressParams,
   ProtocolFrame,
+  RecordAwaitParams,
+  RecordStartParams,
+  RecordStopParams,
   ReloadParams,
   RequestFrame,
   RequestHelpParams,
@@ -40,6 +43,7 @@ import {
   handleScreenshot,
   handleSnapshot,
 } from "./observation";
+import { handleRecordAwait, handleRecordStart, handleRecordStop } from "./record";
 import {
   handleSessionStart,
   handleSessionStop,
@@ -385,6 +389,45 @@ export class ToolDispatcher {
           ...(this.cdp ? { cdp: this.cdp } : {}),
           notifications: makeHelpNotifications(),
           notificationCopy: this.helpNotificationCopy?.(),
+          signal,
+        });
+      case "tool.record_start":
+        return handleRecordStart(this.sessions, req.params as RecordStartParams, {
+          tabsApi: chromeTabsApi,
+          sendToTab: (tabId, msg) => chrome.tabs.sendMessage(tabId, msg),
+          bypassOverlay: async (tabId, enabled) => {
+            try {
+              await chrome.tabs.sendMessage(tabId, {
+                type: OVERLAY_AUTOMATION_BYPASS,
+                enabled,
+              });
+            } catch {
+              // Content script may be unavailable on restricted pages.
+            }
+          },
+          ...(this.cdp ? { cdp: this.cdp } : {}),
+          signal,
+        });
+      case "tool.record_stop":
+        return handleRecordStop(this.sessions, req.params as RecordStopParams, {
+          tabsApi: chromeTabsApi,
+          sendToTab: (tabId, msg) => chrome.tabs.sendMessage(tabId, msg),
+          bypassOverlay: async (tabId, enabled) => {
+            try {
+              await chrome.tabs.sendMessage(tabId, {
+                type: OVERLAY_AUTOMATION_BYPASS,
+                enabled,
+              });
+            } catch {
+              // Content script may be unavailable on restricted pages.
+            }
+          },
+          signal,
+        });
+      case "tool.record_await":
+        return handleRecordAwait(this.sessions, req.params as RecordAwaitParams, {
+          tabsApi: chromeTabsApi,
+          sendToTab: (tabId, msg) => chrome.tabs.sendMessage(tabId, msg),
           signal,
         });
       default:

--- a/apps/extension/src/tools/record.ts
+++ b/apps/extension/src/tools/record.ts
@@ -1,0 +1,825 @@
+// `tool.record_start` / `tool.record_stop` / `tool.record_await` — capture
+// user actions in the Agent Window via the content script and return a
+// semantic (LLM textbook) trace.
+
+import {
+  isRecordFinishMessage,
+  isRecordQueryMessage,
+  isRecordStepMessage,
+  RECORD_CANCEL,
+  RECORD_START,
+  RECORD_STEP,
+  RECORD_STOP,
+  type RecordCancelMessage,
+  type RecordFinishMessage,
+  type RecordQueryResponse,
+  type RecordStartAck,
+  type RecordStartMessage,
+  type RecordStopMessage,
+} from "@/lib/record-bridge";
+import { appendRecordedPayload, observeRecordedNavigation } from "@/lib/recording-step-buffer";
+import { buildTraceEntry, reduceTraceSteps } from "@/lib/trace-reducer";
+import type { SessionManager } from "@/session-manager/manager";
+import type {
+  DraftTraceStep,
+  RecordAwaitParams,
+  RecordAwaitResult,
+  RecordStartParams,
+  RecordStartResult,
+  RecordStopParams,
+  RecordStopResult,
+  RpcError,
+  Trace,
+} from "@/transport/types";
+import { handleNavigate } from "./navigation";
+import {
+  type CdpRunner,
+  type ChromeTabsApi,
+  chromeTabsApi,
+  isRpcError,
+  lookupSession,
+  resolveTargetTab,
+} from "./shared";
+
+interface ActiveRecording {
+  requestId: string;
+  tabId: number;
+  agentWindowId: number;
+  startUrl?: string;
+  purpose?: string;
+  steps: DraftTraceStep[];
+  startedAt: string;
+  finishPromise: Promise<Trace>;
+  resolveFinish: (trace: Trace) => void;
+  rejectFinish: (err: Error) => void;
+  settled: boolean;
+  finishing: boolean;
+  currentUrl?: string;
+  pendingNavigation: boolean;
+  pendingNavigationDeadline?: number;
+}
+
+const recordings = new Map<string, ActiveRecording>();
+
+const RECORD_START_RETRIES = 3;
+const RECORD_START_RETRY_DELAY_MS = 500;
+const RECORD_REARM_DEBOUNCE_MS = 150;
+const RECORD_REARM_MAX_ATTEMPTS = 12;
+const RECORD_REARM_RETRY_DELAY_MS = 400;
+
+const rearmTimers = new Map<number, ReturnType<typeof setTimeout>>();
+
+function makeRequestId(tabId: number): string {
+  return `rec-${tabId}-${Date.now().toString(36)}`;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/** Pages where MV3 content scripts cannot attach (Agent Window boots here). */
+function isContentScriptRestrictedUrl(url: string | undefined): boolean {
+  if (!url) return true;
+  const lower = url.toLowerCase();
+  return (
+    lower === "about:blank" ||
+    lower.startsWith("about:") ||
+    lower.startsWith("chrome://") ||
+    lower.startsWith("chrome-extension://") ||
+    lower.startsWith("edge://") ||
+    lower.startsWith("devtools://") ||
+    lower.startsWith("devtools:") ||
+    lower.startsWith("https://chrome.google.com/webstore")
+  );
+}
+
+async function waitForTabReady(
+  tabId: number,
+  tabsApi: ChromeTabsApi,
+  timeoutMs = 10_000,
+): Promise<void> {
+  try {
+    const tab = await tabsApi.get(tabId);
+    if (tab.status === "complete") return;
+  } catch {
+    return;
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      chrome.tabs.onUpdated.removeListener(listener);
+      reject(new Error("tab load timeout"));
+    }, timeoutMs);
+    const listener = (updatedTabId: number, info: chrome.tabs.TabChangeInfo) => {
+      if (updatedTabId !== tabId || info.status !== "complete") return;
+      clearTimeout(timer);
+      chrome.tabs.onUpdated.removeListener(listener);
+      resolve();
+    };
+    chrome.tabs.onUpdated.addListener(listener);
+  });
+}
+
+function isRecordStartAck(response: unknown): response is RecordStartAck {
+  return (
+    typeof response === "object" &&
+    response !== null &&
+    "ok" in response &&
+    (response as RecordStartAck).ok === true
+  );
+}
+
+async function sendRecordStartWithAck(
+  tabId: number,
+  msg: RecordStartMessage,
+  sendToTab: RecordDeps["sendToTab"],
+): Promise<void> {
+  let lastError: unknown;
+  for (let attempt = 0; attempt < RECORD_START_RETRIES; attempt += 1) {
+    try {
+      const response = await sendToTab(tabId, msg);
+      if (isRecordStartAck(response)) return;
+      lastError = new Error("content script did not ack RECORD_START");
+    } catch (err) {
+      lastError = err;
+    }
+    if (attempt + 1 < RECORD_START_RETRIES) {
+      await sleep(RECORD_START_RETRY_DELAY_MS);
+    }
+  }
+  throw lastError ?? new Error("failed to start recording in content script");
+}
+
+function buildTrace(recording: ActiveRecording): Trace {
+  const reduced = reduceTraceSteps(recording.steps);
+  const entry = buildTraceEntry(recording.startUrl);
+  return {
+    version: 3,
+    ...(recording.purpose ? { purpose: recording.purpose } : {}),
+    recorded_at: new Date().toISOString(),
+    ...(entry ? { entry } : {}),
+    tab_id: recording.tabId,
+    steps: reduced,
+  };
+}
+
+export interface RecordDeps {
+  tabsApi: ChromeTabsApi;
+  sendToTab(
+    tabId: number,
+    msg: RecordStartMessage | RecordStopMessage | RecordCancelMessage,
+  ): Promise<unknown>;
+  bypassOverlay?: (tabId: number, enabled: boolean) => Promise<void>;
+  cdp?: CdpRunner;
+  signal?: AbortSignal;
+}
+
+let defaultDeps: RecordDeps | null = null;
+function getDefaultDeps(): RecordDeps {
+  if (!defaultDeps) {
+    defaultDeps = {
+      tabsApi: chromeTabsApi,
+      sendToTab: (tabId, msg) => chrome.tabs.sendMessage(tabId, msg),
+    };
+  }
+  return defaultDeps;
+}
+
+/** Disposer for lazily attached tab / webNavigation observers. */
+let detachBrowserObservation: (() => void) | null = null;
+
+type AttachObservation = (deps: RecordDeps) => () => void;
+
+// Deferred wrappers so we do not capture attach* before their declarations.
+let attachTabObservation: AttachObservation = (deps) => attachRecordTabListener(deps);
+let attachNavObservation: AttachObservation = (deps) => attachRecordNavigationListener(deps);
+
+/** Test seam: swap real chrome listeners for fakes. */
+export function setBrowserObservationAttachForTests(
+  tab: AttachObservation | null,
+  nav: AttachObservation | null,
+): void {
+  attachTabObservation = tab ?? ((deps) => attachRecordTabListener(deps));
+  attachNavObservation = nav ?? ((deps) => attachRecordNavigationListener(deps));
+}
+
+export function isBrowserObservationAttachedForTests(): boolean {
+  return detachBrowserObservation !== null;
+}
+
+export function resetBrowserObservationForTests(): void {
+  detachBrowserObservation?.();
+  detachBrowserObservation = null;
+  recordings.clear();
+  attachTabObservation = (deps) => attachRecordTabListener(deps);
+  attachNavObservation = (deps) => attachRecordNavigationListener(deps);
+}
+
+/**
+ * Attach tab/webNavigation listeners while any recording is active.
+ * Must run before navigate-on-start so rearm observes the destination load.
+ */
+export function ensureBrowserObservationListeners(deps: RecordDeps = getDefaultDeps()): void {
+  if (detachBrowserObservation) return;
+  const detachTab = attachTabObservation(deps);
+  const detachNav = attachNavObservation(deps);
+  detachBrowserObservation = () => {
+    detachTab();
+    detachNav();
+  };
+}
+
+/** Detach when the recordings map is empty. */
+export function releaseBrowserObservationListenersIfIdle(): void {
+  if (recordings.size > 0) return;
+  if (!detachBrowserObservation) return;
+  detachBrowserObservation();
+  detachBrowserObservation = null;
+}
+
+export function attachRecordStepListener(): () => void {
+  const listener = (
+    message: unknown,
+    _sender: chrome.runtime.MessageSender,
+    _sendResponse: () => void,
+  ) => {
+    if (!isRecordStepMessage(message)) return false;
+    for (const recording of recordings.values()) {
+      if (recording.requestId !== message.requestId) continue;
+      appendRecordedPayload(recording, message.step);
+      return false;
+    }
+    return false;
+  };
+  chrome.runtime.onMessage.addListener(listener);
+  return () => chrome.runtime.onMessage.removeListener(listener);
+}
+
+export function attachRecordFinishListener(deps: RecordDeps = getDefaultDeps()): () => void {
+  const listener = (
+    message: unknown,
+    sender: chrome.runtime.MessageSender,
+    _sendResponse: () => void,
+  ) => {
+    if (!isRecordFinishMessage(message)) return false;
+    const tabId = sender.tab?.id;
+    if (tabId === undefined) return false;
+    void finishRecordingByRequest(message.requestId, tabId, deps);
+    return false;
+  };
+  chrome.runtime.onMessage.addListener(listener);
+  return () => chrome.runtime.onMessage.removeListener(listener);
+}
+
+function findRecordingByTabId(tabId: number): ActiveRecording | null {
+  for (const recording of recordings.values()) {
+    if (recording.tabId === tabId && !recording.settled) return recording;
+  }
+  return null;
+}
+
+async function findRecordingForTab(
+  tabId: number,
+  deps: RecordDeps,
+): Promise<ActiveRecording | null> {
+  const direct = findRecordingByTabId(tabId);
+  if (direct) return direct;
+
+  try {
+    const tab = await deps.tabsApi.get(tabId);
+    const windowId = tab.windowId;
+    if (typeof windowId !== "number") return null;
+    for (const recording of recordings.values()) {
+      if (!recording.settled && recording.agentWindowId === windowId) return recording;
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+function clearRearmTimer(tabId: number): void {
+  const timer = rearmTimers.get(tabId);
+  if (timer) {
+    clearTimeout(timer);
+    rearmTimers.delete(tabId);
+  }
+}
+
+async function clearRearmTimersForRecording(
+  recording: ActiveRecording,
+  deps: RecordDeps,
+): Promise<void> {
+  clearRearmTimer(recording.tabId);
+  try {
+    const tabs = await deps.tabsApi.query({ windowId: recording.agentWindowId });
+    for (const tab of tabs) {
+      if (typeof tab.id === "number") clearRearmTimer(tab.id);
+    }
+  } catch {
+    // Best-effort cleanup.
+  }
+}
+
+async function stopRecordingOnAllAgentTabs(
+  recording: ActiveRecording,
+  deps: RecordDeps,
+): Promise<void> {
+  const stopMsg: RecordStopMessage = { type: RECORD_STOP, requestId: recording.requestId };
+  let tabIds = [recording.tabId];
+  try {
+    const tabs = await deps.tabsApi.query({ windowId: recording.agentWindowId });
+    tabIds = [
+      ...new Set([
+        recording.tabId,
+        ...tabs.flatMap((tab) => (typeof tab.id === "number" ? [tab.id] : [])),
+      ]),
+    ];
+  } catch {
+    // Fall back to the current recording tab.
+  }
+
+  for (const tabId of tabIds) {
+    try {
+      const response = await deps.sendToTab(tabId, stopMsg);
+      if (tabId === recording.tabId && !isRecordStartAck(response)) {
+        throw new Error("content script did not confirm recorded steps");
+      }
+    } catch {
+      if (tabId === recording.tabId) {
+        throw new Error("failed to flush recorded steps");
+      }
+    }
+    if (deps.bypassOverlay) {
+      try {
+        await deps.bypassOverlay(tabId, false);
+      } catch {
+        // Best-effort cleanup.
+      }
+    }
+  }
+}
+
+async function rearmRecording(
+  recording: ActiveRecording,
+  targetTabId: number,
+  deps: RecordDeps,
+): Promise<boolean> {
+  // Do NOT toggle automation-bypass here: each retry used to increment the
+  // content-script counter, and a single stop decrement left the ControlOverlay
+  // stuck with pointer-events:none (page usable, Interrupt dead). RecordOverlay
+  // already hides the control chrome while activeRecord is set.
+  for (let attempt = 0; attempt < RECORD_REARM_MAX_ATTEMPTS; attempt += 1) {
+    const startMsg: RecordStartMessage = { type: RECORD_START, requestId: recording.requestId };
+    try {
+      await sendRecordStartWithAck(targetTabId, startMsg, deps.sendToTab);
+      recording.tabId = targetTabId;
+      return true;
+    } catch {
+      if (attempt + 1 < RECORD_REARM_MAX_ATTEMPTS) {
+        await sleep(RECORD_REARM_RETRY_DELAY_MS);
+      }
+    }
+  }
+  return false;
+}
+
+function scheduleRearmForTab(tabId: number, deps: RecordDeps): void {
+  const existing = rearmTimers.get(tabId);
+  if (existing) clearTimeout(existing);
+  rearmTimers.set(
+    tabId,
+    setTimeout(() => {
+      rearmTimers.delete(tabId);
+      void (async () => {
+        const current = await findRecordingForTab(tabId, deps);
+        if (current) await rearmRecording(current, tabId, deps);
+      })();
+    }, RECORD_REARM_DEBOUNCE_MS),
+  );
+}
+
+export function attachRecordTabListener(deps: RecordDeps = getDefaultDeps()): () => void {
+  const onCreated = (tab: chrome.tabs.Tab) => {
+    const tabId = tab.id;
+    const windowId = tab.windowId;
+    if (tabId === undefined || windowId === undefined) return;
+    for (const recording of recordings.values()) {
+      if (recording.settled || recording.agentWindowId !== windowId) continue;
+      scheduleRearmForTab(tabId, deps);
+      return;
+    }
+  };
+
+  const onActivated = (activeInfo: chrome.tabs.TabActiveInfo) => {
+    scheduleRearmForTab(activeInfo.tabId, deps);
+  };
+
+  chrome.tabs.onCreated.addListener(onCreated);
+  chrome.tabs.onActivated.addListener(onActivated);
+  return () => {
+    chrome.tabs.onCreated.removeListener(onCreated);
+    chrome.tabs.onActivated.removeListener(onActivated);
+  };
+}
+
+export function attachRecordNavigationListener(deps: RecordDeps = getDefaultDeps()): () => void {
+  const observeMainFrame = (tabId: number, url?: string, causedByAction?: boolean) => {
+    void (async () => {
+      const recording = await findRecordingForTab(tabId, deps);
+      if (recording && url) {
+        observeRecordedNavigation(recording, url, causedByAction);
+      }
+    })();
+  };
+  const onMainFrameComplete = (tabId: number, url?: string) => {
+    void (async () => {
+      observeMainFrame(tabId, url);
+      scheduleRearmForTab(tabId, deps);
+    })();
+  };
+
+  if (chrome.webNavigation?.onCompleted) {
+    const completedListener = (
+      details: chrome.webNavigation.WebNavigationFramedCallbackDetails,
+    ) => {
+      if (details.frameId !== 0) return;
+      onMainFrameComplete(details.tabId, details.url);
+    };
+    const committedListener = (
+      details: chrome.webNavigation.WebNavigationTransitionCallbackDetails,
+    ) => {
+      if (details.frameId !== 0) return;
+      const causedByAction =
+        details.transitionType === "link" || details.transitionType === "form_submit"
+          ? true
+          : details.transitionType === "typed" ||
+              details.transitionType === "auto_bookmark" ||
+              details.transitionType === "generated" ||
+              details.transitionType === "keyword" ||
+              details.transitionType === "keyword_generated" ||
+              details.transitionType === "reload"
+            ? false
+            : undefined;
+      observeMainFrame(details.tabId, details.url, causedByAction);
+    };
+    chrome.webNavigation.onCompleted.addListener(completedListener);
+    chrome.webNavigation.onCommitted?.addListener(committedListener);
+    return () => {
+      chrome.webNavigation.onCompleted.removeListener(completedListener);
+      chrome.webNavigation.onCommitted?.removeListener(committedListener);
+    };
+  }
+
+  const listener = (tabId: number, info: chrome.tabs.TabChangeInfo) => {
+    if (info.status !== "complete") return;
+    onMainFrameComplete(tabId, info.url);
+  };
+  chrome.tabs.onUpdated.addListener(listener);
+  return () => chrome.tabs.onUpdated.removeListener(listener);
+}
+
+export function attachRecordQueryListener(deps: RecordDeps = getDefaultDeps()): () => void {
+  const listener = (
+    message: unknown,
+    sender: chrome.runtime.MessageSender,
+    sendResponse: (response: RecordQueryResponse) => void,
+  ) => {
+    if (!isRecordQueryMessage(message)) return false;
+    const tabId = sender.tab?.id;
+    if (tabId === undefined) {
+      sendResponse({ active: false });
+      return false;
+    }
+    void (async () => {
+      const recording = await findRecordingForTab(tabId, deps);
+      if (!recording) {
+        sendResponse({ active: false });
+        return;
+      }
+      await rearmRecording(recording, tabId, deps);
+      sendResponse({ active: true, requestId: recording.requestId });
+    })();
+    return true;
+  };
+  chrome.runtime.onMessage.addListener(listener);
+  return () => chrome.runtime.onMessage.removeListener(listener);
+}
+
+async function finishRecordingByRequest(
+  requestId: string,
+  tabId: number,
+  deps: RecordDeps,
+): Promise<void> {
+  for (const [sessionId, recording] of recordings) {
+    if (recording.requestId !== requestId || recording.settled) continue;
+    const match = await findRecordingForTab(tabId, deps);
+    if (match !== recording) continue;
+    await finishRecording(sessionId, deps);
+    return;
+  }
+}
+
+async function finishRecording(sessionId: string, deps: RecordDeps): Promise<Trace | null> {
+  const recording = recordings.get(sessionId);
+  if (!recording || recording.settled || recording.finishing) return null;
+  recording.finishing = true;
+
+  await clearRearmTimersForRecording(recording, deps);
+  try {
+    await stopRecordingOnAllAgentTabs(recording, deps);
+  } catch {
+    recording.finishing = false;
+    return null;
+  }
+
+  recording.settled = true;
+  recordings.delete(sessionId);
+  releaseBrowserObservationListenersIfIdle();
+  const trace = buildTrace(recording);
+  recording.resolveFinish(trace);
+  return trace;
+}
+
+export async function handleRecordStart(
+  manager: SessionManager,
+  params: RecordStartParams,
+  deps: RecordDeps = getDefaultDeps(),
+): Promise<RecordStartResult | RpcError> {
+  const ctxOrErr = lookupSession(manager, params, "record_start");
+  if (isRpcError(ctxOrErr)) return ctxOrErr;
+  const ctx = ctxOrErr;
+  if (recordings.has(params.session_id)) {
+    return {
+      code: "protocol_error",
+      message: `session ${params.session_id} is already recording`,
+    };
+  }
+  const target = await resolveTargetTab(manager, ctx, params.tab_id, deps.tabsApi);
+  if (isRpcError(target)) return target;
+
+  // Register the recording *before* navigate so content-script syncAgentOverlay
+  // on the destination page can RECORD_QUERY → rearm → show RecordOverlay
+  // instead of flashing ControlOverlay ("Agent 正在控制").
+  const requestId = makeRequestId(target.tabId);
+  let resolveFinish!: (trace: Trace) => void;
+  let rejectFinish!: (err: Error) => void;
+  const finishPromise = new Promise<Trace>((resolve, reject) => {
+    resolveFinish = resolve;
+    rejectFinish = reject;
+  });
+  const provisionalUrl = params.url;
+  recordings.set(params.session_id, {
+    requestId,
+    tabId: target.tabId,
+    agentWindowId: ctx.agentWindowId,
+    startUrl: provisionalUrl,
+    ...(params.purpose ? { purpose: params.purpose } : {}),
+    steps: [],
+    startedAt: new Date().toISOString(),
+    finishPromise,
+    resolveFinish,
+    rejectFinish,
+    settled: false,
+    finishing: false,
+    currentUrl: provisionalUrl,
+    pendingNavigation: false,
+    pendingNavigationDeadline: undefined,
+  });
+  // Observe navigations for the whole recording lifetime; attach before
+  // optional navigate so the destination load can rearm capture.
+  ensureBrowserObservationListeners(deps);
+
+  const abortPending = async (notifyContent: boolean) => {
+    recordings.delete(params.session_id);
+    releaseBrowserObservationListenersIfIdle();
+    if (notifyContent) {
+      try {
+        await deps.sendToTab(target.tabId, {
+          type: RECORD_CANCEL,
+          requestId,
+        });
+      } catch {
+        // Content may never have received RECORD_START.
+      }
+    }
+    if (deps.bypassOverlay) {
+      try {
+        await deps.bypassOverlay(target.tabId, false);
+      } catch {
+        // Ignore cleanup errors.
+      }
+    }
+  };
+
+  const cancelledError = (): RpcError => ({
+    code: "cancelled",
+    message: "record_start aborted",
+  });
+
+  /** Dispatcher may race-cancel while we still hold a provisional recording. */
+  const abortIfCancelled = async (notifyContent: boolean): Promise<RpcError | null> => {
+    if (!deps.signal?.aborted) return null;
+    await abortPending(notifyContent);
+    return cancelledError();
+  };
+
+  {
+    const cancelled = await abortIfCancelled(false);
+    if (cancelled) return cancelled;
+  }
+
+  if (params.url && deps.cdp) {
+    const nav = await handleNavigate(
+      manager,
+      {
+        session_id: params.session_id,
+        url: params.url,
+        tab_id: target.tabId,
+      },
+      { cdp: deps.cdp, tabsApi: deps.tabsApi, signal: deps.signal },
+    );
+    if (isRpcError(nav)) {
+      await abortPending(false);
+      return nav;
+    }
+    {
+      const cancelled = await abortIfCancelled(false);
+      if (cancelled) return cancelled;
+    }
+    try {
+      await waitForTabReady(target.tabId, deps.tabsApi);
+    } catch {
+      // Proceed with retries even if the tab never reports complete.
+    }
+    {
+      const cancelled = await abortIfCancelled(false);
+      if (cancelled) return cancelled;
+    }
+  }
+
+  let startUrl: string | undefined;
+  try {
+    const tab = await deps.tabsApi.get(target.tabId);
+    startUrl = tab.url;
+  } catch {
+    startUrl = params.url;
+  }
+
+  const active = recordings.get(params.session_id);
+  if (!active) {
+    // Cleared by a concurrent abort / session teardown.
+    return cancelledError();
+  }
+  active.startUrl = startUrl;
+  active.currentUrl = startUrl;
+
+  if (isContentScriptRestrictedUrl(startUrl)) {
+    await abortPending(false);
+    return {
+      code: "invalid_params",
+      message: params.url
+        ? `cannot record on restricted URL (${startUrl}); use an http(s) page`
+        : "Agent Window starts on about:blank where the content script cannot inject — pass --url https://… before recording",
+    };
+  }
+
+  {
+    const cancelled = await abortIfCancelled(false);
+    if (cancelled) return cancelled;
+  }
+
+  if (deps.bypassOverlay) {
+    try {
+      // Single ref for the initial race before RecordOverlay mounts; rearm must
+      // not stack additional refs (see rearmRecording). Cleared on stop.
+      await deps.bypassOverlay(target.tabId, true);
+    } catch {
+      // Best-effort; activeRecord also hides the control overlay.
+    }
+  }
+
+  {
+    const cancelled = await abortIfCancelled(true);
+    if (cancelled) return cancelled;
+  }
+
+  const startMsg: RecordStartMessage = { type: RECORD_START, requestId };
+
+  try {
+    await sendRecordStartWithAck(target.tabId, startMsg, deps.sendToTab);
+  } catch {
+    await abortPending(true);
+    return {
+      code: "protocol_error",
+      message:
+        "failed to start recording in content script — reload the BrowserSkill extension, then retry with --url https://…",
+    };
+  }
+
+  {
+    const cancelled = await abortIfCancelled(true);
+    if (cancelled) return cancelled;
+  }
+
+  return { tab_id: target.tabId, recording: true };
+}
+
+export async function handleRecordStop(
+  manager: SessionManager,
+  params: RecordStopParams,
+  deps: RecordDeps = getDefaultDeps(),
+): Promise<RecordStopResult | RpcError> {
+  const ctxOrErr = lookupSession(manager, params, "record_stop");
+  if (isRpcError(ctxOrErr)) return ctxOrErr;
+
+  const recording = recordings.get(params.session_id);
+  if (!recording) {
+    return {
+      code: "not_found",
+      message: `no active recording for session ${params.session_id}`,
+    };
+  }
+
+  const trace = await finishRecording(params.session_id, deps);
+  if (!trace) {
+    return {
+      code: "protocol_error",
+      message: `failed to stop recording for session ${params.session_id}`,
+    };
+  }
+  return { trace };
+}
+
+export async function handleRecordAwait(
+  manager: SessionManager,
+  params: RecordAwaitParams,
+  deps: RecordDeps = getDefaultDeps(),
+): Promise<RecordAwaitResult | RpcError> {
+  const ctxOrErr = lookupSession(manager, params, "record_await");
+  if (isRpcError(ctxOrErr)) return ctxOrErr;
+
+  const recording = recordings.get(params.session_id);
+  if (!recording) {
+    return {
+      code: "not_found",
+      message: `no active recording for session ${params.session_id}`,
+    };
+  }
+
+  if (deps.signal?.aborted) {
+    return { code: "cancelled", message: "record_await aborted" };
+  }
+
+  const outcome = await new Promise<{ trace: Trace } | { error: RpcError }>((resolve) => {
+    let settled = false;
+    const finish = (result: { trace: Trace } | { error: RpcError }) => {
+      if (settled) return;
+      settled = true;
+      if (timer) clearTimeout(timer);
+      deps.signal?.removeEventListener("abort", onAbort);
+      resolve(result);
+    };
+    const onAbort = () => finish({ error: { code: "cancelled", message: "record_await aborted" } });
+    const timer =
+      params.timeout_ms === undefined
+        ? undefined
+        : setTimeout(
+            () =>
+              finish({
+                error: {
+                  code: "timeout",
+                  message: `record_await timed out after ${params.timeout_ms}ms`,
+                },
+              }),
+            params.timeout_ms,
+          );
+    deps.signal?.addEventListener("abort", onAbort, { once: true });
+    void recording.finishPromise.then(
+      (trace) => finish({ trace }),
+      () =>
+        finish({
+          error: { code: "cancelled", message: "recording was cleared" },
+        }),
+    );
+  });
+  return "trace" in outcome ? { trace: outcome.trace } : outcome.error;
+}
+
+export function clearRecordingForSession(sessionId: string): void {
+  const recording = recordings.get(sessionId);
+  if (!recording) {
+    recordings.delete(sessionId);
+    releaseBrowserObservationListenersIfIdle();
+    return;
+  }
+  void clearRearmTimersForRecording(recording, getDefaultDeps());
+  if (!recording.settled) {
+    recording.settled = true;
+    recording.rejectFinish(new Error("recording cleared"));
+  }
+  recordings.delete(sessionId);
+  releaseBrowserObservationListenersIfIdle();
+}
+
+export type { RecordFinishMessage };

--- a/apps/extension/src/tools/session.ts
+++ b/apps/extension/src/tools/session.ts
@@ -1,5 +1,6 @@
 import type { SessionManager } from "@/session-manager/manager";
 import type { RpcError } from "@/transport/types";
+import { clearRecordingForSession } from "./record";
 import { returnBorrowedTab, type TabManagementDeps } from "./tabs";
 
 export interface SessionStartParams {
@@ -155,6 +156,8 @@ export async function handleSessionStop(
 
   // Step 2: clear the per-session RefStore (review M6/M7 parity).
   ctx.refStore.clear();
+
+  clearRecordingForSession(params.session_id);
 
   // Step 3: detach CDP sessions this session opened (no-op if none).
   await deps.cdp?.detachSession(params.session_id);

--- a/apps/extension/src/transport/types.ts
+++ b/apps/extension/src/transport/types.ts
@@ -506,3 +506,152 @@ export interface RequestHelpResult {
   tab_id: number;
   resolved_targets?: ResolvedTarget[];
 }
+
+// --------------------------------------------------------------------------
+// Semantic record payloads — mirror bsk-protocol record.rs (Trace v2)
+// --------------------------------------------------------------------------
+
+export interface TargetDescriptor {
+  role?: string;
+  name?: string;
+  tag: string;
+  name_attr?: string;
+  placeholder?: string;
+  nearby_label?: string;
+}
+
+export type TraceIntent =
+  | "open_entry"
+  | "navigate"
+  | "search"
+  | "open_item"
+  | "provide_input"
+  | "toggle"
+  | "confirm"
+  | "submit_key"
+  | "other";
+
+export type TraceImportance = "essential" | "optional";
+
+export type PageRole = "home" | "list" | "editor" | "dialog" | "other";
+
+export interface PageContext {
+  url?: string;
+  url_pattern?: string;
+  title?: string;
+  role?: PageRole;
+}
+
+export interface StepEffect {
+  navigated_to?: string;
+  url_pattern_after?: string;
+}
+
+export interface NavDestination {
+  url: string;
+  url_pattern?: string;
+}
+
+/** Capture/buffer draft before v3 textbook reduction. */
+export type DraftTraceStep =
+  | {
+      op: "click";
+      target: TargetDescriptor;
+      summary?: string;
+      navigated_to?: string;
+      page_url?: string;
+    }
+  | {
+      op: "fill";
+      target: TargetDescriptor;
+      value: string;
+      summary?: string;
+      redacted?: boolean;
+      page_url?: string;
+    }
+  | {
+      op: "press";
+      key: string;
+      target?: TargetDescriptor;
+      modifiers?: KeyModifier[];
+      summary?: string;
+      navigated_to?: string;
+      page_url?: string;
+    }
+  | {
+      op: "select";
+      target: TargetDescriptor;
+      values: string[];
+      labels?: string[];
+      summary?: string;
+      page_url?: string;
+    }
+  | {
+      op: "navigate";
+      url: string;
+      summary?: string;
+      page_url?: string;
+    };
+
+/** Exported textbook step (trace v3). */
+export interface TraceStep {
+  id: number;
+  op: "click" | "fill" | "press" | "select" | "navigate";
+  intent?: TraceIntent;
+  importance?: TraceImportance;
+  page?: PageContext;
+  summary?: string;
+  target?: TargetDescriptor;
+  effect?: StepEffect;
+  value?: string;
+  redacted?: boolean;
+  key?: string;
+  modifiers?: KeyModifier[];
+  values?: string[];
+  labels?: string[];
+  destination?: NavDestination;
+}
+
+export interface TraceEntry {
+  start_url?: string;
+  start_url_pattern?: string;
+  site?: string;
+}
+
+export interface Trace {
+  version: number;
+  purpose?: string;
+  recorded_at: string;
+  entry?: TraceEntry;
+  tab_id?: number;
+  steps: TraceStep[];
+}
+
+export interface RecordStartParams {
+  session_id: string;
+  tab_id?: number;
+  url?: string;
+  purpose?: string;
+}
+
+export interface RecordStartResult {
+  tab_id: number;
+  recording: boolean;
+}
+
+export interface RecordStopParams {
+  session_id: string;
+}
+
+export interface RecordStopResult {
+  trace: Trace;
+}
+
+export interface RecordAwaitParams {
+  session_id: string;
+  timeout_ms?: number;
+}
+
+export interface RecordAwaitResult {
+  trace: Trace;
+}

--- a/apps/extension/wxt.config.ts
+++ b/apps/extension/wxt.config.ts
@@ -25,7 +25,7 @@ export default defineConfig({
     name: "BrowserSkill",
     description:
       "Let AI agents use your logged-in browser in a separate Agent Window—without interrupting your work. Powered by the bsk CLI.",
-    permissions: ["alarms", "debugger", "notifications", "tabs", "storage", "windows"],
+    permissions: ["alarms", "debugger", "notifications", "tabs", "storage", "webNavigation", "windows"],
     host_permissions: ["<all_urls>"],
     icons: {
       16: "icon/logo.png",

--- a/crates/bsk-cli/skill/SKILL.md
+++ b/crates/bsk-cli/skill/SKILL.md
@@ -46,6 +46,20 @@ Optional: `bsk session start --browser <instance-id-or-label>` when multiple bro
 
 Emergency cleanup: `bsk session stop --all` or the Agent Window overlay **Stop all**.
 
+## Stop when the goal is met
+
+Tasks may come from a **user description** (“play 传奇 on QQ Music”) and/or an optional **`trace.json` textbook**. Either way, treat the session as a short goal loop — not an open-ended browsing session.
+
+1. **State the done condition** up front (from the user’s words, `purpose`, or the last essential textbook step). Example: “《传奇》已开始播放”.
+2. **Take the shortest path** to that condition. Prefer one snapshot → act → (optional) one check.
+3. **As soon as the goal is met, stop acting and `bsk session stop <id>`** unless the user explicitly asked to keep the window open (“先别关”, “keep browsing”, etc.).
+4. **No post-success exploration** — after success, do **not** click again, refresh, re-search, switch tabs, or “make sure it’s really playing”. Extra verification is a new task, not part of finishing.
+5. If unsure whether you’re done: at most **one** extra `bsk snapshot`, then either stop (goal looks met) or ask the user — do not keep clicking.
+
+**With a textbook:** execute `importance: essential` steps in order; after the last essential step (or when its `effect` / success hint is satisfied), apply rules 3–4 immediately. The textbook is guidance, not a license to keep controlling the browser.
+
+**Without a textbook:** the user’s request *is* the done condition. Completing that request ends the task — same stop rules.
+
 ## Core interaction loop
 
 Write operations only affect tabs in the **Agent Window** (or tabs you **borrowed** into it).
@@ -216,13 +230,32 @@ Human errors print `error:` + `hint:` on stderr; `--json` includes `code`, `mess
 
 Always **`bsk session stop <id>`** in a `finally`-style path so the Agent Window closes and borrowed tabs return.
 
+### Record a semantic flow textbook
+
+When the human wants to capture “how I do X in the browser” for later LLM-driven automation:
+
+```bash
+bsk record start --purpose "How to create and publish a document in the wiki." --url https://… [--output trace.json]
+# `--url` is required on a fresh session (about:blank cannot host the content script).
+# Blocks until the user clicks Finish in the browser recording panel.
+# Writes ./trace.json (override with --output) and closes the window.
+
+bsk record stop [--output trace.json]   # terminal fallback if the panel is unavailable
+```
+
+- The trace is a **semantic textbook** (`version: 3`: intent/page/effect + role/name/tag summaries; variable inputs left for the LLM). Recording stops once `trace.json` is written.
+- `--purpose` is optional metadata for post-hoc LLM context; it does **not** change what gets captured.
+- There is **no** `bsk replay` and **no** new execute-from-trace path — to redo the flow, reuse **existing** `session` / `snapshot` / `@eN` / `click` / `fill` tools after reading the textbook. Follow **Stop when the goal is met** when executing from a textbook or from a plain user request.
+- Do **not** record on banking/SSO/password-manager pages; password fields are redacted but traces may still contain sensitive text.
+
 ## Red lines
 
 1. **No token theft** — do not `bsk evaluate` on sensitive sites to read `localStorage`, cookies, or auth headers for exfiltration.
 2. **No long borrow** — do not leave a user's personal tab in the Agent Window across unrelated tasks.
 3. **No skip stop** — always `bsk session stop <id>`; never assume idle timeout will clean up.
-4. **No observe escalation before snapshot** — use `bsk snapshot` first; only use `bsk get-html` or `bsk screenshot` when the snapshot is insufficient. Element screenshots (`--ref @eN`) still require a fresh snapshot ref — never skip snapshot just to grab a visual.
-5. **`evaluate` is powerful and risky** — use only when snapshot + click/fill/select cannot suffice; never on credential surfaces.
+4. **No post-success control** — once the user’s goal (or last textbook essential step) is met, do not keep operating the page; stop the session unless they asked to keep it open.
+5. **No observe escalation before snapshot** — use `bsk snapshot` first; only use `bsk get-html` or `bsk screenshot` when the snapshot is insufficient. Element screenshots (`--ref @eN`) still require a fresh snapshot ref — never skip snapshot just to grab a visual.
+6. **`evaluate` is powerful and risky** — use only when snapshot + click/fill/select cannot suffice; never on credential surfaces.
 
 ---
 

--- a/crates/bsk-cli/src/cli/mod.rs
+++ b/crates/bsk-cli/src/cli/mod.rs
@@ -18,6 +18,8 @@ pub mod install_skill;
 pub mod interaction;
 pub mod logs;
 pub mod navigate;
+pub mod record;
+pub mod record_state;
 pub mod render_error;
 pub mod screenshot;
 pub mod session;
@@ -37,6 +39,7 @@ use crate::cli::human_loop::RequestHelpArgs;
 use crate::cli::install_skill::InstallSkillArgs;
 use crate::cli::interaction::{ClickArgs, FillArgs, PressArgs, SelectArgs};
 use crate::cli::navigate::{NavigateCommand, NavigateHistoryArgs, ReloadArgs};
+use crate::cli::record::RecordCmd;
 use crate::cli::screenshot::ScreenshotArgs;
 use crate::cli::session::SessionCmd;
 use crate::cli::snapshot::SnapshotArgs;
@@ -164,6 +167,9 @@ pub enum Command {
     /// Ask the human to complete an in-page step (captcha / login / confirm).
     #[command(name = "request-help")]
     RequestHelp(RequestHelpArgs),
+
+    /// Record user actions into a semantic `trace.json` textbook for LLMs.
+    Record(RecordCmd),
 }
 
 #[derive(Debug, Clone, Args, Default)]

--- a/crates/bsk-cli/src/cli/record.rs
+++ b/crates/bsk-cli/src/cli/record.rs
@@ -1,0 +1,256 @@
+//! `bsk record start|stop` — capture user actions in the Agent Window.
+
+use std::fs;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use anyhow::Context;
+use bsk_protocol::Method;
+use bsk_protocol::tools::{
+    RecordAwaitParams, RecordAwaitResult, RecordStartParams, RecordStartResult, RecordStopParams,
+    RecordStopResult, Trace,
+};
+use clap::{Args, Subcommand};
+
+use crate::cli::business_rpc;
+use crate::cli::ensure_daemon::ensure_daemon;
+use crate::cli::error::{CliError, Format};
+use crate::cli::record_state;
+use crate::cli::session::{start_session, stop_session};
+use crate::cli::TOOL_IPC_TIMEOUT;
+
+/// Max wait for the user to click 结束 in the browser (24 hours).
+const RECORD_AWAIT_TIMEOUT_MS: u32 = 86_400_000;
+
+/// `bsk record …` subcommand tree.
+#[derive(Debug, Clone, Args)]
+pub struct RecordCmd {
+    #[command(subcommand)]
+    pub sub: RecordSub,
+}
+
+#[derive(Debug, Clone, Subcommand)]
+pub enum RecordSub {
+    /// Open the Agent Window, record user actions, and block until finished in the browser.
+    Start(RecordStartArgs),
+    /// Stop recording from the terminal (fallback), write trace JSON, and close the window.
+    /// Works even while `record start` is blocked in `record_await` (daemon forwards
+    /// `tool.record_stop` without the per-session busy gate).
+    Stop(RecordStopArgs),
+}
+
+#[derive(Debug, Clone, Args)]
+pub struct RecordStartArgs {
+    #[arg(long = "tab-id")]
+    pub tab_id: Option<i64>,
+
+    /// Navigate to this http(s) URL before recording (required for a fresh
+    /// session — Agent Window starts on about:blank, which cannot host the
+    /// content script).
+    #[arg(long)]
+    pub url: Option<String>,
+
+    /// Optional goal text stored on the exported trace for LLM context.
+    #[arg(long)]
+    pub purpose: Option<String>,
+
+    /// Output path for the trace JSON (default `./trace.json`).
+    #[arg(long, default_value = "trace.json")]
+    pub output: PathBuf,
+}
+
+#[derive(Debug, Clone, Args)]
+pub struct RecordStopArgs {
+    /// Output path for the trace JSON (default `./trace.json`).
+    #[arg(long, default_value = "trace.json")]
+    pub output: PathBuf,
+}
+
+pub fn dispatch(cmd: RecordCmd, format: Format) -> Result<(), CliError> {
+    match cmd.sub {
+        RecordSub::Start(args) => dispatch_start(args, format),
+        RecordSub::Stop(args) => dispatch_stop(args, format),
+    }
+}
+
+fn dispatch_start(args: RecordStartArgs, format: Format) -> Result<(), CliError> {
+    if record_state::read().is_ok() {
+        return Err(CliError::Local(anyhow::anyhow!(
+            "a recording is already in progress; run `bsk record stop` first"
+        )));
+    }
+
+    let info = ensure_daemon().context("ensure daemon is running")?;
+    let session = start_session(info.sock_path.clone(), None)?;
+
+    let start_params = RecordStartParams {
+        session_id: session.session_id.clone(),
+        tab_id: args.tab_id,
+        url: args.url,
+        purpose: args.purpose.clone(),
+    };
+    let start_result = business_rpc::call::<RecordStartParams, RecordStartResult>(
+        info.sock_path.clone(),
+        "record-start",
+        Method::ToolRecordStart,
+        Some(start_params),
+        TOOL_IPC_TIMEOUT,
+    );
+
+    let start_result = match start_result {
+        Ok(result) => result,
+        Err(err) => {
+            let _ = stop_session(info.sock_path, &session.session_id);
+            return Err(err);
+        }
+    };
+
+    if let Err(err) = record_state::write(&session.session_id) {
+        let _ = stop_session(info.sock_path.clone(), &session.session_id);
+        return Err(CliError::Local(err));
+    }
+
+    if format == Format::Human {
+        println!(
+            "recording on tab={} — click 结束 in the browser when done",
+            start_result.tab_id
+        );
+    }
+
+    let await_params = RecordAwaitParams {
+        session_id: session.session_id.clone(),
+        timeout_ms: Some(RECORD_AWAIT_TIMEOUT_MS),
+    };
+    let await_result = business_rpc::call::<RecordAwaitParams, RecordAwaitResult>(
+        info.sock_path.clone(),
+        "record-await",
+        Method::ToolRecordAwait,
+        Some(await_params),
+        record_await_ipc_timeout(RECORD_AWAIT_TIMEOUT_MS),
+    );
+
+    // Keep write/render inside a Result so `?` cannot skip session teardown.
+    let run_result: Result<(), CliError> = match await_result {
+        Ok(result) => (|| {
+            write_trace_file(&args.output, &result.trace)?;
+            render_finish(&result.trace, &args.output, format)
+        })(),
+        Err(err) => Err(err),
+    };
+
+    let session_stop_result = stop_session(info.sock_path, &session.session_id);
+    record_state::clear();
+
+    run_result?;
+    session_stop_result?;
+    Ok(())
+}
+
+fn dispatch_stop(args: RecordStopArgs, format: Format) -> Result<(), CliError> {
+    let state = record_state::read().map_err(CliError::Local)?;
+    let info = ensure_daemon().context("ensure daemon is running")?;
+    let session_id = state.session_id.clone();
+
+    let run_result: Result<(), CliError> = (|| {
+        let params = RecordStopParams {
+            session_id: session_id.clone(),
+        };
+        let result = business_rpc::call::<RecordStopParams, RecordStopResult>(
+            info.sock_path.clone(),
+            "record-stop",
+            Method::ToolRecordStop,
+            Some(params),
+            TOOL_IPC_TIMEOUT,
+        )?;
+        write_trace_file(&args.output, &result.trace)?;
+        render_stop(&result, &args.output, format)
+    })();
+
+    let session_stop_result = stop_session(info.sock_path, &session_id);
+    record_state::clear();
+
+    run_result?;
+    session_stop_result?;
+    Ok(())
+}
+
+fn record_await_ipc_timeout(timeout_ms: u32) -> Duration {
+    Duration::from_millis(u64::from(timeout_ms))
+        .checked_add(Duration::from_secs(15))
+        .unwrap_or(Duration::from_secs(u64::from(timeout_ms / 1_000) + 15))
+}
+
+fn write_trace_file(output: &PathBuf, trace: &Trace) -> Result<(), CliError> {
+    let json = serde_json::to_string_pretty(trace)
+        .context("serialize trace JSON")
+        .map_err(CliError::Local)?;
+    if let Some(parent) = output.parent() {
+        if !parent.as_os_str().is_empty() {
+            fs::create_dir_all(parent)
+                .with_context(|| format!("create output directory {}", parent.display()))
+                .map_err(|e| CliError::Local(e.into()))?;
+        }
+    }
+    fs::write(output, format!("{json}\n"))
+        .with_context(|| format!("write trace to {}", output.display()))
+        .map_err(CliError::Local)?;
+    Ok(())
+}
+
+fn render_finish(trace: &Trace, output: &PathBuf, format: Format) -> Result<(), CliError> {
+    match format {
+        Format::Json => {
+            println!(
+                "{}",
+                serde_json::to_string(&serde_json::json!({
+                    "output": output,
+                    "trace": trace,
+                    "window_closed": true,
+                }))
+                .map_err(|e| CliError::Local(e.into()))?
+            );
+        }
+        Format::Human => {
+            println!(
+                "saved {} steps to {}",
+                trace.steps.len(),
+                output.display()
+            );
+        }
+    }
+    Ok(())
+}
+
+fn render_stop(result: &RecordStopResult, output: &PathBuf, format: Format) -> Result<(), CliError> {
+    render_finish(&result.trace, output, format)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_output_is_trace_json() {
+        let args = RecordStopArgs {
+            output: PathBuf::from("trace.json"),
+        };
+        assert_eq!(args.output, PathBuf::from("trace.json"));
+    }
+
+    #[test]
+    fn start_args_default_output_is_trace_json() {
+        let args = RecordStartArgs {
+            tab_id: None,
+            url: None,
+            purpose: None,
+            output: PathBuf::from("trace.json"),
+        };
+        assert_eq!(args.output, PathBuf::from("trace.json"));
+    }
+
+    #[test]
+    fn record_await_ipc_timeout_covers_long_wait() {
+        let got = record_await_ipc_timeout(RECORD_AWAIT_TIMEOUT_MS);
+        assert!(got >= Duration::from_secs(86_400));
+    }
+}

--- a/crates/bsk-cli/src/cli/record_state.rs
+++ b/crates/bsk-cli/src/cli/record_state.rs
@@ -1,0 +1,120 @@
+//! Persist the session id between `bsk record start` and `bsk record stop`.
+
+use std::fs;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+use crate::daemon::paths;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RecordSessionState {
+    pub session_id: String,
+    pub started_at: String,
+}
+
+pub fn write(session_id: &str) -> Result<()> {
+    let path = paths::record_session_path()?;
+    paths::ensure_bsk_home()?;
+    if path.exists() {
+        return Err(anyhow::anyhow!(
+            "a recording is already in progress; run `bsk record stop` first"
+        ));
+    }
+    let state = RecordSessionState {
+        session_id: session_id.to_string(),
+        started_at: started_at_unix_ms(),
+    };
+    let json = serde_json::to_string_pretty(&state).context("serialize record session state")?;
+    fs::write(&path, format!("{json}\n"))
+        .with_context(|| format!("write {}", path.display()))?;
+    Ok(())
+}
+
+pub fn read() -> Result<RecordSessionState> {
+    let path = paths::record_session_path()?;
+    if !path.exists() {
+        return Err(anyhow::anyhow!(
+            "no recording in progress; run `bsk record start` first"
+        ));
+    }
+    let raw = fs::read_to_string(&path)
+        .with_context(|| format!("read {}", path.display()))?;
+    serde_json::from_str(&raw)
+        .with_context(|| format!("parse {}", path.display()))
+}
+
+pub fn clear() {
+    if let Ok(path) = paths::record_session_path() {
+        let _ = fs::remove_file(path);
+    }
+}
+
+fn started_at_unix_ms() -> String {
+    let ms = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis();
+    format!("{ms}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    fn env_guard() -> &'static Mutex<()> {
+        static GUARD: Mutex<()> = Mutex::new(());
+        &GUARD
+    }
+
+    fn with_temp_home<F: FnOnce()>(f: F) {
+        let _lock = env_guard().lock().unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        unsafe {
+            std::env::set_var(crate::daemon::paths::BSK_HOME_ENV, tmp.path());
+        }
+        f();
+        clear();
+        unsafe {
+            std::env::remove_var(crate::daemon::paths::BSK_HOME_ENV);
+        }
+    }
+
+    #[test]
+    fn write_read_round_trips() {
+        with_temp_home(|| {
+            write("abcd").unwrap();
+            let state = read().unwrap();
+            assert_eq!(state.session_id, "abcd");
+            assert!(!state.started_at.is_empty());
+        });
+    }
+
+    #[test]
+    fn write_rejects_duplicate() {
+        with_temp_home(|| {
+            write("abcd").unwrap();
+            let err = write("efgh").unwrap_err();
+            assert!(err.to_string().contains("already in progress"));
+        });
+    }
+
+    #[test]
+    fn read_errors_when_missing() {
+        with_temp_home(|| {
+            let err = read().unwrap_err();
+            assert!(err.to_string().contains("no recording in progress"));
+        });
+    }
+
+    #[test]
+    fn clear_removes_state_file() {
+        with_temp_home(|| {
+            write("abcd").unwrap();
+            clear();
+            assert!(read().is_err());
+        });
+    }
+}

--- a/crates/bsk-cli/src/cli/session.rs
+++ b/crates/bsk-cli/src/cli/session.rs
@@ -63,11 +63,11 @@ struct StartParams {
 }
 
 #[derive(Debug, Deserialize)]
-struct StartReply {
-    session_id: String,
-    browser_instance_id: String,
+pub struct StartReply {
+    pub session_id: String,
+    pub browser_instance_id: String,
     #[serde(default)]
-    agent_window_id: Option<i64>,
+    pub agent_window_id: Option<i64>,
 }
 
 #[derive(Debug, Serialize)]
@@ -78,21 +78,21 @@ struct StopParams {
 }
 
 #[derive(Debug, Deserialize)]
-struct StopReply {
-    stopped: Vec<String>,
+pub struct StopReply {
+    pub stopped: Vec<String>,
     #[serde(default)]
-    failed: Vec<StopFailure>,
+    pub failed: Vec<StopFailure>,
     #[serde(default)]
-    returned_tab_ids: Vec<i64>,
+    pub returned_tab_ids: Vec<i64>,
     #[serde(default)]
-    return_failures: Vec<ReturnFailure>,
+    pub return_failures: Vec<ReturnFailure>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
-struct StopFailure {
-    session_id: String,
-    code: ErrorCode,
-    message: String,
+pub struct StopFailure {
+    pub session_id: String,
+    pub code: ErrorCode,
+    pub message: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -113,14 +113,7 @@ pub fn dispatch(cmd: SessionCmd, format: Format) -> Result<(), CliError> {
 }
 
 fn run_start(sock: PathBuf, args: SessionStartArgs, format: Format) -> Result<(), CliError> {
-    let result: Result<StartReply, CliError> = call(
-        sock,
-        Method::SessionStart,
-        Some(StartParams {
-            browser_instance_id: args.browser,
-        }),
-        Duration::from_secs(30),
-    );
+    let result = start_session(sock, args.browser);
     match result {
         Ok(reply) => match format {
             Format::Json => {
@@ -141,6 +134,31 @@ fn run_start(sock: PathBuf, args: SessionStartArgs, format: Format) -> Result<()
         Err(err) => return Err(handle_start_error(err, format)),
     }
     Ok(())
+}
+
+/// Start a session and open the Agent Window. Used by `session start` and `record start`.
+pub fn start_session(sock: PathBuf, browser: Option<String>) -> Result<StartReply, CliError> {
+    call(
+        sock,
+        Method::SessionStart,
+        Some(StartParams {
+            browser_instance_id: browser,
+        }),
+        Duration::from_secs(30),
+    )
+}
+
+/// Stop a single session by id.
+pub fn stop_session(sock: PathBuf, session_id: &str) -> Result<StopReply, CliError> {
+    call(
+        sock,
+        Method::SessionStop,
+        Some(StopParams {
+            session_id: Some(session_id.to_string()),
+            all: false,
+        }),
+        SESSION_STOP_IPC_TIMEOUT,
+    )
 }
 
 /// Render a `session.start` failure (review I3).

--- a/crates/bsk-cli/src/daemon/ipc.rs
+++ b/crates/bsk-cli/src/daemon/ipc.rs
@@ -241,7 +241,10 @@ pub fn full_handler(status: DaemonStatus, state: Arc<DaemonState>) -> RpcHandler
                 | Method::ToolSelect
                 | Method::ToolEvaluate
                 | Method::ToolWaitForNavigation
-                | Method::ToolRequestHelp => {
+                | Method::ToolRequestHelp
+                | Method::ToolRecordStart
+                | Method::ToolRecordStop
+                | Method::ToolRecordAwait => {
                     handle_tool_dispatch(&state, rpc_id, method, params).await
                 }
                 Method::ToolWaitMs => handle_wait_ms(&state.abort_registry, rpc_id, params).await,
@@ -318,10 +321,19 @@ async fn handle_tool_dispatch(
         }
     };
     let entry = inflight_guard.entry();
-    let outcome = state
-        .tool_queues
-        .dispatch(&session_id, method, params, timeout, Some(entry))
-        .await;
+    // `record_stop` must reach the extension while `record_await` holds the
+    // serial busy lock — finishing the recording unblocks await.
+    let outcome = if method == Method::ToolRecordStop {
+        state
+            .tool_queues
+            .dispatch_unlocked(&session_id, method, params, timeout, Some(entry))
+            .await
+    } else {
+        state
+            .tool_queues
+            .dispatch(&session_id, method, params, timeout, Some(entry))
+            .await
+    };
     drop(inflight_guard);
     match outcome {
         Ok(v) => ResponseBody::Ok(v),

--- a/crates/bsk-cli/src/daemon/paths.rs
+++ b/crates/bsk-cli/src/daemon/paths.rs
@@ -95,6 +95,11 @@ pub fn sock_path() -> Result<PathBuf> {
     Ok(bsk_home()?.join("run").join("daemon.sock"))
 }
 
+/// Path to the in-progress recording session state (`record-session.json`).
+pub fn record_session_path() -> Result<PathBuf> {
+    Ok(bsk_home()?.join("record-session.json"))
+}
+
 /// Windows named-pipe name. Include the resolved `BSK_HOME` path in the
 /// token so test homes and custom installs do not share a predictable
 /// per-username pipe.
@@ -163,6 +168,10 @@ mod tests {
             assert_eq!(log_path().unwrap(), home.join("daemon.log"));
             assert_eq!(update_check_path().unwrap(), home.join("update-check.json"));
             assert_eq!(sock_path().unwrap(), home.join("run").join("daemon.sock"));
+            assert_eq!(
+                record_session_path().unwrap(),
+                home.join("record-session.json")
+            );
         });
     }
 }

--- a/crates/bsk-cli/src/daemon/queue.rs
+++ b/crates/bsk-cli/src/daemon/queue.rs
@@ -221,6 +221,13 @@ impl ToolQueueRegistry {
         guard.get(sid).is_some_and(|entry| entry.accepting)
     }
 
+    #[cfg(test)]
+    fn force_busy_for_tests(&self, sid: &SessionId, busy: bool) {
+        let guard = self.queues.lock().expect("tool queue registry poisoned");
+        let entry = guard.get(sid).expect("queue must exist");
+        entry.state.lock().expect("queue state poisoned").busy = busy;
+    }
+
     /// Spawn the worker task for a session id. Idempotent: spawning the
     /// same id twice replaces the previous queue (the previous worker
     /// closes when its sender drops).
@@ -311,6 +318,42 @@ impl ToolQueueRegistry {
             inflight,
         )
         .await
+    }
+
+    /// Forward a tool RPC to the extension without taking the
+    /// per-session busy lock. Used by `tool.record_stop` so a second
+    /// CLI can finish an in-flight `tool.record_await` (extension
+    /// dispatch already runs concurrent `void dispatch(msg)` handlers).
+    pub async fn dispatch_unlocked(
+        &self,
+        sid: &SessionId,
+        method: Method,
+        params: Value,
+        timeout: Duration,
+        inflight: Option<Arc<ToolInflightEntry>>,
+    ) -> Result<Value, DispatchError> {
+        {
+            let guard = self.queues.lock().expect("tool queue registry poisoned");
+            let Some(entry) = guard.get(sid) else {
+                return Err(DispatchError::SessionNotFound);
+            };
+            if !entry.accepting {
+                return Err(DispatchError::SessionStopping);
+            }
+        }
+        let (respond_tx, _respond_rx) = oneshot::channel();
+        let job = ToolJob {
+            method,
+            params,
+            timeout,
+            respond: respond_tx,
+            inflight,
+            session_id: sid.clone(),
+        };
+        match forward_one(sid, &self.browsers, &self.sessions, &job).await {
+            Ok(v) => Ok(v),
+            Err(err) => Err(DispatchError::Rpc(err)),
+        }
     }
 
     /// Stop accepting new jobs for `sid`, enqueue one final control RPC,
@@ -780,5 +823,52 @@ mod tool_job_session_id_tests {
             session_id: SessionId("sess-A".into()),
         };
         assert_eq!(job.session_id.0, "sess-A");
+    }
+}
+
+#[cfg(test)]
+mod dispatch_unlocked_tests {
+    use super::*;
+    use crate::daemon::browsers::BrowserRegistry;
+    use crate::daemon::sessions::{SessionId, SessionRegistry};
+    use bsk_protocol::Method;
+    use serde_json::json;
+    use std::sync::Arc;
+
+    #[tokio::test]
+    async fn unlocked_dispatch_skips_session_busy_gate() {
+        let browsers = Arc::new(BrowserRegistry::new());
+        let sessions = Arc::new(SessionRegistry::new());
+        let queues = ToolQueueRegistry::new(browsers, sessions);
+        let sid = SessionId("s-record".into());
+        queues.spawn(sid.clone());
+        queues.force_busy_for_tests(&sid, true);
+
+        let busy = queues
+            .dispatch(
+                &sid,
+                Method::ToolTabList,
+                json!({ "session_id": "s-record" }),
+                Duration::from_secs(1),
+                None,
+            )
+            .await;
+        assert!(matches!(busy, Err(DispatchError::SessionBusy)));
+
+        let unlocked = queues
+            .dispatch_unlocked(
+                &sid,
+                Method::ToolRecordStop,
+                json!({ "session_id": "s-record" }),
+                Duration::from_secs(1),
+                None,
+            )
+            .await;
+        assert!(
+            !matches!(unlocked, Err(DispatchError::SessionBusy)),
+            "record_stop must not be rejected as SessionBusy; got {unlocked:?}"
+        );
+        // No session row → forward_one returns NotFound as Rpc.
+        assert!(matches!(unlocked, Err(DispatchError::Rpc(_))));
     }
 }

--- a/crates/bsk-cli/src/main.rs
+++ b/crates/bsk-cli/src/main.rs
@@ -93,6 +93,7 @@ fn dispatch(cli: Cli, format: Format) -> Result<(), CliError> {
         Command::WaitForNavigation(args) => cli::waits::dispatch_wait_for_navigation(args, format),
         Command::WaitMs(args) => cli::waits::dispatch_wait_ms(args, format),
         Command::RequestHelp(args) => cli::human_loop::dispatch(args, format),
+        Command::Record(cmd) => cli::record::dispatch(cmd, format),
     }
 }
 

--- a/crates/bsk-protocol/schema/tool_record_await_params.json
+++ b/crates/bsk-protocol/schema/tool_record_await_params.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "RecordAwaitParams",
+  "type": "object",
+  "required": [
+    "session_id"
+  ],
+  "properties": {
+    "session_id": {
+      "type": "string"
+    },
+    "timeout_ms": {
+      "description": "Max wait for the user to finish recording in the browser (milliseconds).",
+      "type": [
+        "integer",
+        "null"
+      ],
+      "format": "uint32",
+      "minimum": 0.0
+    }
+  }
+}

--- a/crates/bsk-protocol/schema/tool_record_await_result.json
+++ b/crates/bsk-protocol/schema/tool_record_await_result.json
@@ -1,0 +1,396 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "RecordAwaitResult",
+  "type": "object",
+  "required": [
+    "trace"
+  ],
+  "properties": {
+    "trace": {
+      "$ref": "#/definitions/Trace"
+    }
+  },
+  "definitions": {
+    "KeyModifier": {
+      "description": "Keyboard modifier flags. Multiple flags may be combined; the extension folds them into CDP's bitfield (`alt=1, ctrl=2, meta=4, shift=8`).",
+      "type": "string",
+      "enum": [
+        "alt",
+        "ctrl",
+        "meta",
+        "shift"
+      ]
+    },
+    "NavDestination": {
+      "description": "Navigate destination.",
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "properties": {
+        "url": {
+          "type": "string"
+        },
+        "url_pattern": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "PageContext": {
+      "description": "Page context attached to a step.",
+      "type": "object",
+      "properties": {
+        "role": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PageRole"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "title": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "url": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "url_pattern": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "PageRole": {
+      "description": "Coarse page role for LLM textbook steps.",
+      "type": "string",
+      "enum": [
+        "home",
+        "list",
+        "editor",
+        "dialog",
+        "other"
+      ]
+    },
+    "StepEffect": {
+      "description": "Side effect of a step (typically navigation).",
+      "type": "object",
+      "properties": {
+        "navigated_to": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "url_pattern_after": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "TargetDescriptor": {
+      "description": "Stable semantic handle for an interacted element.",
+      "type": "object",
+      "required": [
+        "tag"
+      ],
+      "properties": {
+        "name": {
+          "description": "Visible accessible name (label, button text, `aria-label`, …).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "name_attr": {
+          "description": "`name` attribute when present (form fields).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "nearby_label": {
+          "description": "Nearby visible label text when inferred.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "placeholder": {
+          "description": "Placeholder text when present.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "role": {
+          "description": "Accessibility / ARIA role when known (`button`, `textbox`, `link`, …).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "tag": {
+          "description": "HTML tag name, lowercased (`input`, `button`, `a`, …).",
+          "type": "string"
+        }
+      }
+    },
+    "Trace": {
+      "description": "Persisted semantic action trace exported by `tool.record_stop` / `await`.",
+      "type": "object",
+      "required": [
+        "recorded_at",
+        "steps",
+        "version"
+      ],
+      "properties": {
+        "entry": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/TraceEntry"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "purpose": {
+          "description": "Optional user-provided goal for post-hoc LLM context.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "recorded_at": {
+          "description": "RFC 3339 timestamp when recording stopped.",
+          "type": "string"
+        },
+        "steps": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/TraceStep"
+          }
+        },
+        "tab_id": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "int64"
+        },
+        "version": {
+          "description": "Schema version — LLM textbook traces are `3`.",
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        }
+      }
+    },
+    "TraceEntry": {
+      "description": "Entry-point context for the recorded flow.",
+      "type": "object",
+      "properties": {
+        "site": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "start_url": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "start_url_pattern": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "TraceImportance": {
+      "description": "Whether the step should stay in the exported textbook.",
+      "type": "string",
+      "enum": [
+        "essential",
+        "optional"
+      ]
+    },
+    "TraceIntent": {
+      "description": "High-level intent of a textbook step.",
+      "type": "string",
+      "enum": [
+        "open_entry",
+        "navigate",
+        "search",
+        "open_item",
+        "provide_input",
+        "toggle",
+        "confirm",
+        "submit_key",
+        "other"
+      ]
+    },
+    "TraceOp": {
+      "description": "Action kind.",
+      "type": "string",
+      "enum": [
+        "click",
+        "fill",
+        "press",
+        "select",
+        "navigate"
+      ]
+    },
+    "TraceStep": {
+      "description": "One recorded user action (trace v3 flat textbook step).",
+      "type": "object",
+      "required": [
+        "id",
+        "op"
+      ],
+      "properties": {
+        "destination": {
+          "description": "navigate",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/NavDestination"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "effect": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StepEffect"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "id": {
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        },
+        "importance": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/TraceImportance"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "intent": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/TraceIntent"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "key": {
+          "description": "press",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "labels": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "modifiers": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/KeyModifier"
+          }
+        },
+        "op": {
+          "$ref": "#/definitions/TraceOp"
+        },
+        "page": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PageContext"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "redacted": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "summary": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "target": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/TargetDescriptor"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "value": {
+          "description": "fill",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "values": {
+          "description": "select",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/bsk-protocol/schema/tool_record_start_params.json
+++ b/crates/bsk-protocol/schema/tool_record_start_params.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "RecordStartParams",
+  "type": "object",
+  "required": [
+    "session_id"
+  ],
+  "properties": {
+    "purpose": {
+      "description": "Optional goal text stored on the exported trace for LLM context.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "session_id": {
+      "type": "string"
+    },
+    "tab_id": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "format": "int64"
+    },
+    "url": {
+      "description": "Optional URL to navigate before recording begins.",
+      "type": [
+        "string",
+        "null"
+      ]
+    }
+  }
+}

--- a/crates/bsk-protocol/schema/tool_record_start_result.json
+++ b/crates/bsk-protocol/schema/tool_record_start_result.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "RecordStartResult",
+  "type": "object",
+  "required": [
+    "recording",
+    "tab_id"
+  ],
+  "properties": {
+    "recording": {
+      "type": "boolean"
+    },
+    "tab_id": {
+      "type": "integer",
+      "format": "int64"
+    }
+  }
+}

--- a/crates/bsk-protocol/schema/tool_record_stop_params.json
+++ b/crates/bsk-protocol/schema/tool_record_stop_params.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "RecordStopParams",
+  "type": "object",
+  "required": [
+    "session_id"
+  ],
+  "properties": {
+    "session_id": {
+      "type": "string"
+    }
+  }
+}

--- a/crates/bsk-protocol/schema/tool_record_stop_result.json
+++ b/crates/bsk-protocol/schema/tool_record_stop_result.json
@@ -1,0 +1,396 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "RecordStopResult",
+  "type": "object",
+  "required": [
+    "trace"
+  ],
+  "properties": {
+    "trace": {
+      "$ref": "#/definitions/Trace"
+    }
+  },
+  "definitions": {
+    "KeyModifier": {
+      "description": "Keyboard modifier flags. Multiple flags may be combined; the extension folds them into CDP's bitfield (`alt=1, ctrl=2, meta=4, shift=8`).",
+      "type": "string",
+      "enum": [
+        "alt",
+        "ctrl",
+        "meta",
+        "shift"
+      ]
+    },
+    "NavDestination": {
+      "description": "Navigate destination.",
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "properties": {
+        "url": {
+          "type": "string"
+        },
+        "url_pattern": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "PageContext": {
+      "description": "Page context attached to a step.",
+      "type": "object",
+      "properties": {
+        "role": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PageRole"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "title": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "url": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "url_pattern": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "PageRole": {
+      "description": "Coarse page role for LLM textbook steps.",
+      "type": "string",
+      "enum": [
+        "home",
+        "list",
+        "editor",
+        "dialog",
+        "other"
+      ]
+    },
+    "StepEffect": {
+      "description": "Side effect of a step (typically navigation).",
+      "type": "object",
+      "properties": {
+        "navigated_to": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "url_pattern_after": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "TargetDescriptor": {
+      "description": "Stable semantic handle for an interacted element.",
+      "type": "object",
+      "required": [
+        "tag"
+      ],
+      "properties": {
+        "name": {
+          "description": "Visible accessible name (label, button text, `aria-label`, …).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "name_attr": {
+          "description": "`name` attribute when present (form fields).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "nearby_label": {
+          "description": "Nearby visible label text when inferred.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "placeholder": {
+          "description": "Placeholder text when present.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "role": {
+          "description": "Accessibility / ARIA role when known (`button`, `textbox`, `link`, …).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "tag": {
+          "description": "HTML tag name, lowercased (`input`, `button`, `a`, …).",
+          "type": "string"
+        }
+      }
+    },
+    "Trace": {
+      "description": "Persisted semantic action trace exported by `tool.record_stop` / `await`.",
+      "type": "object",
+      "required": [
+        "recorded_at",
+        "steps",
+        "version"
+      ],
+      "properties": {
+        "entry": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/TraceEntry"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "purpose": {
+          "description": "Optional user-provided goal for post-hoc LLM context.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "recorded_at": {
+          "description": "RFC 3339 timestamp when recording stopped.",
+          "type": "string"
+        },
+        "steps": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/TraceStep"
+          }
+        },
+        "tab_id": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "int64"
+        },
+        "version": {
+          "description": "Schema version — LLM textbook traces are `3`.",
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        }
+      }
+    },
+    "TraceEntry": {
+      "description": "Entry-point context for the recorded flow.",
+      "type": "object",
+      "properties": {
+        "site": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "start_url": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "start_url_pattern": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "TraceImportance": {
+      "description": "Whether the step should stay in the exported textbook.",
+      "type": "string",
+      "enum": [
+        "essential",
+        "optional"
+      ]
+    },
+    "TraceIntent": {
+      "description": "High-level intent of a textbook step.",
+      "type": "string",
+      "enum": [
+        "open_entry",
+        "navigate",
+        "search",
+        "open_item",
+        "provide_input",
+        "toggle",
+        "confirm",
+        "submit_key",
+        "other"
+      ]
+    },
+    "TraceOp": {
+      "description": "Action kind.",
+      "type": "string",
+      "enum": [
+        "click",
+        "fill",
+        "press",
+        "select",
+        "navigate"
+      ]
+    },
+    "TraceStep": {
+      "description": "One recorded user action (trace v3 flat textbook step).",
+      "type": "object",
+      "required": [
+        "id",
+        "op"
+      ],
+      "properties": {
+        "destination": {
+          "description": "navigate",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/NavDestination"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "effect": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StepEffect"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "id": {
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        },
+        "importance": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/TraceImportance"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "intent": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/TraceIntent"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "key": {
+          "description": "press",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "labels": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "modifiers": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/KeyModifier"
+          }
+        },
+        "op": {
+          "$ref": "#/definitions/TraceOp"
+        },
+        "page": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PageContext"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "redacted": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "summary": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "target": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/TargetDescriptor"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "value": {
+          "description": "fill",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "values": {
+          "description": "select",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/bsk-protocol/schema/trace.json
+++ b/crates/bsk-protocol/schema/trace.json
@@ -1,0 +1,385 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Trace",
+  "description": "Persisted semantic action trace exported by `tool.record_stop` / `await`.",
+  "type": "object",
+  "required": [
+    "recorded_at",
+    "steps",
+    "version"
+  ],
+  "properties": {
+    "entry": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/TraceEntry"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "purpose": {
+      "description": "Optional user-provided goal for post-hoc LLM context.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "recorded_at": {
+      "description": "RFC 3339 timestamp when recording stopped.",
+      "type": "string"
+    },
+    "steps": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/TraceStep"
+      }
+    },
+    "tab_id": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "format": "int64"
+    },
+    "version": {
+      "description": "Schema version — LLM textbook traces are `3`.",
+      "type": "integer",
+      "format": "uint32",
+      "minimum": 0.0
+    }
+  },
+  "definitions": {
+    "KeyModifier": {
+      "description": "Keyboard modifier flags. Multiple flags may be combined; the extension folds them into CDP's bitfield (`alt=1, ctrl=2, meta=4, shift=8`).",
+      "type": "string",
+      "enum": [
+        "alt",
+        "ctrl",
+        "meta",
+        "shift"
+      ]
+    },
+    "NavDestination": {
+      "description": "Navigate destination.",
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "properties": {
+        "url": {
+          "type": "string"
+        },
+        "url_pattern": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "PageContext": {
+      "description": "Page context attached to a step.",
+      "type": "object",
+      "properties": {
+        "role": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PageRole"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "title": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "url": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "url_pattern": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "PageRole": {
+      "description": "Coarse page role for LLM textbook steps.",
+      "type": "string",
+      "enum": [
+        "home",
+        "list",
+        "editor",
+        "dialog",
+        "other"
+      ]
+    },
+    "StepEffect": {
+      "description": "Side effect of a step (typically navigation).",
+      "type": "object",
+      "properties": {
+        "navigated_to": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "url_pattern_after": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "TargetDescriptor": {
+      "description": "Stable semantic handle for an interacted element.",
+      "type": "object",
+      "required": [
+        "tag"
+      ],
+      "properties": {
+        "name": {
+          "description": "Visible accessible name (label, button text, `aria-label`, …).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "name_attr": {
+          "description": "`name` attribute when present (form fields).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "nearby_label": {
+          "description": "Nearby visible label text when inferred.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "placeholder": {
+          "description": "Placeholder text when present.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "role": {
+          "description": "Accessibility / ARIA role when known (`button`, `textbox`, `link`, …).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "tag": {
+          "description": "HTML tag name, lowercased (`input`, `button`, `a`, …).",
+          "type": "string"
+        }
+      }
+    },
+    "TraceEntry": {
+      "description": "Entry-point context for the recorded flow.",
+      "type": "object",
+      "properties": {
+        "site": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "start_url": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "start_url_pattern": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "TraceImportance": {
+      "description": "Whether the step should stay in the exported textbook.",
+      "type": "string",
+      "enum": [
+        "essential",
+        "optional"
+      ]
+    },
+    "TraceIntent": {
+      "description": "High-level intent of a textbook step.",
+      "type": "string",
+      "enum": [
+        "open_entry",
+        "navigate",
+        "search",
+        "open_item",
+        "provide_input",
+        "toggle",
+        "confirm",
+        "submit_key",
+        "other"
+      ]
+    },
+    "TraceOp": {
+      "description": "Action kind.",
+      "type": "string",
+      "enum": [
+        "click",
+        "fill",
+        "press",
+        "select",
+        "navigate"
+      ]
+    },
+    "TraceStep": {
+      "description": "One recorded user action (trace v3 flat textbook step).",
+      "type": "object",
+      "required": [
+        "id",
+        "op"
+      ],
+      "properties": {
+        "destination": {
+          "description": "navigate",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/NavDestination"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "effect": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StepEffect"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "id": {
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        },
+        "importance": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/TraceImportance"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "intent": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/TraceIntent"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "key": {
+          "description": "press",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "labels": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "modifiers": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/KeyModifier"
+          }
+        },
+        "op": {
+          "$ref": "#/definitions/TraceOp"
+        },
+        "page": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PageContext"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "redacted": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "summary": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "target": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/TargetDescriptor"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "value": {
+          "description": "fill",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "values": {
+          "description": "select",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/bsk-protocol/schema/trace_step.json
+++ b/crates/bsk-protocol/schema/trace_step.json
@@ -1,0 +1,310 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "TraceStep",
+  "description": "One recorded user action (trace v3 flat textbook step).",
+  "type": "object",
+  "required": [
+    "id",
+    "op"
+  ],
+  "properties": {
+    "destination": {
+      "description": "navigate",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/NavDestination"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "effect": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/StepEffect"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "id": {
+      "type": "integer",
+      "format": "uint32",
+      "minimum": 0.0
+    },
+    "importance": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/TraceImportance"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "intent": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/TraceIntent"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "key": {
+      "description": "press",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "labels": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "type": "string"
+      }
+    },
+    "modifiers": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "$ref": "#/definitions/KeyModifier"
+      }
+    },
+    "op": {
+      "$ref": "#/definitions/TraceOp"
+    },
+    "page": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/PageContext"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "redacted": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "summary": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "target": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/TargetDescriptor"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "value": {
+      "description": "fill",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "values": {
+      "description": "select",
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "definitions": {
+    "KeyModifier": {
+      "description": "Keyboard modifier flags. Multiple flags may be combined; the extension folds them into CDP's bitfield (`alt=1, ctrl=2, meta=4, shift=8`).",
+      "type": "string",
+      "enum": [
+        "alt",
+        "ctrl",
+        "meta",
+        "shift"
+      ]
+    },
+    "NavDestination": {
+      "description": "Navigate destination.",
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "properties": {
+        "url": {
+          "type": "string"
+        },
+        "url_pattern": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "PageContext": {
+      "description": "Page context attached to a step.",
+      "type": "object",
+      "properties": {
+        "role": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PageRole"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "title": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "url": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "url_pattern": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "PageRole": {
+      "description": "Coarse page role for LLM textbook steps.",
+      "type": "string",
+      "enum": [
+        "home",
+        "list",
+        "editor",
+        "dialog",
+        "other"
+      ]
+    },
+    "StepEffect": {
+      "description": "Side effect of a step (typically navigation).",
+      "type": "object",
+      "properties": {
+        "navigated_to": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "url_pattern_after": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "TargetDescriptor": {
+      "description": "Stable semantic handle for an interacted element.",
+      "type": "object",
+      "required": [
+        "tag"
+      ],
+      "properties": {
+        "name": {
+          "description": "Visible accessible name (label, button text, `aria-label`, …).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "name_attr": {
+          "description": "`name` attribute when present (form fields).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "nearby_label": {
+          "description": "Nearby visible label text when inferred.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "placeholder": {
+          "description": "Placeholder text when present.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "role": {
+          "description": "Accessibility / ARIA role when known (`button`, `textbox`, `link`, …).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "tag": {
+          "description": "HTML tag name, lowercased (`input`, `button`, `a`, …).",
+          "type": "string"
+        }
+      }
+    },
+    "TraceImportance": {
+      "description": "Whether the step should stay in the exported textbook.",
+      "type": "string",
+      "enum": [
+        "essential",
+        "optional"
+      ]
+    },
+    "TraceIntent": {
+      "description": "High-level intent of a textbook step.",
+      "type": "string",
+      "enum": [
+        "open_entry",
+        "navigate",
+        "search",
+        "open_item",
+        "provide_input",
+        "toggle",
+        "confirm",
+        "submit_key",
+        "other"
+      ]
+    },
+    "TraceOp": {
+      "description": "Action kind.",
+      "type": "string",
+      "enum": [
+        "click",
+        "fill",
+        "press",
+        "select",
+        "navigate"
+      ]
+    }
+  }
+}

--- a/crates/bsk-protocol/src/bin/dump-schema.rs
+++ b/crates/bsk-protocol/src/bin/dump-schema.rs
@@ -97,4 +97,13 @@ fn main() {
     dump!(WaitMsResult, "tool_wait_ms_result");
     dump!(RequestHelpParams, "tool_request_help_params");
     dump!(RequestHelpResult, "tool_request_help_result");
+
+    dump!(Trace, "trace");
+    dump!(TraceStep, "trace_step");
+    dump!(RecordStartParams, "tool_record_start_params");
+    dump!(RecordStartResult, "tool_record_start_result");
+    dump!(RecordStopParams, "tool_record_stop_params");
+    dump!(RecordStopResult, "tool_record_stop_result");
+    dump!(RecordAwaitParams, "tool_record_await_params");
+    dump!(RecordAwaitResult, "tool_record_await_result");
 }

--- a/crates/bsk-protocol/src/method.rs
+++ b/crates/bsk-protocol/src/method.rs
@@ -72,6 +72,12 @@ pub enum Method {
     ToolWaitMs,
     #[serde(rename = "tool.request_help")]
     ToolRequestHelp,
+    #[serde(rename = "tool.record_start")]
+    ToolRecordStart,
+    #[serde(rename = "tool.record_stop")]
+    ToolRecordStop,
+    #[serde(rename = "tool.record_await")]
+    ToolRecordAwait,
 
     #[serde(rename = "cancel")]
     Cancel,
@@ -119,9 +125,16 @@ impl Method {
             | Method::ToolFill
             | Method::ToolPress
             | Method::ToolSelect
-            | Method::ToolEvaluate => true,
+            | Method::ToolEvaluate
+            // May navigate via optional `url` and changes Agent Window
+            // chrome; gate behind pending-interrupt like other writes.
+            | Method::ToolRecordStart => true,
 
             // Read-only tool calls — transparent.
+            //
+            // `record_stop` / `record_await` observe / finish a recording
+            // without driving new automation gestures, so they stay
+            // ungated (teardown after interrupt must still work).
             Method::ToolTabList
             | Method::ToolSnapshot
             | Method::ToolGetHtml
@@ -129,7 +142,9 @@ impl Method {
             | Method::ToolConsole
             | Method::ToolWaitForNavigation
             | Method::ToolWaitMs
-            | Method::ToolRequestHelp => false,
+            | Method::ToolRequestHelp
+            | Method::ToolRecordStop
+            | Method::ToolRecordAwait => false,
 
             // Session lifecycle — not gated.
             Method::SessionStart
@@ -207,6 +222,13 @@ mod tests {
         assert!(Method::ToolPress.is_mutating());
         assert!(Method::ToolSelect.is_mutating());
         assert!(Method::ToolEvaluate.is_mutating());
+        assert!(Method::ToolRecordStart.is_mutating());
+    }
+
+    #[test]
+    fn is_mutating_classifies_record_stop_await_as_non_mutating() {
+        assert!(!Method::ToolRecordStop.is_mutating());
+        assert!(!Method::ToolRecordAwait.is_mutating());
     }
 
     #[test]

--- a/crates/bsk-protocol/src/tools/mod.rs
+++ b/crates/bsk-protocol/src/tools/mod.rs
@@ -1,4 +1,4 @@
-//! Typed params/results for the 21 `tool.*` RPC methods (§7).
+//! Typed params/results for the `tool.*` RPC methods (§7).
 
 pub mod console;
 pub mod dialog;
@@ -6,6 +6,7 @@ pub mod human_loop;
 pub mod interaction;
 pub mod navigation;
 pub mod observation;
+pub mod record;
 pub mod script;
 pub mod session;
 pub mod tabs;
@@ -17,6 +18,7 @@ pub use human_loop::*;
 pub use interaction::*;
 pub use navigation::*;
 pub use observation::*;
+pub use record::*;
 pub use script::*;
 pub use session::*;
 pub use tabs::*;

--- a/crates/bsk-protocol/src/tools/record.rs
+++ b/crates/bsk-protocol/src/tools/record.rs
@@ -1,0 +1,380 @@
+//! Semantic user-action recording (`tool.record_start` / `stop` / `await`).
+//!
+//! Traces describe what the user did in human/LLM-readable terms (role, visible
+//! name, tag) — not CSS selectors or `@eN` refs. There is no mechanical replay
+//! in this phase. Variable inputs are left for a downstream LLM to infer from
+//! control names + example values (no `parameters[]` slot extraction here).
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use super::interaction::KeyModifier;
+
+/// Stable semantic handle for an interacted element.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct TargetDescriptor {
+    /// Accessibility / ARIA role when known (`button`, `textbox`, `link`, …).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub role: Option<String>,
+    /// Visible accessible name (label, button text, `aria-label`, …).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    /// HTML tag name, lowercased (`input`, `button`, `a`, …).
+    pub tag: String,
+    /// `name` attribute when present (form fields).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name_attr: Option<String>,
+    /// Placeholder text when present.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub placeholder: Option<String>,
+    /// Nearby visible label text when inferred.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub nearby_label: Option<String>,
+}
+
+/// Entry-point context for the recorded flow.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct TraceEntry {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub start_url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub start_url_pattern: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub site: Option<String>,
+}
+
+/// Coarse page role for LLM textbook steps.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum PageRole {
+    Home,
+    List,
+    Editor,
+    Dialog,
+    Other,
+}
+
+/// Page context attached to a step.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct PageContext {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub url_pattern: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub role: Option<PageRole>,
+}
+
+/// Side effect of a step (typically navigation).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct StepEffect {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub navigated_to: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub url_pattern_after: Option<String>,
+}
+
+/// Navigate destination.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct NavDestination {
+    pub url: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub url_pattern: Option<String>,
+}
+
+/// High-level intent of a textbook step.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum TraceIntent {
+    OpenEntry,
+    Navigate,
+    Search,
+    OpenItem,
+    ProvideInput,
+    Toggle,
+    Confirm,
+    SubmitKey,
+    Other,
+}
+
+/// Whether the step should stay in the exported textbook.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum TraceImportance {
+    Essential,
+    Optional,
+}
+
+/// Action kind.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum TraceOp {
+    Click,
+    Fill,
+    Press,
+    Select,
+    Navigate,
+}
+
+/// One recorded user action (trace v3 flat textbook step).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct TraceStep {
+    pub id: u32,
+    pub op: TraceOp,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub intent: Option<TraceIntent>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub importance: Option<TraceImportance>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub page: Option<PageContext>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub summary: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub target: Option<TargetDescriptor>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub effect: Option<StepEffect>,
+    /// fill
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub value: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub redacted: Option<bool>,
+    /// press
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub key: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub modifiers: Option<Vec<KeyModifier>>,
+    /// select
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub values: Option<Vec<String>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub labels: Option<Vec<String>>,
+    /// navigate
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub destination: Option<NavDestination>,
+}
+
+/// Persisted semantic action trace exported by `tool.record_stop` / `await`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct Trace {
+    /// Schema version — LLM textbook traces are `3`.
+    pub version: u32,
+    /// Optional user-provided goal for post-hoc LLM context.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub purpose: Option<String>,
+    /// RFC 3339 timestamp when recording stopped.
+    pub recorded_at: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub entry: Option<TraceEntry>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tab_id: Option<i64>,
+    pub steps: Vec<TraceStep>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct RecordStartParams {
+    pub session_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tab_id: Option<i64>,
+    /// Optional URL to navigate before recording begins.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    /// Optional goal text stored on the exported trace for LLM context.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub purpose: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct RecordStartResult {
+    pub tab_id: i64,
+    pub recording: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct RecordStopParams {
+    pub session_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct RecordStopResult {
+    pub trace: Trace,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct RecordAwaitParams {
+    pub session_id: String,
+    /// Max wait for the user to finish recording in the browser (milliseconds).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timeout_ms: Option<u32>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct RecordAwaitResult {
+    pub trace: Trace,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn sample_target() -> TargetDescriptor {
+        TargetDescriptor {
+            role: Some("button".into()),
+            name: Some("发布".into()),
+            tag: "button".into(),
+            name_attr: None,
+            placeholder: None,
+            nearby_label: None,
+        }
+    }
+
+    #[test]
+    fn trace_step_click_round_trips() {
+        let step = TraceStep {
+            id: 1,
+            op: TraceOp::Click,
+            intent: Some(TraceIntent::Confirm),
+            importance: Some(TraceImportance::Essential),
+            page: None,
+            summary: Some("点击「发布」按钮".into()),
+            target: Some(sample_target()),
+            effect: Some(StepEffect {
+                navigated_to: Some("https://example.com/p/1".into()),
+                url_pattern_after: Some("https://example.com/p/*".into()),
+            }),
+            value: None,
+            redacted: None,
+            key: None,
+            modifiers: None,
+            values: None,
+            labels: None,
+            destination: None,
+        };
+        let v = serde_json::to_value(&step).unwrap();
+        assert_eq!(v.get("op").and_then(|v| v.as_str()), Some("click"));
+        assert!(v.get("selector").is_none());
+        let round: TraceStep = serde_json::from_value(v).unwrap();
+        assert_eq!(round, step);
+    }
+
+    #[test]
+    fn trace_step_fill_round_trips() {
+        let step = TraceStep {
+            id: 2,
+            op: TraceOp::Fill,
+            intent: Some(TraceIntent::ProvideInput),
+            importance: Some(TraceImportance::Essential),
+            page: None,
+            summary: Some("在「服务名称」输入框填入 my-svc".into()),
+            target: Some(TargetDescriptor {
+                role: Some("textbox".into()),
+                name: Some("服务名称".into()),
+                tag: "input".into(),
+                name_attr: Some("serviceName".into()),
+                placeholder: None,
+                nearby_label: None,
+            }),
+            effect: None,
+            value: Some("my-svc".into()),
+            redacted: None,
+            key: None,
+            modifiers: None,
+            values: None,
+            labels: None,
+            destination: None,
+        };
+        let v = serde_json::to_value(&step).unwrap();
+        assert_eq!(v.get("op").and_then(|v| v.as_str()), Some("fill"));
+        let round: TraceStep = serde_json::from_value(v).unwrap();
+        assert_eq!(round, step);
+    }
+
+    #[test]
+    fn purpose_omitted_when_none() {
+        let trace = Trace {
+            version: 3,
+            purpose: None,
+            recorded_at: "2026-07-13T03:00:00Z".into(),
+            entry: Some(TraceEntry {
+                start_url: Some("https://example.com".into()),
+                start_url_pattern: Some("https://example.com/".into()),
+                site: Some("example.com".into()),
+            }),
+            tab_id: Some(1),
+            steps: vec![],
+        };
+        let v = serde_json::to_value(&trace).unwrap();
+        assert!(v.get("purpose").is_none());
+        assert!(v.get("parameters").is_none());
+        assert_eq!(v.get("version").and_then(|v| v.as_u64()), Some(3));
+    }
+
+    #[test]
+    fn purpose_serialized_when_set() {
+        let trace = Trace {
+            version: 3,
+            purpose: Some("这是一个在 p6n 发布服务的操作流程。".into()),
+            recorded_at: "2026-07-13T03:00:00Z".into(),
+            entry: None,
+            tab_id: None,
+            steps: vec![TraceStep {
+                id: 1,
+                op: TraceOp::Navigate,
+                intent: Some(TraceIntent::OpenEntry),
+                importance: Some(TraceImportance::Essential),
+                page: None,
+                summary: Some("打开起始页".into()),
+                target: None,
+                effect: None,
+                value: None,
+                redacted: None,
+                key: None,
+                modifiers: None,
+                values: None,
+                labels: None,
+                destination: Some(NavDestination {
+                    url: "https://example.com".into(),
+                    url_pattern: Some("https://example.com/".into()),
+                }),
+            }],
+        };
+        let v = serde_json::to_value(&trace).unwrap();
+        assert_eq!(
+            v.get("purpose").and_then(|v| v.as_str()),
+            Some("这是一个在 p6n 发布服务的操作流程。")
+        );
+        let round: Trace = serde_json::from_value(v).unwrap();
+        assert_eq!(round, trace);
+    }
+
+    #[test]
+    fn press_with_target_and_modifiers_round_trips() {
+        let step = TraceStep {
+            id: 3,
+            op: TraceOp::Press,
+            intent: Some(TraceIntent::SubmitKey),
+            importance: Some(TraceImportance::Essential),
+            page: None,
+            summary: Some("按下 Enter".into()),
+            target: Some(sample_target()),
+            effect: Some(StepEffect {
+                navigated_to: Some("https://example.com/next".into()),
+                url_pattern_after: None,
+            }),
+            value: None,
+            redacted: None,
+            key: Some("Enter".into()),
+            modifiers: Some(vec![KeyModifier::Ctrl, KeyModifier::Shift]),
+            values: None,
+            labels: None,
+            destination: None,
+        };
+        let value = serde_json::to_value(&step).unwrap();
+        assert_eq!(value["key"], "Enter");
+        assert_eq!(value["modifiers"], json!(["ctrl", "shift"]));
+        let round: TraceStep = serde_json::from_value(value).unwrap();
+        assert_eq!(round, step);
+    }
+}

--- a/docs/semantic-record-change-review.md
+++ b/docs/semantic-record-change-review.md
@@ -1,0 +1,282 @@
+# 改动评审：语义化录制（Semantic Record / Trace v2）
+
+| 项 | 内容 |
+|----|------|
+| **对比基线** | **远程仓库 `origin/main`（`bc05ef5` Initial public release）** |
+| 工作分支 | `new_record`（当前 tip 与 `origin/main` 同 commit；改动均在工作区，尚未提交） |
+| **本需求范围** | **只新增录制能力**：人工操作 → 写出语义 `trace.json`。交付物到文件落盘即结束 |
+| **不在本需求** | 任何新的执行 / 回放能力（无 `bsk replay`、无 trace 执行引擎、无自动 semantic→`@eN`） |
+| **事后怎么跑** | **完全复用 `origin/main` 已有能力**：`session` + `snapshot`/`@eN` + `click`/`fill`/`press`…（由 LLM/Agent 读教材后自行调用，本 PR 不新增执行路径） |
+| 产品说明 | [docs/semantic-record.md](./semantic-record.md) |
+
+> **评审口径：** 以下所有「新增 / 修改」均相对 **`origin/main` 原始版本**。  
+> 远程 `main` 无 record；本需求 **仅** 从零加入录制端。执行侧零新增，靠既有工具闭环。
+
+---
+
+## 1. 相对 `origin/main`：远程原先没有什么 / 本需求加什么
+
+在 `origin/main`（公开初始版本）中：
+
+- **无** `tool.record_*`、**无** `bsk record`、**无** 录制 overlay
+- **已有**（本需求执行侧直接复用、不改语义）：`session`、`navigate`、`snapshot`、`click`/`fill`/`press`/`select`、`request-help` 等
+
+本需求 **只新增录制端**：
+
+```text
+人工在 Agent Window 操作
+        ↓
+语义捕获 → Trace v2
+        ↓
+写出 ./trace.json          ← 本需求交付边界
+```
+
+**不在本需求内：** 读 trace 并驱动浏览器的新代码 / 新 CLI / 新协议方法。  
+事后若要用教材完成同类任务，Agent 按既有 skill 流程调用现有 `bsk` 命令即可。
+
+### 产品决策
+
+1. **默认输出** `./trace.json`（`--output` 可覆盖）
+2. **`purpose` 可选元数据**：写入 JSON 供 LLM 理解目标；**不**参与录制期过滤
+3. **UI**：底部「正在录制用户操作」+「结束」；点结束后写文件并关窗
+4. **Trace 主键**：语义 `target` + `summary`；禁止「点击div」类无意义步骤
+
+与既有能力的关系：
+
+```text
+本需求：  bsk record → trace.json（教材）
+既有能力： LLM 读教材 → bsk session/snapshot/click/fill…（零新增执行代码）
+```
+
+---
+
+## 2. 改动总览（vs `origin/main`）
+
+| 层 | 相对远程 main 的变化 |
+|----|----------------------|
+| Protocol | **新增** Trace v2、`tool.record_start\|stop\|await`、schema；**无** replay / execute 类方法 |
+| Extension | **新增**语义捕获、录制 overlay、record 编排；**不**新增按 trace 执行的工具 |
+| CLI | **新增** `bsk record start\|stop`；**无** `bsk replay` |
+| Docs / i18n | 录制说明与 UI 文案 |
+
+**验收标准（本需求）：** `bsk record …` → 得到合格的 `trace.json`。不要求、不交付任何自动执行路径。
+
+---
+
+## 3. 协议（`bsk-protocol`）— vs `origin/main`
+
+### 新增
+
+- [`crates/bsk-protocol/src/tools/record.rs`](../crates/bsk-protocol/src/tools/record.rs)
+  - `TargetDescriptor`：`role?` / `name?` / `tag` / `name_attr?`
+  - `Trace`：`version: 3`，可选 `purpose`，`recorded_at`，`entry?`，`tab_id?`，`steps`（无 `parameters[]`）
+  - `TraceStep`：`click` / `fill` / `press` / `select` / `navigate`（`intent`/`page`/`effect` + 语义字段；动作引起的跳转进 `effect`）
+  - `RecordStartParams`（含可选 `purpose`）/ `Stop` / `Await`
+- Schema：`schema/trace.json`、`trace_step.json`、`tool_record_*_{params,result}.json`
+
+### 修改（在 main 已有文件上扩展）
+
+- [`method.rs`](../crates/bsk-protocol/src/method.rs)：新增 `ToolRecordStart|Stop|Await`；`ToolRecordStart` 的 `is_mutating() == true`（可带 `url` 导航，需受 pending-interrupt 闸）；`Stop`/`Await` 为 false（便于收尾）
+- [`tools/mod.rs`](../crates/bsk-protocol/src/tools/mod.rs)、[`dump-schema.rs`](../crates/bsk-protocol/src/bin/dump-schema.rs)：导出注册
+
+### Trace 形态（main 上不存在，本需求引入）
+
+```json
+{
+  "version": 3,
+  "purpose": "这是一个在 iwiki 撰写文档的操作流程。",
+  "recorded_at": "...",
+  "entry": { "start_url": "https://iwiki.woa.com/dashboard", "site": "iwiki.woa.com" },
+  "steps": [
+    {
+      "id": 1,
+      "op": "click",
+      "intent": "confirm",
+      "target": { "role": "button", "name": "发布", "tag": "button" },
+      "summary": "点击「发布」按钮",
+      "effect": { "navigated_to": "https://iwiki.woa.com/p/...", "url_pattern_after": "https://iwiki.woa.com/p/*" }
+    }
+  ]
+}
+```
+
+**质量门禁（捕获层）：**
+
+| 应收 | 应拒 |
+|------|------|
+| 有可读名称的交互控件（按钮/链接/自定义 btn 等） | `{ "tag": "div" }` / 「点击div」 |
+| FillSession 最终值 + summary | 逐键；联想建议 click |
+| 密码 `***` + `redacted` | `@eN`、深路径 CSS、standalone `wait_for_navigation` |
+
+---
+
+## 4. 扩展（`apps/extension`）— vs `origin/main`
+
+### 新增核心文件（main 上无对应实现）
+
+| 文件 | 职责 |
+|------|------|
+| `lib/describe-target.ts` | 可见名 / role / 可点击解析；`isMeaningfulClickTarget` |
+| `content/record-capture.ts` | DOM 捕获：FillSession、忽略 suggestion click、语义 emit |
+| `lib/record-bridge.ts` | content ↔ background 消息协议 |
+| `lib/recording-step-buffer.ts` | payload → DraftTraceStep；动作引起的跳转写草稿 `navigated_to`，否则 `navigate` |
+| `lib/url-pattern.ts` | URL canonicalize / pattern / page role |
+| `lib/trace-reducer.ts` | Draft → v3 textbook（intent/page/effect；无 parameters 抽取） |
+| `tools/record.ts` | `record_start/stop/await`、finishPromise、导航 re-arm |
+| `content/RecordOverlay.tsx` | 录制中 + 结束 |
+
+### 修改（在 main 已有入口上接线）
+
+- `dispatcher.ts`：处理 `tool.record_*`
+- `background.ts`：挂 step / finish / navigation / query / tab listeners；`webNavigation` 权限
+- `content.ts` + `overlay-controller.ts`：录制面板；录制时隐藏控制遮罩
+- `session.ts`：`session_stop` 清理进行中的 recording
+- `transport/types.ts`：TS 侧 Trace v2 类型
+- `wxt.config.ts`：增加 `webNavigation`
+
+### 录制启动约束
+
+Agent Window 在 main 上即默认 `about:blank`，content script 无法注入。  
+本需求的 `record_start` 在受限 URL 上返回明确错误，要求：
+
+```bash
+bsk record start --purpose "..." --url https://...
+```
+
+### UI / i18n
+
+- **新增**键：`recordOverlay.recording` / `finish`（en / zh）
+
+---
+
+## 5. CLI（`bsk-cli`）— vs `origin/main`
+
+### 新增
+
+- `bsk record start [--purpose] [--url] [--output trace.json] [--tab-id]`
+  - `session.start` → `tool.record_start` → **阻塞** `tool.record_await` → 写文件 → `session.stop`
+- `bsk record stop [--output trace.json]`：终端兜底结束
+- `cli/record_state.rs` + `paths::record_session_path()`：`~/.bsk/record-session.json`
+
+### 修改
+
+- `cli/mod.rs` / `main.rs`：注册子命令
+- `daemon/ipc.rs`：转发 `ToolRecord*`
+- `cli/session.rs`：抽出可复用的 `start_session` / `stop_session`（供 record 复用）
+- `skill/SKILL.md`（仓库根与 `crates/bsk-cli/skill`）：**新增**录制用法段落
+
+---
+
+## 6. 测试与验证
+
+### 单测
+
+- `bsk-protocol`：`tools::record` round-trip / purpose 序列化
+- `bsk`：`cli::record` / `record_state`
+- Extension Vitest：`describe-target`、`recording-step-buffer`、`record-capture`、`overlay-controller`
+
+### 手工验收（相对 main：全新路径）
+
+1. 基于本分支构建 CLI + 扩展并刷新扩展；`bsk status` 已连接  
+2. `bsk record start --purpose "demo" --url https://...`  
+3. UI 出现录制中 + 结束；页面可交互  
+4. 操作后点「结束」→ `./trace.json`：`version === 2`；有 `target`/`summary`；无 `@eN`；无「点击div」  
+
+---
+
+## 7. 文件清单（相对 `origin/main`）
+
+### 新增
+
+```
+crates/bsk-protocol/src/tools/record.rs
+crates/bsk-protocol/schema/trace.json
+crates/bsk-protocol/schema/trace_step.json
+crates/bsk-protocol/schema/tool_record_*.json
+apps/extension/src/lib/describe-target.ts
+apps/extension/src/lib/record-bridge.ts
+apps/extension/src/lib/recording-step-buffer.ts
+apps/extension/src/lib/trace-reducer.ts
+apps/extension/src/lib/__tests__/describe-target.test.ts
+apps/extension/src/lib/__tests__/recording-step-buffer.test.ts
+apps/extension/src/content/record-capture.ts
+apps/extension/src/content/RecordOverlay.tsx
+apps/extension/src/content/__tests__/record-capture.test.ts
+apps/extension/src/tools/record.ts
+crates/bsk-cli/src/cli/record.rs
+crates/bsk-cli/src/cli/record_state.rs
+docs/semantic-record.md
+docs/semantic-record-change-review.md   # 本文
+```
+
+### 修改（main 已有文件）
+
+```
+crates/bsk-protocol/src/method.rs
+crates/bsk-protocol/src/tools/mod.rs
+crates/bsk-protocol/src/bin/dump-schema.rs
+apps/extension/src/tools/dispatcher.ts
+apps/extension/src/entrypoints/{background,content}.ts
+apps/extension/src/content/overlay-controller.ts
+apps/extension/src/content/__tests__/overlay-controller.test.ts
+apps/extension/src/tools/session.ts
+apps/extension/src/transport/types.ts
+apps/extension/wxt.config.ts
+crates/bsk-cli/src/{main.rs,cli/mod.rs,cli/session.rs,daemon/ipc.rs,daemon/paths.rs}
+skill/SKILL.md
+crates/bsk-cli/skill/SKILL.md
+packages/i18n/src/locales/{en-US,zh-CN}/extension.json
+```
+
+### 请勿合入
+
+- 仓库根目录本地产物 [`trace.json`](../trace.json)（用户录制结果）
+
+---
+
+## 8. 风险与后续
+
+| 风险 | 说明 | 建议 |
+|------|------|------|
+| 自定义控件漏录 / 误录 | 依赖可见名 + clickable 启发式 | 用真实内网页回归；按需调整规则 |
+| `about:blank` 启动失败 | 无 `--url` 必失败 | 错误文案已提示；可考虑后续默认起跳页 |
+| 菜单项不在 a11y 树 | 如 iwiki「文档 C+D」 | 录制尽量记有 name 的项；事后执行仍靠既有 snapshot/@eN |
+| 教材质量 vs 执行 | 本需求不保证自动跑通 | 执行完全复用现有工具；由 Agent/人读 trace 后自行驱动 |
+
+---
+
+## 9. Review 关注问题
+
+1. 相对 main，是否 **仅** 增加了录制相关代码，没有夹带 replay/执行引擎？  
+2. Trace v2 是否足够作为 LLM 教材（有 name/summary），噪声是否可接受？  
+3. `isMeaningfulClickTarget` 是否过严或过松？  
+4. `record_await` 长超时与 daemon IPC 是否匹配？  
+5. `record_start` 标为 mutating、`stop`/`await` 标为 non-mutating 是否合理？  
+6. 文档是否写清：**交付 = trace.json；执行 = 复用既有 bsk 能力**？
+---
+
+## 10. 建议评审命令（对照远程 main）
+
+```bash
+git fetch origin
+git checkout new_record
+
+# 工作区相对 origin/main 的变更一览（含未跟踪新文件）
+git status
+git diff origin/main --stat
+git diff origin/main -- crates/bsk-protocol/src/method.rs crates/bsk-cli/src/main.rs
+
+# 新增文件直接阅读（相对 main 为从零新增）
+less crates/bsk-protocol/src/tools/record.rs
+less apps/extension/src/lib/describe-target.ts
+less apps/extension/src/content/record-capture.ts
+less apps/extension/src/tools/record.ts
+less crates/bsk-cli/src/cli/record.rs
+
+cargo test -p bsk-protocol --lib tools::record
+cargo test -p bsk --lib record
+cd apps/extension && pnpm exec vitest run \
+  src/lib/__tests__/describe-target.test.ts \
+  src/lib/__tests__/recording-step-buffer.test.ts \
+  src/content/__tests__/record-capture.test.ts
+```

--- a/docs/semantic-record.md
+++ b/docs/semantic-record.md
@@ -1,0 +1,119 @@
+# Semantic recording (`bsk record`)
+
+Record a user flow as an LLM-readable **textbook** (`trace.json`).
+
+**本需求只交付录制：** 得到 `trace.json` 即结束。  
+**不**新增执行 / 回放命令或引擎。事后若要完成同类操作，**完全复用已有** `bsk session` / `snapshot` / `@eN` / `click` / `fill` 等能力（由 LLM 或人读教材后自行调用）。
+
+## Quality bar for each step
+
+Every recorded step should answer: **「这一步要找什么、做什么？」**
+
+| Good (LLM can act) | Bad (drop / never record) |
+|--------------------|---------------------------|
+| `点击「发布」按钮` | `点击div` / `{ "tag": "div" }` |
+| `在「服务名称」填入 my-svc` | 只有 CSS 路径或 `@eN` |
+| `点击「Tencent 腾讯」链接` | 无名布局空白、装饰点击 |
+
+Recording the control’s **visible name** is the usual way to meet this bar (not a rigid schema mandate): whatever we store, the LLM must be able to know *where* to click/fill next.
+
+## Product loop
+
+```text
+（可选）purpose + 录制 steps
+        ↓
+写出 trace.json          ← 本需求边界
+        ↓
+（既有能力，非本需求）LLM 读教材或用户描述 → 常规 bsk 工具循环
+        ↓
+目标达成后立即 session stop（见 skill「Stop when the goal is met」）
+```
+
+There is **no** `bsk replay` and **no** new execute-from-trace API in this change. Agents may also act from a plain user request without a textbook; either path must stop controlling the browser as soon as the goal is met.
+## CLI
+
+```bash
+bsk record start [--purpose "..."] --url https://... [--output trace.json]
+# `--url` is required for a fresh session (Agent Window boots on about:blank).
+# Blocks until the user clicks Finish / 结束 in the browser panel.
+# Writes ./trace.json by default, then closes the Agent Window.
+
+bsk record stop [--output trace.json]   # terminal fallback
+```
+
+## UI
+
+After `record start`, the Agent Window shows a bottom panel:
+
+- Status: **正在录制用户操作** / “Recording your actions”
+- Button: **结束** / “Finish”
+
+The control mask is hidden so the page stays interactive. Clicking Finish stops capture, saves the trace, and closes the window.
+
+## `purpose` is metadata only
+
+| Stage | Does `purpose` affect it? |
+|-------|---------------------------|
+| Capture rules (fill commit, ignore suggestion clicks, semantic targets) | **No** |
+| Filtering “irrelevant” actions by goal | **No** (not in this phase) |
+| Post-hoc LLM understanding of *why* the flow exists | **Yes** — written to `trace.json` top-level when provided |
+
+Omitting `--purpose` still produces a complete trace.
+
+## Trace shape (v3)
+
+LLM textbook: each step has `id` / `op` / `intent` / `importance` / `page` / `summary`, plus op-specific fields. Action-caused navigation becomes `effect`, not a separate wait step. Variable inputs are **not** auto-extracted (`parameters[]` omitted) — downstream LLM infers them from control names + `value`.
+
+```json
+{
+  "version": 3,
+  "purpose": "…",
+  "recorded_at": "…",
+  "entry": {
+    "start_url": "…",
+    "start_url_pattern": "…",
+    "site": "…"
+  },
+  "steps": [
+    {
+      "id": 1,
+      "op": "fill",
+      "intent": "provide_input",
+      "importance": "essential",
+      "target": { "role": "textbox", "name": "服务名称", "tag": "input", "name_attr": "serviceName" },
+      "value": "my-svc",
+      "summary": "在「服务名称」填入 my-svc",
+      "page": { "url_pattern": "https://example.com/*/edit", "role": "editor" }
+    },
+    {
+      "id": 2,
+      "op": "click",
+      "intent": "confirm",
+      "importance": "essential",
+      "target": { "role": "button", "name": "发布", "tag": "button" },
+      "summary": "点击「发布」按钮",
+      "effect": {
+        "navigated_to": "https://example.com/p/99",
+        "url_pattern_after": "https://example.com/p/*"
+      }
+    }
+  ]
+}
+```
+
+**Forbidden in the export:** `@eN`, tracking hrefs as primary descriptors, deep `nth-of-type` CSS paths, standalone `wait_for_navigation`, anonymous layout clicks (`{ "tag": "div" }` with no name).
+
+**Capture rules:**
+- FillSession emits the final value only; autocomplete/suggestion clicks are ignored
+- Clicks are recorded only for **named interactive** controls (button/link/role + accessible name); bare `div`/`span` chrome is dropped
+- Passwords become `"***"` with `redacted: true`
+- `press` keeps Enter/Escape; drops bare typing and Meta/Ctrl+a|c|v|x noise
+- URLs are patternized (drop tracking query, collapse numeric path ids)
+
+## Manual check
+
+1. `bsk record start --purpose "demo"` (or without purpose)
+2. Confirm the recording panel appears
+3. Perform a few clicks/fills (optionally Enter to submit)
+4. Click **结束**
+5. Open `./trace.json` — `version` is `3`, steps have `intent`/`summary`/`page` or `effect`, no `@eN` / `parameters`

--- a/packages/i18n/src/locales/en-US/extension.json
+++ b/packages/i18n/src/locales/en-US/extension.json
@@ -68,5 +68,9 @@
     "expand": "Expand",
     "dragHandle": "Drag to move",
     "notificationTitle": "BrowserSkill: Agent needs your help"
+  },
+  "recordOverlay": {
+    "recording": "Recording your actions",
+    "finish": "Finish"
   }
 }

--- a/packages/i18n/src/locales/zh-CN/extension.json
+++ b/packages/i18n/src/locales/zh-CN/extension.json
@@ -68,5 +68,9 @@
     "expand": "展开",
     "dragHandle": "拖动以移动",
     "notificationTitle": "BrowserSkill：Agent 需要你的帮助"
+  },
+  "recordOverlay": {
+    "recording": "正在录制用户操作",
+    "finish": "结束"
   }
 }

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -46,6 +46,20 @@ Optional: `bsk session start --browser <instance-id-or-label>` when multiple bro
 
 Emergency cleanup: `bsk session stop --all` or the Agent Window overlay **Stop all**.
 
+## Stop when the goal is met
+
+Tasks may come from a **user description** (“play 传奇 on QQ Music”) and/or an optional **`trace.json` textbook**. Either way, treat the session as a short goal loop — not an open-ended browsing session.
+
+1. **State the done condition** up front (from the user’s words, `purpose`, or the last essential textbook step). Example: “《传奇》已开始播放”.
+2. **Take the shortest path** to that condition. Prefer one snapshot → act → (optional) one check.
+3. **As soon as the goal is met, stop acting and `bsk session stop <id>`** unless the user explicitly asked to keep the window open (“先别关”, “keep browsing”, etc.).
+4. **No post-success exploration** — after success, do **not** click again, refresh, re-search, switch tabs, or “make sure it’s really playing”. Extra verification is a new task, not part of finishing.
+5. If unsure whether you’re done: at most **one** extra `bsk snapshot`, then either stop (goal looks met) or ask the user — do not keep clicking.
+
+**With a textbook:** execute `importance: essential` steps in order; after the last essential step (or when its `effect` / success hint is satisfied), apply rules 3–4 immediately. The textbook is guidance, not a license to keep controlling the browser.
+
+**Without a textbook:** the user’s request *is* the done condition. Completing that request ends the task — same stop rules.
+
 ## Core interaction loop
 
 Write operations only affect tabs in the **Agent Window** (or tabs you **borrowed** into it).
@@ -216,13 +230,32 @@ Human errors print `error:` + `hint:` on stderr; `--json` includes `code`, `mess
 
 Always **`bsk session stop <id>`** in a `finally`-style path so the Agent Window closes and borrowed tabs return.
 
+### Record a semantic flow textbook
+
+When the human wants to capture “how I do X in the browser” for later LLM-driven automation:
+
+```bash
+bsk record start --purpose "How to create and publish a document in the wiki." --url https://… [--output trace.json]
+# `--url` is required on a fresh session (about:blank cannot host the content script).
+# Blocks until the user clicks Finish in the browser recording panel.
+# Writes ./trace.json (override with --output) and closes the window.
+
+bsk record stop [--output trace.json]   # terminal fallback if the panel is unavailable
+```
+
+- The trace is a **semantic textbook** (`version: 3`: intent/page/effect + role/name/tag summaries; variable inputs left for the LLM). Recording stops once `trace.json` is written.
+- `--purpose` is optional metadata for post-hoc LLM context; it does **not** change what gets captured.
+- There is **no** `bsk replay` and **no** new execute-from-trace path — to redo the flow, reuse **existing** `session` / `snapshot` / `@eN` / `click` / `fill` tools after reading the textbook. Follow **Stop when the goal is met** when executing from a textbook or from a plain user request.
+- Do **not** record on banking/SSO/password-manager pages; password fields are redacted but traces may still contain sensitive text.
+
 ## Red lines
 
 1. **No token theft** — do not `bsk evaluate` on sensitive sites to read `localStorage`, cookies, or auth headers for exfiltration.
 2. **No long borrow** — do not leave a user's personal tab in the Agent Window across unrelated tasks.
 3. **No skip stop** — always `bsk session stop <id>`; never assume idle timeout will clean up.
-4. **No observe escalation before snapshot** — use `bsk snapshot` first; only use `bsk get-html` or `bsk screenshot` when the snapshot is insufficient. Element screenshots (`--ref @eN`) still require a fresh snapshot ref — never skip snapshot just to grab a visual.
-5. **`evaluate` is powerful and risky** — use only when snapshot + click/fill/select cannot suffice; never on credential surfaces.
+4. **No post-success control** — once the user’s goal (or last textbook essential step) is met, do not keep operating the page; stop the session unless they asked to keep it open.
+5. **No observe escalation before snapshot** — use `bsk snapshot` first; only use `bsk get-html` or `bsk screenshot` when the snapshot is insufficient. Element screenshots (`--ref @eN`) still require a fresh snapshot ref — never skip snapshot just to grab a visual.
+6. **`evaluate` is powerful and risky** — use only when snapshot + click/fill/select cannot suffice; never on credential surfaces.
 
 ---
 


### PR DESCRIPTION
## Summary
- Add `bsk record` to capture user flows as LLM-readable `trace.json` (Trace v3: intent/page/effect, press denoise, URL patterns; no `parameters[]` heuristics).
- Lazily attach tab/webNavigation observers only while recording; harden record start cancel cleanup and CLI teardown after write failures; teach agents to stop when the goal is met.
- Bump CLI to `0.1.8` and extension to `0.1.4` for release tagging.

## Test plan
- [ ] `cargo test -p bsk-protocol --locked`
- [ ] `pnpm --filter @browser-skill/extension test`
- [ ] `bsk record start --purpose "demo" --url https://example.com` → Finish → `trace.json` has `version: 3`
- [ ] Non-record path: `session start` → navigate/snapshot/click → `session stop` still works
- [ ] Optional: tag `cli-v0.1.8` / `ext-v0.1.4` on a writable repo to verify release workflows