### PR TITLE
Make the recording overlay draggable to avoid obstructing page controls

### DIFF
--- a/apps/extension/src/content/RecordOverlay.tsx
+++ b/apps/extension/src/content/RecordOverlay.tsx
@@ -1,6 +1,12 @@
 import { useTranslation } from "@browser-skill/i18n/react";
-import { RiStopCircleLine } from "@remixicon/react";
-import { useEffect, useState } from "react";
+import { RiDragMove2Line, RiStopCircleLine } from "@remixicon/react";
+import {
+  type PointerEvent as ReactPointerEvent,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 
 export interface RecordRequestData {
   id: string;
@@ -11,9 +17,42 @@ type Props = {
   request: RecordRequestData | null;
 };
 
+const VIEWPORT_MARGIN = 16;
+const FALLBACK_PILL_WIDTH = 360;
+const FALLBACK_PILL_HEIGHT = 54;
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+function clampDragPos(
+  top: number,
+  left: number,
+  pillWidth: number,
+  pillHeight: number,
+): { top: number; left: number } {
+  const maxLeft = window.innerWidth - pillWidth - VIEWPORT_MARGIN;
+  const maxTop = window.innerHeight - pillHeight - VIEWPORT_MARGIN;
+  return {
+    top: clamp(top, VIEWPORT_MARGIN, Math.max(VIEWPORT_MARGIN, maxTop)),
+    left: clamp(left, VIEWPORT_MARGIN, Math.max(VIEWPORT_MARGIN, maxLeft)),
+  };
+}
+
 export function RecordOverlay({ request }: Props) {
   const { t } = useTranslation("extension");
   const [show, setShow] = useState(false);
+  const [dragPos, setDragPos] = useState<{ top: number; left: number } | null>(null);
+  const [dragging, setDragging] = useState(false);
+  const pillRef = useRef<HTMLDivElement>(null);
+  const dragStartRef = useRef<{
+    pointerX: number;
+    pointerY: number;
+    originLeft: number;
+    originTop: number;
+    pillWidth: number;
+    pillHeight: number;
+  } | null>(null);
 
   useEffect(() => {
     if (request) {
@@ -22,6 +61,58 @@ export function RecordOverlay({ request }: Props) {
     }
     setShow(false);
   }, [request]);
+
+  useEffect(() => {
+    setDragPos(null);
+    setDragging(false);
+    dragStartRef.current = null;
+  }, [request?.id]);
+
+  const onDragHandlePointerDown = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
+    if (event.button !== 0) return;
+    const pill = pillRef.current;
+    if (!pill) return;
+    const rect = pill.getBoundingClientRect();
+    dragStartRef.current = {
+      pointerX: event.clientX,
+      pointerY: event.clientY,
+      originLeft: rect.left,
+      originTop: rect.top,
+      pillWidth: pill.offsetWidth || rect.width || FALLBACK_PILL_WIDTH,
+      pillHeight: pill.offsetHeight || rect.height || FALLBACK_PILL_HEIGHT,
+    };
+    setDragPos({ top: rect.top, left: rect.left });
+    setDragging(true);
+    event.preventDefault();
+  }, []);
+
+  useEffect(() => {
+    if (!dragging) return;
+    const onMove = (event: PointerEvent) => {
+      const start = dragStartRef.current;
+      if (!start) return;
+      setDragPos(
+        clampDragPos(
+          start.originTop + event.clientY - start.pointerY,
+          start.originLeft + event.clientX - start.pointerX,
+          start.pillWidth,
+          start.pillHeight,
+        ),
+      );
+    };
+    const onUp = () => {
+      setDragging(false);
+      dragStartRef.current = null;
+    };
+    window.addEventListener("pointermove", onMove);
+    window.addEventListener("pointerup", onUp);
+    window.addEventListener("pointercancel", onUp);
+    return () => {
+      window.removeEventListener("pointermove", onMove);
+      window.removeEventListener("pointerup", onUp);
+      window.removeEventListener("pointercancel", onUp);
+    };
+  }, [dragging]);
 
   if (!request) return null;
 
@@ -35,11 +126,14 @@ export function RecordOverlay({ request }: Props) {
       `}</style>
 
       <div
+        ref={pillRef}
         data-slot="record-overlay-pill"
+        data-dragging={dragging ? "true" : "false"}
         style={{
           position: "fixed",
-          bottom: 32,
-          left: "50%",
+          top: dragPos?.top,
+          bottom: dragPos ? "auto" : 32,
+          left: dragPos?.left ?? "50%",
           zIndex: 2147483647,
           pointerEvents: "auto",
           display: "flex",
@@ -50,13 +144,40 @@ export function RecordOverlay({ request }: Props) {
           padding: "10px 10px 10px 20px",
           boxShadow: "0 8px 32px rgba(15,23,42,0.16), 0 2px 8px rgba(0,0,0,0.1)",
           opacity: show ? 1 : 0,
-          transform: show ? "translateX(-50%) translateY(0)" : "translateX(-50%) translateY(8px)",
-          transition: "opacity 300ms ease-out, transform 300ms ease-out",
+          transform: dragPos
+            ? show
+              ? "none"
+              : "translateY(8px)"
+            : show
+              ? "translateX(-50%) translateY(0)"
+              : "translateX(-50%) translateY(8px)",
+          transition: dragging ? "none" : "opacity 300ms ease-out, transform 300ms ease-out",
           fontFamily:
             '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif',
           maxWidth: "min(420px, calc(100vw - 32px))",
         }}
       >
+        <div
+          data-slot="record-overlay-drag-handle"
+          role="img"
+          aria-label={t("recordOverlay.dragHandle")}
+          onPointerDown={onDragHandlePointerDown}
+          style={{
+            pointerEvents: "auto",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            flexShrink: 0,
+            marginLeft: -8,
+            padding: 4,
+            color: dragging ? "#4b5563" : "#9ca3af",
+            cursor: dragging ? "grabbing" : "grab",
+            touchAction: "none",
+            userSelect: "none",
+          }}
+        >
+          <RiDragMove2Line size={18} aria-hidden />
+        </div>
         <span
           data-slot="record-overlay-indicator"
           style={{

--- a/apps/extension/src/content/__tests__/RecordOverlay.test.tsx
+++ b/apps/extension/src/content/__tests__/RecordOverlay.test.tsx
@@ -26,6 +26,85 @@ describe("RecordOverlay", () => {
     expect(onFinish).toHaveBeenCalledTimes(1);
   });
 
+  it("moves the pill by its drag handle", () => {
+    const { container } = render(<RecordOverlay request={{ id: "rec-1", onFinish: vi.fn() }} />);
+    const pill = container.querySelector("[data-slot='record-overlay-pill']") as HTMLElement;
+    const handle = container.querySelector(
+      "[data-slot='record-overlay-drag-handle']",
+    ) as HTMLElement;
+    pill.getBoundingClientRect = () =>
+      ({
+        top: 500,
+        left: 300,
+        width: 360,
+        height: 54,
+        right: 660,
+        bottom: 554,
+      }) as DOMRect;
+    Object.defineProperty(pill, "offsetWidth", { value: 360, configurable: true });
+    Object.defineProperty(pill, "offsetHeight", { value: 54, configurable: true });
+
+    fireEvent.pointerDown(handle, { button: 0, clientX: 320, clientY: 520, pointerId: 1 });
+    fireEvent(window, new PointerEvent("pointermove", { clientX: 420, clientY: 470 }));
+    fireEvent(window, new PointerEvent("pointerup", { pointerId: 1 }));
+
+    expect(pill.style.top).toBe("450px");
+    expect(pill.style.left).toBe("400px");
+    expect(pill.style.bottom).toBe("auto");
+    expect(pill.getAttribute("data-dragging")).toBe("false");
+  });
+
+  it("clamps dragging to the viewport", () => {
+    const originalInnerWidth = window.innerWidth;
+    const originalInnerHeight = window.innerHeight;
+    Object.defineProperty(window, "innerWidth", { value: 800, configurable: true });
+    Object.defineProperty(window, "innerHeight", { value: 600, configurable: true });
+    const { container } = render(<RecordOverlay request={{ id: "rec-1", onFinish: vi.fn() }} />);
+    const pill = container.querySelector("[data-slot='record-overlay-pill']") as HTMLElement;
+    const handle = container.querySelector(
+      "[data-slot='record-overlay-drag-handle']",
+    ) as HTMLElement;
+    pill.getBoundingClientRect = () =>
+      ({
+        top: 100,
+        left: 100,
+        width: 300,
+        height: 60,
+        right: 400,
+        bottom: 160,
+      }) as DOMRect;
+    Object.defineProperty(pill, "offsetWidth", { value: 300, configurable: true });
+    Object.defineProperty(pill, "offsetHeight", { value: 60, configurable: true });
+
+    fireEvent.pointerDown(handle, { button: 0, clientX: 110, clientY: 110, pointerId: 1 });
+    fireEvent(window, new PointerEvent("pointermove", { clientX: 2000, clientY: 2000 }));
+    fireEvent(window, new PointerEvent("pointerup", { pointerId: 1 }));
+
+    expect(pill.style.top).toBe("524px");
+    expect(pill.style.left).toBe("484px");
+    Object.defineProperty(window, "innerWidth", {
+      value: originalInnerWidth,
+      configurable: true,
+    });
+    Object.defineProperty(window, "innerHeight", {
+      value: originalInnerHeight,
+      configurable: true,
+    });
+  });
+
+  it("keeps the finish button independent from dragging", () => {
+    const onFinish = vi.fn();
+    const { container } = render(<RecordOverlay request={{ id: "rec-1", onFinish }} />);
+    const pill = container.querySelector("[data-slot='record-overlay-pill']") as HTMLElement;
+    const finish = container.querySelector("[data-slot='record-overlay-finish']") as HTMLElement;
+
+    fireEvent.pointerDown(finish, { button: 0, clientX: 10, clientY: 10, pointerId: 1 });
+    fireEvent.click(finish);
+
+    expect(pill.getAttribute("data-dragging")).toBe("false");
+    expect(onFinish).toHaveBeenCalledTimes(1);
+  });
+
   it("shows a pulsing recording indicator and no full-screen glow layer", () => {
     const { container } = render(<RecordOverlay request={{ id: "rec-1", onFinish: vi.fn() }} />);
     expect(container.querySelector("[data-slot='record-overlay']")).toBeNull();

--- a/packages/i18n/src/locales/en-US/extension.json
+++ b/packages/i18n/src/locales/en-US/extension.json
@@ -86,6 +86,7 @@
   },
   "recordOverlay": {
     "recording": "Recording your actions",
-    "finish": "Finish"
+    "finish": "Finish",
+    "dragHandle": "Drag to move"
   }
 }

--- a/packages/i18n/src/locales/zh-CN/extension.json
+++ b/packages/i18n/src/locales/zh-CN/extension.json
@@ -86,6 +86,7 @@
   },
   "recordOverlay": {
     "recording": "正在录制用户操作",
-    "finish": "结束"
+    "finish": "结束",
+    "dragHandle": "拖动以移动"
   }
 }


### PR DESCRIPTION
## Problem

During `bsk record`, the recording status pill is fixed at the bottom center of the viewport. It can cover page controls in the same position and prevent users from interacting with them while recording.

## Solution

- Add a dedicated drag handle to the recording status pill.
- Use pointer events so the overlay can be moved with a mouse or touch input.
- Keep the overlay within the visible viewport while dragging.
- Reset the overlay to its default position for each new recording.
- Keep the Finish button independent from the drag interaction.
- Add localized drag-handle labels for English and Chinese.
- Add regression tests for dragging, viewport boundaries, and the Finish button.

## Testing

- [x] `pnpm --filter @browser-skill/extension compile`
- [x] `pnpm --filter @browser-skill/extension test`
- [x] `pnpm ext:build`
- [x] Biome check on all changed files
- [x] Manually tested the unpacked extension in Chrome
- [x] Verified that the recording pill can be moved away from a covered page control
- [x] Verified that page controls and the Finish button remain functional


## Screenshots

### Drag handle

The recording overlay now provides a dedicated drag handle.

<img width="354" height="108" alt="img_v3_02142_827eab4b-4b2a-4706-9b5e-10b9f843d84g" src="https://github.com/user-attachments/assets/84717ed0-8428-4831-a8be-b799438c0a27" />


### Overlay moved away from the page control

The overlay can be repositioned to reveal and interact with controls that were previously obscured.

<img width="384" height="167" alt="img_v3_02142_9619de48-6f55-4761-982d-e894421d2d3g" src="https://github.com/user-attachments/assets/3cade261-8106-4375-8def-be44bf4c2d27" />


Fixes #48