### PR TITLE
fix(extension): roll back CDP attach when a domain enable fails

### DIFF
--- a/apps/extension/src/browser-driver/__tests__/chromium-cdp.test.ts
+++ b/apps/extension/src/browser-driver/__tests__/chromium-cdp.test.ts
@@ -67,6 +67,30 @@ describe("ChromiumCdp", () => {
     expect(cdp.isAttached(5)).toBe(false);
   });
 
+  it("rolls back the raw attach when a domain enable fails so the tab is not left stuck", async () => {
+    const { api } = fakeApi();
+    (api.sendCommand as ReturnType<typeof vi.fn>).mockImplementation(
+      async (_target, method: string) => {
+        if (method === "Page.enable") throw new Error("Page.enable rejected");
+        return {};
+      },
+    );
+    const cdp = new ChromiumCdp(api);
+
+    // Raw attach succeeds, but Page.enable fails. Without the rollback
+    // the debugger would stay attached while `attachedTabs` omits the id,
+    // leaving the tab stuck on "Another debugger is already attached" for
+    // every later call until the extension is reloaded.
+    await expect(cdp.ensureAttached(42)).rejects.toThrow(/Page\.enable rejected/);
+    expect(cdp.isAttached(42)).toBe(false);
+    expect(api.detach).toHaveBeenCalledWith({ tabId: 42 });
+
+    // The rollback detached, so a fresh attach can succeed afterwards.
+    (api.sendCommand as ReturnType<typeof vi.fn>).mockResolvedValue({});
+    await expect(cdp.ensureAttached(42)).resolves.toBeUndefined();
+    expect(cdp.isAttached(42)).toBe(true);
+  });
+
   it("send() rejects on chrome.runtime.lastError-style failures", async () => {
     const { api } = fakeApi();
     (api.sendCommand as ReturnType<typeof vi.fn>).mockImplementation(

--- a/apps/extension/src/browser-driver/chromium-cdp.ts
+++ b/apps/extension/src/browser-driver/chromium-cdp.ts
@@ -155,10 +155,26 @@ export class ChromiumCdp {
     }
     const attach = (async () => {
       await this.api.attach({ tabId }, CDP_PROTOCOL_VERSION);
-      await this.enablePageDomain(tabId);
-      await this.enableConsoleDomains(tabId);
-      await this.enableNetworkDomainBestEffort(tabId);
-      this.attachedTabs.add(tabId);
+      try {
+        await this.enablePageDomain(tabId);
+        await this.enableConsoleDomains(tabId);
+        await this.enableNetworkDomainBestEffort(tabId);
+        this.attachedTabs.add(tabId);
+      } catch (err) {
+        // A CDP domain enable failed after the raw attach succeeded
+        // (e.g. `Page.enable` rejects because the tab just navigated to
+        // a chrome:// URL or the Web Store). `attachedTabs` does not yet
+        // hold `tabId`, so without rolling back the debugger would stay
+        // attached and the next `ensureAttached` would re-attach and hit
+        // "Another debugger is already attached" forever — the tab is
+        // unusable until the extension is reloaded. Detach directly
+        // (`this.detach()` is a no-op here because `attachedTabs` lacks
+        // the id) so the next attempt starts from a clean slate.
+        await this.api.detach({ tabId }).catch((detachErr) => {
+          console.debug("[bsk cdp] rollback detach failed", { tabId, detachErr });
+        });
+        throw err;
+      }
     })()
       .catch((err) => {
         // Chrome surfaces "Another debugger is already attached" when


### PR DESCRIPTION
## Problem

`ChromiumCdp.ensureAttached` can leave a tab **permanently stuck** when a CDP domain enable fails after the raw attach succeeds.

The attach sequence was:

```ts
await this.api.attach({ tabId }, CDP_PROTOCOL_VERSION); // succeeds -> Chrome has the debugger attached
await this.enablePageDomain(tabId);                     // can throw (Page.enable)
await this.enableConsoleDomains(tabId);                 // best-effort (swallows)
await this.enableNetworkDomainBestEffort(tabId);        // best-effort (swallows)
this.attachedTabs.add(tabId);                           // only reached if all of the above succeed
```

`enablePageDomain` is the only domain enable that is neither best-effort nor guarded. If it rejects — e.g. the tab navigates to a `chrome://` URL or the Web Store in the gap between `attach` and `Page.enable`, or a transient CDP error during attach — the `.catch` re-throws but performs **no cleanup**, and `attachedTabs` never records the tabId.

On the next tool call, `ensureAttached` sees the tabId is not cached, has no in-flight attach, and calls `api.attach` again → Chrome rejects it with **"Another debugger is already attached"**. Every subsequent operation on that tab fails until the extension is reloaded. Note the public `detach()` cannot self-heal this, because it no-ops when `attachedTabs` lacks the id.

## Fix

Detach the debuggee directly in the failure path (before re-throwing) so the next attempt starts from a clean slate:

```ts
await this.api.attach({ tabId }, CDP_PROTOCOL_VERSION);
try {
  await this.enablePageDomain(tabId);
  await this.enableConsoleDomains(tabId);
  await this.enableNetworkDomainBestEffort(tabId);
  this.attachedTabs.add(tabId);
} catch (err) {
  await this.api.detach({ tabId }).catch((detachErr) => {
    console.debug("[bsk cdp] rollback detach failed", { tabId, detachErr });
  });
  throw err;
}
```

`api.attach` failures are untouched (no detach attempted, since nothing was attached) — only failures *after* a successful attach roll back.

## Test

Adds a regression test that mocks `Page.enable` to throw after `attach` succeeds, then asserts:
- `ensureAttached` rejects with the original error,
- the rollback calls `api.detach({ tabId })`,
- the tab is not left in the cache, and
- a fresh `ensureAttached` succeeds afterwards.

This test **fails on the previous code** (0 detach calls) and passes with the fix.

## Validation

Ran the frontend CI gates locally against this branch:
- `pnpm --filter @browser-skill/extension exec wxt prepare` ✅
- `pnpm ext:test` — 388 passed ✅
- `pnpm --filter @browser-skill/extension compile` (tsc --noEmit) ✅
- `pnpm lint` (biome + stylelint) ✅
- `pnpm ext:build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)