### PR TITLE
fix: bsk session start 在浏览器未运行时先拉起浏览器

### DIFF
--- a/crates/bsk-cli/src/cli/launch_browser.rs
+++ b/crates/bsk-cli/src/cli/launch_browser.rs
@@ -1,0 +1,140 @@
+//! Best-effort launch of a supported browser when `bsk session start`
+//! fails with `no_browser_connected`.
+//!
+//! When the daemon reports that no browser extension is connected, it is
+//! often simply because the browser process is not running, so the
+//! BrowserSkill extension's background worker never started. Spawning the
+//! browser lets an already-installed extension connect to the daemon, after
+//! which the `session.start` retry succeeds. If the browser cannot be
+//! launched (not installed), the caller surfaces the usual "install the
+//! extension" hint instead.
+
+use std::process::Command;
+use std::time::Duration;
+
+/// How long to wait, after launching the browser, for the extension to
+/// reconnect to the daemon before giving up and showing the install hint.
+pub const POST_LAUNCH_CONNECT_WAIT: Duration = Duration::from_secs(20);
+
+/// Try to bring a supported browser online so the BrowserSkill extension
+/// can connect to the daemon.
+///
+/// Returns `Ok(())` when a supported browser is already running or was
+/// successfully launched, and `Err(_)` when no supported browser could be
+/// found or started (the caller should then tell the user to install the
+/// extension).
+pub fn attempt_launch_browser() -> Result<(), String> {
+    if is_any_supported_browser_running() {
+        // Already running: the missing connection is an extension-level
+        // problem (not installed / disabled), not a missing process, so
+        // launching another instance would not help.
+        return Ok(());
+    }
+    launch_default_browser()
+}
+
+/// Whether any supported browser process appears to be running.
+#[cfg(unix)]
+fn is_any_supported_browser_running() -> bool {
+    let patterns: &[&str] = if cfg!(target_os = "macos") {
+        &[
+            "Google Chrome",
+            "Chromium",
+            "Microsoft Edge",
+            "Brave Browser",
+        ]
+    } else {
+        &["chrome", "chromium", "msedge", "brave"]
+    };
+    patterns.iter().any(|pattern| {
+        Command::new("pgrep")
+            .args(["-f", "-i", pattern])
+            .output()
+            .map(|out| {
+                let stdout = String::from_utf8_lossy(&out.stdout);
+                out.status.success() && !stdout.trim().is_empty()
+            })
+            .unwrap_or(false)
+    })
+}
+
+#[cfg(windows)]
+fn is_any_supported_browser_running() -> bool {
+    const EXES: &[&str] = &["chrome.exe", "msedge.exe", "brave.exe"];
+    EXES.iter().any(|exe| {
+        Command::new("tasklist")
+            .args(["/fi", &format!("IMAGENAME eq {exe}")])
+            .output()
+            .map(|out| String::from_utf8_lossy(&out.stdout).contains(exe))
+            .unwrap_or(false)
+    })
+}
+
+/// Launch the first supported browser found on the system.
+#[cfg(target_os = "macos")]
+fn launch_default_browser() -> Result<(), String> {
+    const NAMES: &[&str] = &[
+        "Google Chrome",
+        "Google Chrome Canary",
+        "Chromium",
+        "Microsoft Edge",
+        "Brave Browser",
+    ];
+    for name in NAMES {
+        if Command::new("open")
+            .args(["-a", name])
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false)
+        {
+            return Ok(());
+        }
+    }
+    Err("no supported browser found (install Chrome, Chromium, Edge, or Brave)".into())
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+fn launch_default_browser() -> Result<(), String> {
+    const NAMES: &[&str] = &[
+        "google-chrome",
+        "google-chrome-stable",
+        "chromium",
+        "chromium-browser",
+        "microsoft-edge",
+        "brave-browser",
+    ];
+    for name in NAMES {
+        // `spawn` returns immediately for a GUI browser; we intentionally
+        // detach (drop the child handle) so the CLI call returns at once.
+        if Command::new(name).arg("about:blank").spawn().is_ok() {
+            return Ok(());
+        }
+    }
+    Err("no supported browser found on PATH (install Chrome, Chromium, Edge, or Brave)".into())
+}
+
+#[cfg(windows)]
+fn launch_default_browser() -> Result<(), String> {
+    const EXES: &[&str] = &["chrome", "msedge", "brave"];
+    for exe in EXES {
+        if Command::new("cmd")
+            .args(["/c", "start", "", exe])
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false)
+        {
+            return Ok(());
+        }
+    }
+    Err("no supported browser found (install Chrome, Chromium, Edge, or Brave)".into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn post_launch_connect_wait_is_positive() {
+        assert!(POST_LAUNCH_CONNECT_WAIT.as_secs() > 0);
+    }
+}

--- a/crates/bsk-cli/src/cli/mod.rs
+++ b/crates/bsk-cli/src/cli/mod.rs
@@ -16,6 +16,7 @@ pub mod get_html;
 pub mod human_loop;
 pub mod install_skill;
 pub mod interaction;
+pub mod launch_browser;
 pub mod logs;
 pub mod navigate;
 pub mod network;

--- a/crates/bsk-cli/src/cli/render_error.rs
+++ b/crates/bsk-cli/src/cli/render_error.rs
@@ -156,7 +156,7 @@ pub fn info_for(code: ErrorCode) -> RenderInfo {
         ErrorCode::NoBrowserConnected => RenderInfo {
             summary: "no browser is connected to the daemon",
             hint: Some(
-                "open the browser-skill extension in your browser and wait for the popup to show \"connected\"",
+                "if your browser is open, check that the browser-skill extension is installed and enabled and wait for the popup to show \"connected\"; if it is not installed, add it from the Chrome Web Store (or your browser's extension store) and open it once",
             ),
             exit_code: 1,
         },

--- a/crates/bsk-cli/src/cli/session.rs
+++ b/crates/bsk-cli/src/cli/session.rs
@@ -5,11 +5,11 @@
 //! human-readable by default; pass the global `--json` flag to get
 //! structured JSON instead.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use anyhow::Context;
-use bsk_protocol::system::{BrowserStatusEntry, SessionStatusEntry};
+use bsk_protocol::system::{BrowserListParams, BrowserStatusEntry, SessionStatusEntry};
 use bsk_protocol::tools::ReturnFailure;
 use bsk_protocol::{ErrorCode, Method};
 use clap::{Args, Subcommand};
@@ -17,6 +17,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::cli::ensure_daemon::ensure_daemon;
 use crate::cli::error::{self, CliError, Format, RenderExtras};
+use crate::cli::launch_browser;
 
 const SESSION_STOP_IPC_TIMEOUT: Duration = Duration::from_secs(60 * 60);
 
@@ -113,34 +114,100 @@ pub fn dispatch(cmd: SessionCmd, format: Format) -> Result<(), CliError> {
 }
 
 fn run_start(sock: PathBuf, args: SessionStartArgs, format: Format) -> Result<(), CliError> {
-    let result: Result<StartReply, CliError> = call(
-        sock,
+    let first: Result<StartReply, CliError> = call(
+        sock.clone(),
         Method::SessionStart,
         Some(StartParams {
-            browser_instance_id: args.browser,
+            browser_instance_id: args.browser.clone(),
         }),
         Duration::from_secs(30),
     );
-    match result {
-        Ok(reply) => match format {
-            Format::Json => {
-                println!(
-                    "{}",
-                    serde_json::to_string_pretty(&serde_json::json!({
-                        "session_id": reply.session_id,
-                        "browser_instance_id": reply.browser_instance_id,
-                        "agent_window_id": reply.agent_window_id,
-                    }))
-                    .map_err(|e| CliError::Local(anyhow::anyhow!(e)))?
+    let reply = match first {
+        Ok(reply) => reply,
+        Err(err) => {
+            if err.code() == Some(ErrorCode::NoBrowserConnected) {
+                // The daemon sees no connected browser. Most often the
+                // browser process simply isn't running, so the extension
+                // never had a chance to connect. Try to bring it up, wait
+                // for the extension to reconnect, then retry once.
+                eprintln!(
+                    "BrowserSkill: no browser is connected — launching your browser so the extension can connect …"
                 );
+                match retry_after_launch(sock, &args) {
+                    Some(reply) => reply,
+                    None => return Err(handle_start_error(err, format)),
+                }
+            } else {
+                return Err(handle_start_error(err, format));
             }
-            Format::Human => {
-                println!("{}", reply.session_id);
-            }
-        },
-        Err(err) => return Err(handle_start_error(err, format)),
+        }
+    };
+    match format {
+        Format::Json => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&serde_json::json!({
+                    "session_id": reply.session_id,
+                    "browser_instance_id": reply.browser_instance_id,
+                    "agent_window_id": reply.agent_window_id,
+                }))
+                .map_err(|e| CliError::Local(anyhow::anyhow!(e)))?
+            );
+        }
+        Format::Human => {
+            println!("{}", reply.session_id);
+        }
     }
     Ok(())
+}
+
+/// On `no_browser_connected`, try to bring the browser process up (so an
+/// installed extension can connect), wait for it to appear, then retry
+/// `session.start` once. Returns the reply on success, or `None` if the
+/// browser could not be launched or the retry still failed — in which case
+/// the caller surfaces the usual install hint.
+fn retry_after_launch(sock: PathBuf, args: &SessionStartArgs) -> Option<StartReply> {
+    if launch_browser::attempt_launch_browser().is_err() {
+        return None;
+    }
+    if !wait_for_browser_connection(&sock) {
+        return None;
+    }
+    call::<_, StartReply>(
+        sock,
+        Method::SessionStart,
+        Some(StartParams {
+            browser_instance_id: args.browser.clone(),
+        }),
+        Duration::from_secs(30),
+    )
+    .ok()
+}
+
+/// Reply shape for `browser.list` (mirrors the daemon's private
+/// `BrowserListResult`); only the `browsers` field is needed here.
+#[derive(Debug, Deserialize)]
+struct BrowserListReply {
+    browsers: Vec<BrowserStatusEntry>,
+}
+
+/// Block (via the daemon's browser-list wait) until a browser connects, or
+/// the launch wait window elapses.
+fn wait_for_browser_connection(sock: &Path) -> bool {
+    let wait = launch_browser::POST_LAUNCH_CONNECT_WAIT;
+    let params = BrowserListParams {
+        wait_for_browser_ms: Some(wait.as_millis() as u64),
+    };
+    let timeout = wait + Duration::from_secs(5);
+    match call::<_, BrowserListReply>(
+        sock.to_path_buf(),
+        Method::BrowserList,
+        Some(params),
+        timeout,
+    ) {
+        Ok(result) => !result.browsers.is_empty(),
+        Err(_) => false,
+    }
 }
 
 /// Render a `session.start` failure (review I3).


### PR DESCRIPTION
关联 Issue Closes #40

问题 当浏览器未运行时执行 bsk session start，CLI 返回 no browser is connected 错误并退出，不会尝试启动浏览器。用户需先手动启动浏览器并确保扩展已连接，再重新执行命令。

改动

- 新增 crates/bsk-cli/src/cli/launch_browser.rs：先通过进程检测（macOS pgrep / Windows tasklist）判断浏览器是否已运行；未运行时自动拉起默认浏览器（Chrome / Chromium / Edge / Brave）。
- crates/bsk-cli/src/cli/session.rs：捕获 NoBrowserConnected 后，先检测并拉起浏览器，等待扩展重连后重试 session.start 一次。
- crates/bsk-cli/src/cli/render_error.rs：补充 NoBrowserConnected 的提示文案。
- crates/bsk-cli/src/cli/mod.rs：注册新模块。

验证

- 浏览器未运行 → bsk session start 自动拉起浏览器，扩展重连后创建会话；
- 浏览器已运行但扩展未连接 → 不重复拉起，提示检查扩展；
- 无支持的浏览器 → 回退安装提示（exit 1）。


Linked Issue Closes #40

Problem When bsk session start is run while no browser is running, the CLI returns a no browser is connected error and exits without attempting to start a browser. The user must manually launch the browser, ensure the extension is connected, then re-run the command.

Changes

- Added crates/bsk-cli/src/cli/launch_browser.rs: first checks via process detection (macOS pgrep / Windows tasklist) whether a browser is already running; if not, auto-launches the default browser (Chrome / Chromium / Edge / Brave).
- crates/bsk-cli/src/cli/session.rs: on catching NoBrowserConnected, detects and launches the browser, then retries session.start once after the extension reconnects.
- crates/bsk-cli/src/cli/render_error.rs: added hint text for NoBrowserConnected.
- crates/bsk-cli/src/cli/mod.rs: registered the new module.

Verification

- Browser not running → bsk session start auto-launches it and creates the session after the extension reconnects;
- Browser running but extension not connected → no second instance launched; prompts to check the extension;
- No supported browser → falls back to install hint (exit 1).