### PR TITLE
Correct the incorrect command examples in the error message that does not indicate the mistake.

### DIFF
--- a/crates/bsk-cli/src/cli/render_error.rs
+++ b/crates/bsk-cli/src/cli/render_error.rs
@@ -93,7 +93,7 @@ pub fn info_for(code: ErrorCode) -> RenderInfo {
         ErrorCode::NotFound => RenderInfo {
             summary: "requested resource does not exist",
             hint: Some(
-                "the session, tab, or browser may have stopped; run `bsk sessions` / `bsk browsers` to see current state",
+                "the session, tab, or browser may have stopped; run `bsk session list` / `bsk browsers` to see current state",
             ),
             exit_code: 1,
         },


### PR DESCRIPTION
Correct the incorrect command examples in the error message that does not indicate the mistake.

<img width="1500" height="564" alt="image" src="https://github.com/user-attachments/assets/ec4389b5-4c11-4f7c-8cbb-7a336f0ab23c" />

The correct command should be `bsk session list`

<img width="516" height="120" alt="image" src="https://github.com/user-attachments/assets/87c3ddd1-e575-438c-a7c6-7638df137d41" />
