### PR TITLE
chore(release): bsk 0.1.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,7 +134,7 @@ dependencies = [
 
 [[package]]
 name = "bsk"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "anyhow",
  "bsk-protocol",
@@ -168,7 +168,7 @@ dependencies = [
 
 [[package]]
 name = "bsk-protocol"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "schemars",
  "semver",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 default-members = ["crates/bsk-cli"]
 
 [workspace.package]
-version = "0.1.9"
+version = "0.1.10"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT"


### PR DESCRIPTION
Bump workspace version 0.1.9 → 0.1.10 (Cargo.toml + Cargo.lock entries for bsk and bsk-protocol). After merge, tag this commit as `cli-v0.1.10` to trigger the CLI release workflow.

Changes since 0.1.9: #52 Agent Window sizing, #53 BSK_REQUEST_HELP=off, #59 install-skill --all fix, #60 mobile emulation, #64 screenshot overlay exclusion, #65 Kimi Code harness.