### PR TITLE
feat(extension): 添加控制覆盖层可见性切换功能

### DIFF
--- a/apps/extension/src/entrypoints/content.ts
+++ b/apps/extension/src/entrypoints/content.ts
@@ -25,6 +25,7 @@ import {
   isHelpCancelMessage,
   isHelpRequestMessage,
 } from "@/lib/help-bridge";
+import { getControlOverlayVisible, STORAGE_KEYS } from "@/lib/instance-id";
 import {
   isOverlayAgentOverlayResetMessage,
   OVERLAY_AUTOMATION_BYPASS,
@@ -41,7 +42,6 @@ import {
   type RecordStopAck,
 } from "@/lib/record-bridge";
 import { SESSIONS_LIVE_FLAG_KEY } from "@/lib/sessions-live-flag";
-import { getControlOverlayVisible, STORAGE_KEYS } from "@/lib/instance-id";
 import type {
   BorrowCancelMessage,
   BorrowRequestMessage,

--- a/apps/extension/src/entrypoints/content.ts
+++ b/apps/extension/src/entrypoints/content.ts
@@ -92,7 +92,11 @@ export default defineContentScript({
       },
     });
 
-    controlOverlayVisible = await getControlOverlayVisible();
+    try {
+      controlOverlayVisible = await getControlOverlayVisible();
+    } catch {
+      // default to visible
+    }
 
     function renderOverlay() {
       const overlayState = overlays.snapshot();

--- a/apps/extension/src/entrypoints/content.ts
+++ b/apps/extension/src/entrypoints/content.ts
@@ -41,6 +41,7 @@ import {
   type RecordStopAck,
 } from "@/lib/record-bridge";
 import { SESSIONS_LIVE_FLAG_KEY } from "@/lib/sessions-live-flag";
+import { getControlOverlayVisible, STORAGE_KEYS } from "@/lib/instance-id";
 import type {
   BorrowCancelMessage,
   BorrowRequestMessage,
@@ -65,6 +66,7 @@ export default defineContentScript({
     let overlayHost: HTMLElement | null = null;
     let hostLossReported = false;
     let remountInProgress = false;
+    let controlOverlayVisible = true;
 
     const ui = await createShadowRootUi(ctx, {
       name: "browser-skill-overlay",
@@ -90,6 +92,8 @@ export default defineContentScript({
       },
     });
 
+    controlOverlayVisible = await getControlOverlayVisible();
+
     function renderOverlay() {
       const overlayState = overlays.snapshot();
       reactRoot?.render(
@@ -103,7 +107,7 @@ export default defineContentScript({
               requests: overlayState.borrowRequests,
             }),
             React.createElement(ControlOverlay, {
-              visible: shouldShowAgentControlOverlay(overlayState),
+              visible: shouldShowAgentControlOverlay(overlayState) && controlOverlayVisible,
               interrupting: overlayState.interrupting,
               automationBypass: overlayState.automationBypassCount > 0,
               onInterrupt: handleInterrupt,
@@ -375,8 +379,19 @@ export default defineContentScript({
       if (event.persisted) void syncAgentOverlay();
     };
 
+    const onStorageChanged = (
+      changes: Record<string, chrome.storage.StorageChange>,
+      area: string,
+    ) => {
+      if (area === "local" && changes[STORAGE_KEYS.CONTROL_OVERLAY_VISIBLE]) {
+        controlOverlayVisible = changes[STORAGE_KEYS.CONTROL_OVERLAY_VISIBLE].newValue ?? true;
+        renderOverlay();
+      }
+    };
+
     ui.mount();
     chrome.runtime.onMessage.addListener(onMessage);
+    chrome.storage.onChanged.addListener(onStorageChanged);
     void syncAgentOverlay();
 
     window.addEventListener("pageshow", onPageShow);
@@ -404,6 +419,7 @@ export default defineContentScript({
     ctx.onInvalidated(() => {
       hostObserver.disconnect();
       chrome.runtime.onMessage.removeListener(onMessage);
+      chrome.storage.onChanged.removeListener(onStorageChanged);
       window.removeEventListener("pageshow", onPageShow);
       // Restore history hooks / remove capture listeners before the CS unloads.
       recordCapture?.dispose();

--- a/apps/extension/src/entrypoints/popup/App.test.tsx
+++ b/apps/extension/src/entrypoints/popup/App.test.tsx
@@ -243,4 +243,11 @@ describe("App", () => {
     expect(copyButton.getAttribute("disabled")).not.toBeNull();
     expect(screen.getByText("连接后可用")).toBeTruthy();
   });
+
+  it("renders the control overlay toggle with switch semantics", () => {
+    render(<App />);
+
+    const toggle = screen.getByRole("switch", { name: "显示 Agent 控制状态" });
+    expect(toggle.getAttribute("aria-checked")).toBe("true");
+  });
 });

--- a/apps/extension/src/entrypoints/popup/App.tsx
+++ b/apps/extension/src/entrypoints/popup/App.tsx
@@ -12,6 +12,10 @@ import { PROTOCOL_VERSION } from "@/transport/handshake";
 import { ConnectionStatusIndicator } from "./connection-status-indicator";
 import { POPUP_FEATURES, type PopupView } from "./features";
 import { type PopupStatusState, useConnectionState } from "./use-connection-state";
+import {
+  getControlOverlayVisible,
+  setControlOverlayVisible,
+} from "@/lib/instance-id";
 
 const STATE_LABEL_KEYS = {
   disconnected: "popup.stateLabel.disconnected",
@@ -45,6 +49,11 @@ export function App() {
   // auto-hide timer restarts) even when the copied content is unchanged.
   const [copiedTick, setCopiedTick] = useState(0);
   const showCopiedToast = copiedTick > 0;
+  const [controlOverlayVisible, setControlOverlayVisibleState] = useState(true);
+
+  useEffect(() => {
+    void getControlOverlayVisible().then(setControlOverlayVisibleState);
+  }, []);
 
   useEffect(() => {
     const query = window.matchMedia("(prefers-color-scheme: dark)");
@@ -208,6 +217,35 @@ export function App() {
                   />
                 </button>
               </div>
+            </div>
+            <div className="mt-2 flex items-center justify-between gap-2">
+              <span className="text-xs text-muted-foreground">
+                {t("popup.controlOverlayToggleTitle")}
+              </span>
+              <button
+                type="button"
+                role="switch"
+                aria-checked={controlOverlayVisible}
+                aria-label={t("popup.controlOverlayToggleTitle")}
+                data-slot="popup-control-overlay-toggle"
+                className={cn(
+                  "relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50",
+                  controlOverlayVisible ? "bg-primary" : "bg-muted",
+                )}
+                onClick={() => {
+                  const next = !controlOverlayVisible;
+                  setControlOverlayVisibleState(next);
+                  void setControlOverlayVisible(next);
+                }}
+              >
+                <span
+                  className={cn(
+                    "pointer-events-none block size-4 rounded-full bg-background shadow-sm transition-transform",
+                    controlOverlayVisible ? "translate-x-4" : "translate-x-0.5",
+                  )}
+                  aria-hidden
+                />
+              </button>
             </div>
             {isSkewed && (
               <p

--- a/apps/extension/src/entrypoints/popup/App.tsx
+++ b/apps/extension/src/entrypoints/popup/App.tsx
@@ -8,14 +8,11 @@ import {
   RiFileCopyLine,
 } from "@remixicon/react";
 import { type ChangeEvent, useEffect, useState } from "react";
+import { getControlOverlayVisible, setControlOverlayVisible } from "@/lib/instance-id";
 import { PROTOCOL_VERSION } from "@/transport/handshake";
 import { ConnectionStatusIndicator } from "./connection-status-indicator";
 import { POPUP_FEATURES, type PopupView } from "./features";
 import { type PopupStatusState, useConnectionState } from "./use-connection-state";
-import {
-  getControlOverlayVisible,
-  setControlOverlayVisible,
-} from "@/lib/instance-id";
 
 const STATE_LABEL_KEYS = {
   disconnected: "popup.stateLabel.disconnected",

--- a/apps/extension/src/entrypoints/popup/App.tsx
+++ b/apps/extension/src/entrypoints/popup/App.tsx
@@ -49,7 +49,9 @@ export function App() {
   const [controlOverlayVisible, setControlOverlayVisibleState] = useState(true);
 
   useEffect(() => {
-    getControlOverlayVisible().then(setControlOverlayVisibleState).catch(() => {});
+    getControlOverlayVisible()
+      .then(setControlOverlayVisibleState)
+      .catch(() => {});
   }, []);
 
   useEffect(() => {

--- a/apps/extension/src/entrypoints/popup/App.tsx
+++ b/apps/extension/src/entrypoints/popup/App.tsx
@@ -49,7 +49,7 @@ export function App() {
   const [controlOverlayVisible, setControlOverlayVisibleState] = useState(true);
 
   useEffect(() => {
-    void getControlOverlayVisible().then(setControlOverlayVisibleState);
+    getControlOverlayVisible().then(setControlOverlayVisibleState).catch(() => {});
   }, []);
 
   useEffect(() => {

--- a/apps/extension/src/lib/instance-id.ts
+++ b/apps/extension/src/lib/instance-id.ts
@@ -1,6 +1,7 @@
 const STORAGE_KEY = "bsk_instance_id";
 const LABEL_STORAGE_KEY = "bh_label";
 const CONNECTION_ENABLED_KEY = "bh_connection_enabled";
+const CONTROL_OVERLAY_VISIBLE_KEY = "bh_control_overlay_visible";
 
 export interface StorageBackend {
   get(keys: string | string[]): Promise<Record<string, unknown>>;
@@ -105,8 +106,25 @@ export async function setConnectionEnabled(
   await storage.set({ [CONNECTION_ENABLED_KEY]: enabled });
 }
 
+/** Defaults to visible when unset or non-boolean. */
+export async function getControlOverlayVisible(
+  storage: StorageBackend = defaultStorage(),
+): Promise<boolean> {
+  const items = await storage.get(CONTROL_OVERLAY_VISIBLE_KEY);
+  const raw = items[CONTROL_OVERLAY_VISIBLE_KEY];
+  return typeof raw === "boolean" ? raw : true;
+}
+
+export async function setControlOverlayVisible(
+  visible: boolean,
+  storage: StorageBackend = defaultStorage(),
+): Promise<void> {
+  await storage.set({ [CONTROL_OVERLAY_VISIBLE_KEY]: visible });
+}
+
 export const STORAGE_KEYS = {
   INSTANCE_ID: STORAGE_KEY,
   LABEL: LABEL_STORAGE_KEY,
   CONNECTION_ENABLED: CONNECTION_ENABLED_KEY,
+  CONTROL_OVERLAY_VISIBLE: CONTROL_OVERLAY_VISIBLE_KEY,
 } as const;

--- a/packages/i18n/src/locales/en-US/extension.json
+++ b/packages/i18n/src/locales/en-US/extension.json
@@ -23,6 +23,7 @@
       "disabled": "Off"
     },
     "connectionToggleTitle": "BrowserSkill connection",
+    "controlOverlayToggleTitle": "Show agent control status",
     "versionSkewWarning": "Extension protocol v{{extensionProtocol}}, daemon v{{daemonProtocol}}.",
     "upgradeAvailable": "Upgradable",
     "launcher": {

--- a/packages/i18n/src/locales/zh-CN/extension.json
+++ b/packages/i18n/src/locales/zh-CN/extension.json
@@ -23,6 +23,7 @@
       "disabled": "Off"
     },
     "connectionToggleTitle": "BrowserSkill 连接",
+    "controlOverlayToggleTitle": "显示 Agent 控制状态",
     "versionSkewWarning": "扩展协议 v{{extensionProtocol}}，daemon 协议 v{{daemonProtocol}}。",
     "upgradeAvailable": "可升级",
     "launcher": {


### PR DESCRIPTION
- 在 popup 界面添加控制覆盖层可见性开关组件
- 实现控制覆盖层可见性状态的本地存储管理
- 在 content script 中集成控制覆盖层可见性逻辑
- 添加存储变化监听器以同步控制覆盖层状态
- 更新国际化资源文件添加相关翻译
- 实现控制覆盖层可见性默认值处理机制
- 相关issue https://github.com/Tencent/BrowserSkill/issues/46
- 相关反馈
<img width="1015" height="410" alt="image" src="https://github.com/user-attachments/assets/f253d4a2-47d9-4b90-acea-46ac6b4a6f4f" />
