### PR TITLE
fix(extension): resolve wait_until=commit when the readyState probe fails

### DIFF
--- a/apps/extension/src/tools/__tests__/navigation.test.ts
+++ b/apps/extension/src/tools/__tests__/navigation.test.ts
@@ -49,6 +49,8 @@ function makeFakeCdp(opts?: {
   beforeLoaderId?: string;
   readyState?: string;
   readyStateSequence?: string[];
+  /** Make the readyState probe's `Runtime.evaluate` throw (returns null). */
+  evaluateThrows?: boolean;
 }) {
   const readyStates = opts?.readyStateSequence ?? (opts?.readyState ? [opts.readyState] : []);
   let readyStateIdx = 0;
@@ -94,7 +96,10 @@ function makeFakeCdp(opts?: {
       return {};
     },
     "Runtime.enable": () => ({}),
-    "Runtime.evaluate": () => ({ result: { value: nextReadyState() } }),
+    "Runtime.evaluate": () => {
+      if (opts?.evaluateThrows) throw new Error("Cannot execute in a destroyed execution context");
+      return { result: { value: nextReadyState() } };
+    },
     "Page.getNavigationHistory": () => ({
       currentIndex: opts?.historyIndex ?? 1,
       entries: opts?.historyEntries ?? [
@@ -168,8 +173,13 @@ function makeFakeCdp(opts?: {
       const payload = { name, frameId, loaderId };
       for (const listener of [...events]) listener({ tabId: 4 }, "Page.lifecycleEvent", payload);
     },
-    fireFrameNavigated(frameId = opts?.navigateFrameId ?? "frame-1") {
-      const payload = { frame: { id: frameId, url: opts?.finalUrl ?? "https://example.com/" } };
+    fireFrameNavigated(
+      frameId = opts?.navigateFrameId ?? "frame-1",
+      loaderId = opts?.navigateLoaderId ?? "loader-after",
+    ) {
+      const payload = {
+        frame: { id: frameId, loaderId, url: opts?.finalUrl ?? "https://example.com/" },
+      };
       for (const listener of [...events]) listener({ tabId: 4 }, "Page.frameNavigated", payload);
     },
     listeners: events,
@@ -452,6 +462,34 @@ describe("handleNavigate", () => {
 
     await new Promise((r) => setTimeout(r, 5));
     fake.fireFrameNavigated();
+    const res = await navP;
+    if ("code" in res) throw new Error(`unexpected error: ${JSON.stringify(res)}`);
+    expect(res.reached).toBe("commit");
+    expect(fake.listeners.length).toBe(0);
+  });
+
+  it("resolves wait_until=commit from Page.frameNavigated when the readyState probe fails", async () => {
+    const sm = new SessionManager({ agentWindow: fakeAgentWindow([100]) });
+    await sm.start("aa11");
+    // Cross-origin-style navigation: the readyState probe can't read the
+    // (already destroyed) old execution context, so commit must come from
+    // the Page.frameNavigated event. Before the fix this timed out because
+    // the handler dropped the frame's loaderId and the loader guard then
+    // rejected the event.
+    const fake = makeFakeCdp({ evaluateThrows: true });
+    const navP = handleNavigate(
+      sm,
+      {
+        session_id: "aa11",
+        url: "https://example.com/",
+        wait_until: "commit",
+        timeout_ms: 1_000,
+      },
+      { cdp: fake.cdp, tabsApi: fake.tabsApi },
+    );
+
+    await new Promise((r) => setTimeout(r, 5));
+    fake.fireFrameNavigated("frame-1", "loader-after");
     const res = await navP;
     if ("code" in res) throw new Error(`unexpected error: ${JSON.stringify(res)}`);
     expect(res.reached).toBe("commit");

--- a/apps/extension/src/tools/navigation.ts
+++ b/apps/extension/src/tools/navigation.ts
@@ -325,14 +325,14 @@ function startLifecycleWait(
           if (source.tabId !== expectedTabId) return;
 
           if (targetName === "commit" && method === "Page.frameNavigated") {
-            const p = params as { frame?: { id?: string; parentId?: string } };
+            const p = params as { frame?: { id?: string; parentId?: string; loaderId?: string } };
             const expectedFrameId = currentFrameId();
             if (expectedFrameId.length > 0) {
               if (p.frame?.id !== expectedFrameId) return;
             } else if (p.frame?.parentId) {
               return;
             }
-            if (!acceptLifecycleEvent("commit", p.frame?.id)) return;
+            if (!acceptLifecycleEvent("commit", p.frame?.id, p.frame?.loaderId)) return;
             finish({ reached: "match", lastLifecycle: "commit" });
             return;
           }


### PR DESCRIPTION
## Problem

`handleNavigate` with `wait_until: "commit"` can **time out for the full `timeout_ms`** instead of resolving on commit, on cross-origin navigations.

The `Page.frameNavigated` handler called `acceptLifecycleEvent` without the frame's `loaderId`:

```ts
if (targetName === "commit" && method === "Page.frameNavigated") {
  const p = params as { frame?: { id?: string; parentId?: string } };
  ...
  if (!acceptLifecycleEvent("commit", p.frame?.id)) return;   // no loaderId
  ...
}
```

Once `Page.navigate` resolves, the loader guard always carries the new `loaderId`, so `eventLoaderIsRelevant(undefined, guard)` hits the `expected.length > 0 && !eventLoaderId` branch and **rejects the commit event outright** (every time).

This was masked in the common case because the `document.readyState` probe short-circuits first (`lifecycleAlreadyReached("loading" | "interactive", "commit")` is `true`). But on a **cross-origin navigation** the probe returns `null` — the old execution context is destroyed, so the `Runtime.evaluate` throws — and the wait falls back to `Page.frameNavigated`, which is then rejected. Result: the commit wait runs to `timeout_ms` (default 30s).

## Fix

Pass the frame's `loaderId` through, exactly as the sibling `Page.lifecycleEvent` branches already do (`navigation.ts` lines that call `acceptLifecycleEvent(p.name, p.frameId, p.loaderId)`):

```ts
const p = params as { frame?: { id?: string; parentId?: string; loaderId?: string } };
...
if (!acceptLifecycleEvent("commit", p.frame?.id, p.frame?.loaderId)) return;
```

## Test

Adds a regression test that makes the readyState probe throw (returns `null`, simulating the destroyed old execution context of a cross-origin nav) and asserts `wait_until="commit"` is reached from the `Page.frameNavigated` event. This test **fails on the previous code** (`reached: "timeout"`) and passes with the fix. The existing commit test is unaffected (it still resolves via the probe).

## Validation

Frontend CI gates run locally against this branch:
- `pnpm ext:test` — 388 passed ✅
- `pnpm --filter @browser-skill/extension compile` (tsc --noEmit) ✅
- `pnpm lint` (biome + stylelint) ✅
- `pnpm ext:build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)