### PR TITLE
feat(request-help): add BSK_REQUEST_HELP=off to disable blocking help requests

### DIFF
--- a/apps/extension/src/transport/types.ts
+++ b/apps/extension/src/transport/types.ts
@@ -518,7 +518,7 @@ export interface HelpTarget {
   selector?: string;
 }
 
-export type HelpOutcome = "continued" | "cancelled" | "timed_out" | "completed" | "navigated";
+export type HelpOutcome = "continued" | "cancelled" | "timed_out" | "completed" | "navigated" | "disabled";
 
 export interface HelpCompletionCondition {
   url_contains?: string;

--- a/apps/extension/src/transport/types.ts
+++ b/apps/extension/src/transport/types.ts
@@ -518,7 +518,13 @@ export interface HelpTarget {
   selector?: string;
 }
 
-export type HelpOutcome = "continued" | "cancelled" | "timed_out" | "completed" | "navigated" | "disabled";
+export type HelpOutcome =
+  | "continued"
+  | "cancelled"
+  | "timed_out"
+  | "completed"
+  | "navigated"
+  | "disabled";
 
 export interface HelpCompletionCondition {
   url_contains?: string;

--- a/crates/bsk-cli/skill/SKILL.md
+++ b/crates/bsk-cli/skill/SKILL.md
@@ -220,15 +220,10 @@ control. After a `continued` or `completed` result, issue a separate
 observation tool call (usually `bsk snapshot --session <id>`) before using
 new refs or reasoning about the post-help page state.
 #### Disabling request-help (unattended mode)
-Set `BSK_REQUEST_HELP=off` to disable `bsk request-help` entirely. This is
-meant for unattended / background-server deployments where a blocking
-human-in-the-loop overlay must never appear. When disabled, the call
-returns immediately with `outcome="disabled"`: no overlay is shown, nothing
-waits, and the command still exits 0. The variable is unset or holds any
-other value by default, which keeps request-help enabled.
-If you receive `outcome="disabled"`, do **not** retry `request-help` —
-nobody will ever answer it. Complete the task autonomously instead, or
-terminate gracefully when the step genuinely requires a human.
+Set `BSK_REQUEST_HELP=off` on unattended servers: `bsk request-help` then
+returns immediately with `outcome="disabled"` (no overlay, no waiting,
+exit 0). Any other value keeps it enabled. If you get `disabled`, do not
+retry — complete the task autonomously or stop gracefully.
 
 ### Recording — `bsk record`
 

--- a/crates/bsk-cli/skill/SKILL.md
+++ b/crates/bsk-cli/skill/SKILL.md
@@ -219,6 +219,16 @@ which refs/selectors matched a live element.
 control. After a `continued` or `completed` result, issue a separate
 observation tool call (usually `bsk snapshot --session <id>`) before using
 new refs or reasoning about the post-help page state.
+#### Disabling request-help (unattended mode)
+Set `BSK_REQUEST_HELP=off` to disable `bsk request-help` entirely. This is
+meant for unattended / background-server deployments where a blocking
+human-in-the-loop overlay must never appear. When disabled, the call
+returns immediately with `outcome="disabled"`: no overlay is shown, nothing
+waits, and the command still exits 0. The variable is unset or holds any
+other value by default, which keeps request-help enabled.
+If you receive `outcome="disabled"`, do **not** retry `request-help` —
+nobody will ever answer it. Complete the task autonomously instead, or
+terminate gracefully when the step genuinely requires a human.
 
 ### Recording — `bsk record`
 

--- a/crates/bsk-cli/src/cli/human_loop.rs
+++ b/crates/bsk-cli/src/cli/human_loop.rs
@@ -8,13 +8,38 @@ use std::time::Duration;
 use anyhow::Context;
 use bsk_protocol::Method;
 use bsk_protocol::tools::{
-    HelpCompletionCriteria, HelpTarget, RequestHelpParams, RequestHelpResult,
+    HelpCompletionCriteria, HelpOutcome, HelpTarget, RequestHelpParams, RequestHelpResult,
 };
 use clap::Args;
 
 use crate::cli::ensure_daemon::ensure_daemon;
 use crate::cli::error::{CliError, Format};
 use crate::cli::navigate::parse_timeout_ms;
+
+/// Environment variable that disables the blocking `request-help`
+/// human-in-loop tool, for unattended / background-server deployments
+/// where a blocking help overlay must never appear.
+pub(crate) const REQUEST_HELP_ENV: &str = "BSK_REQUEST_HELP";
+
+/// Note attached to the synthetic result returned when request-help is
+/// disabled, so the agent knows why no overlay was shown.
+pub(crate) const REQUEST_HELP_DISABLED_NOTE: &str =
+    "request-help disabled by BSK_REQUEST_HELP=off (unattended mode)";
+
+/// Whether `request-help` is disabled via [`REQUEST_HELP_ENV`]. Only the
+/// value `off` (case-insensitive, surrounding whitespace ignored)
+/// disables it; unset or any other value keeps the default enabled
+/// behaviour.
+pub(crate) fn request_help_disabled() -> bool {
+    is_off_value(std::env::var(REQUEST_HELP_ENV).ok().as_deref())
+}
+
+/// Pure value check behind [`request_help_disabled`], kept separate so it
+/// can be unit-tested without touching process env (parallel tests race
+/// on `std::env::set_var`, which is also `unsafe` in edition 2024).
+fn is_off_value(value: Option<&str>) -> bool {
+    value.is_some_and(|v| v.trim().eq_ignore_ascii_case("off"))
+}
 
 #[derive(Debug, Clone, Args)]
 pub struct RequestHelpArgs {
@@ -72,6 +97,18 @@ pub fn parse_target(raw: &str) -> HelpTarget {
 }
 
 pub fn dispatch(args: RequestHelpArgs, format: Format) -> Result<(), CliError> {
+    // Disabled (`BSK_REQUEST_HELP=off`): return a synthetic `disabled`
+    // result immediately — no daemon startup, no overlay, no waiting.
+    if request_help_disabled() {
+        let result = RequestHelpResult {
+            outcome: HelpOutcome::Disabled,
+            completed_by: None,
+            note: Some(REQUEST_HELP_DISABLED_NOTE.into()),
+            tab_id: args.tab_id.unwrap_or(0),
+            resolved_targets: None,
+        };
+        return render(&result, format);
+    }
     let info = ensure_daemon().context("ensure daemon is running")?;
     let targets: Vec<HelpTarget> = args.target.iter().map(|t| parse_target(t)).collect();
     let completion_criteria = args
@@ -155,5 +192,20 @@ mod tests {
         // `email` starts with `e` but is not `e<digits>` → selector.
         assert_eq!(parse_target("email").selector.as_deref(), Some("email"));
         assert!(parse_target("#login").ref_.is_none());
+    }
+
+    #[test]
+    fn off_value_detection() {
+        assert!(is_off_value(Some("off")));
+        assert!(is_off_value(Some("OFF")));
+        assert!(is_off_value(Some("Off")));
+        assert!(is_off_value(Some("  off  ")));
+        assert!(is_off_value(Some("\toff\n")));
+        assert!(!is_off_value(None));
+        assert!(!is_off_value(Some("")));
+        assert!(!is_off_value(Some("on")));
+        assert!(!is_off_value(Some("0")));
+        assert!(!is_off_value(Some("offx")));
+        assert!(!is_off_value(Some("of f")));
     }
 }

--- a/crates/bsk-cli/src/daemon/ipc.rs
+++ b/crates/bsk-cli/src/daemon/ipc.rs
@@ -26,7 +26,9 @@ use bsk_protocol::system::{
     BrowserListParams, BrowserStatusEntry, SessionStatusEntry, StatusParams, StatusResult,
     VersionSkewEntry,
 };
-use bsk_protocol::tools::{ReturnFailure, WaitMsParams, WaitMsResult};
+use bsk_protocol::tools::{
+    HelpOutcome, RequestHelpResult, ReturnFailure, WaitMsParams, WaitMsResult,
+};
 use bsk_protocol::{
     CancelParams, CancelResult, ErrorCode, Method, PingResult, ResponseBody, RpcError, RpcId,
 };
@@ -280,6 +282,19 @@ async fn handle_tool_dispatch(
     method: Method,
     params: Value,
 ) -> ResponseBody {
+    // `BSK_REQUEST_HELP=off` (unattended mode): never forward the
+    // blocking human-in-loop call to the extension; answer immediately
+    // with a synthetic `disabled` result.
+    if method == Method::ToolRequestHelp && crate::cli::human_loop::request_help_disabled() {
+        let result = RequestHelpResult {
+            outcome: HelpOutcome::Disabled,
+            completed_by: None,
+            note: Some(crate::cli::human_loop::REQUEST_HELP_DISABLED_NOTE.into()),
+            tab_id: params.get("tab_id").and_then(Value::as_i64).unwrap_or(0),
+            resolved_targets: None,
+        };
+        return ResponseBody::Ok(serde_json::to_value(result).unwrap_or(Value::Null));
+    }
     let session_id = match params.get("session_id").and_then(|v| v.as_str()) {
         Some(s) if !s.is_empty() => SessionId(s.to_string()),
         _ => {

--- a/crates/bsk-protocol/schema/tool_request_help_result.json
+++ b/crates/bsk-protocol/schema/tool_request_help_result.json
@@ -83,6 +83,13 @@
           "enum": [
             "navigated"
           ]
+        },
+        {
+          "description": "request-help is disabled by configuration (`BSK_REQUEST_HELP=off`): the call returns immediately without ever showing the overlay.",
+          "type": "string",
+          "enum": [
+            "disabled"
+          ]
         }
       ]
     },

--- a/crates/bsk-protocol/src/tools/human_loop.rs
+++ b/crates/bsk-protocol/src/tools/human_loop.rs
@@ -95,6 +95,9 @@ pub enum HelpOutcome {
     /// The page navigated while waiting (full reload or SPA URL change).
     /// Deprecated: navigation alone should not end a help request.
     Navigated,
+    /// request-help is disabled by configuration (`BSK_REQUEST_HELP=off`):
+    /// the call returns immediately without ever showing the overlay.
+    Disabled,
 }
 
 impl HelpOutcome {
@@ -105,6 +108,7 @@ impl HelpOutcome {
             Self::TimedOut => "timed_out",
             Self::Completed => "completed",
             Self::Navigated => "navigated",
+            Self::Disabled => "disabled",
         }
     }
 }
@@ -201,6 +205,10 @@ mod tests {
         assert_eq!(
             serde_json::to_value(HelpOutcome::Navigated).unwrap(),
             json!("navigated")
+        );
+        assert_eq!(
+            serde_json::to_value(HelpOutcome::Disabled).unwrap(),
+            json!("disabled")
         );
     }
 

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -220,15 +220,10 @@ control. After a `continued` or `completed` result, issue a separate
 observation tool call (usually `bsk snapshot --session <id>`) before using
 new refs or reasoning about the post-help page state.
 #### Disabling request-help (unattended mode)
-Set `BSK_REQUEST_HELP=off` to disable `bsk request-help` entirely. This is
-meant for unattended / background-server deployments where a blocking
-human-in-the-loop overlay must never appear. When disabled, the call
-returns immediately with `outcome="disabled"`: no overlay is shown, nothing
-waits, and the command still exits 0. The variable is unset or holds any
-other value by default, which keeps request-help enabled.
-If you receive `outcome="disabled"`, do **not** retry `request-help` —
-nobody will ever answer it. Complete the task autonomously instead, or
-terminate gracefully when the step genuinely requires a human.
+Set `BSK_REQUEST_HELP=off` on unattended servers: `bsk request-help` then
+returns immediately with `outcome="disabled"` (no overlay, no waiting,
+exit 0). Any other value keeps it enabled. If you get `disabled`, do not
+retry — complete the task autonomously or stop gracefully.
 
 ### Recording — `bsk record`
 

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -219,6 +219,16 @@ which refs/selectors matched a live element.
 control. After a `continued` or `completed` result, issue a separate
 observation tool call (usually `bsk snapshot --session <id>`) before using
 new refs or reasoning about the post-help page state.
+#### Disabling request-help (unattended mode)
+Set `BSK_REQUEST_HELP=off` to disable `bsk request-help` entirely. This is
+meant for unattended / background-server deployments where a blocking
+human-in-the-loop overlay must never appear. When disabled, the call
+returns immediately with `outcome="disabled"`: no overlay is shown, nothing
+waits, and the command still exits 0. The variable is unset or holds any
+other value by default, which keeps request-help enabled.
+If you receive `outcome="disabled"`, do **not** retry `request-help` —
+nobody will ever answer it. Complete the task autonomously instead, or
+terminate gracefully when the step genuinely requires a human.
 
 ### Recording — `bsk record`
 


### PR DESCRIPTION
## Motivation

`bsk request-help` is a blocking human-in-the-loop command: it brings the tab to the foreground, shows the help overlay, and waits until the user acts or the call times out (default 5m). On unattended / background-server deployments there is no human around, and a blocking help prompt must never appear — but today there is no way to turn the command off.

## What changes

New environment variable **`BSK_REQUEST_HELP`**:

- `BSK_REQUEST_HELP=off` (case-insensitive, surrounding whitespace ignored) disables `request-help`.
- Unset or any other value keeps the current default behaviour (enabled).

When disabled, `bsk request-help` returns immediately — no daemon startup, no overlay, no waiting — with a synthetic structured result and exit code 0:

```json
{ "outcome": "disabled", "note": "request-help disabled by BSK_REQUEST_HELP=off (unattended mode)", "tab_id": 0 }
```

The agent therefore gets a normal, machine-readable result instead of an error and can react deliberately (the skill docs now tell agents not to retry `request-help` after a `disabled` outcome, and to continue autonomously or stop gracefully).

## Implementation

- `bsk-protocol`: new `HelpOutcome::Disabled` variant (`"disabled"`) + regenerated `tool_request_help_result.json` schema.
- CLI (`human_loop.rs`): `dispatch()` short-circuits before `ensure_daemon()` when disabled; the `off` value parsing lives in a pure, unit-tested helper.
- Daemon (`ipc.rs`): `handle_tool_dispatch` refuses to forward `tool.request_help` to the extension when disabled and answers with the same synthetic result, so non-CLI IPC callers are covered too.
- Extension `transport/types.ts`: `HelpOutcome` union gains `"disabled"` (no behaviour change — the daemon never forwards the call when disabled).
- Docs: both `skill/SKILL.md` copies document the variable's purpose (unattended mode), its exact behaviour, and the agent guidance above.

## Tests

- `cargo fmt --all`, `cargo clippy -p bsk-protocol -p bsk --all-targets -- -D warnings`: clean.
- `cargo test -p bsk-protocol`: 104 passed.
- `cargo test -p bsk`: all green except one pre-existing, environment-dependent failure in `skill_install::sync::tests::sync_continues_on_partial_error` (also fails on a clean tree in this environment; unrelated to this change).
- New unit tests cover the `off` value detection and `disabled` outcome serialization.