### PR TITLE
chore(release): extension 0.1.6

### DIFF
--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@browser-skill/extension",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Bump apps/extension package.json version 0.1.5 → 0.1.6. After merge, tag as `ext-v0.1.6` to trigger the extension release workflow (zip build + GitHub Release).