### PR TITLE
docs(skill): list bsk console and bsk network in SKILL.md

### DIFF
--- a/crates/bsk-cli/skill/SKILL.md
+++ b/crates/bsk-cli/skill/SKILL.md
@@ -175,6 +175,15 @@ bsk emulate --session <id> --off
 | `bsk get-html` | Raw HTML dump after snapshot is insufficient (high token cost) |
 | `bsk screenshot` | PNG capture after snapshot is insufficient: full visible tab, or `--ref @eN` to crop to one element (`--out` path optional) |
 
+### Console & network debugging (read-only; require `--session`)
+
+| Command | Summary |
+|---------|---------|
+| `bsk console` | Buffered page console messages, JS exceptions, and browser log entries (`--include-stack` for stack traces) |
+| `bsk network` | Buffered network responses (status, method, URL, MIME/resource type) and failures (`net::ERR_*` reason) |
+
+Both capture from the moment the tab is attached and read a bounded per-tab buffer: `--since <seq>` pages from a cursor (`next_since` in the result), `--limit` (default 50, max 200), `--max-text-chars` (default 1000, max 4096), `--tab-id` to target a non-active tab. Both are strictly read-only — they never intercept or modify traffic, and request/response headers, bodies, and timings are not captured.
+
 ### Navigation
 
 | Command | Summary |

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -175,6 +175,15 @@ bsk emulate --session <id> --off
 | `bsk get-html` | Raw HTML dump after snapshot is insufficient (high token cost) |
 | `bsk screenshot` | PNG capture after snapshot is insufficient: full visible tab, or `--ref @eN` to crop to one element (`--out` path optional) |
 
+### Console & network debugging (read-only; require `--session`)
+
+| Command | Summary |
+|---------|---------|
+| `bsk console` | Buffered page console messages, JS exceptions, and browser log entries (`--include-stack` for stack traces) |
+| `bsk network` | Buffered network responses (status, method, URL, MIME/resource type) and failures (`net::ERR_*` reason) |
+
+Both capture from the moment the tab is attached and read a bounded per-tab buffer: `--since <seq>` pages from a cursor (`next_since` in the result), `--limit` (default 50, max 200), `--max-text-chars` (default 1000, max 4096), `--tab-id` to target a non-active tab. Both are strictly read-only — they never intercept or modify traffic, and request/response headers, bodies, and timings are not captured.
+
 ### Navigation
 
 | Command | Summary |


### PR DESCRIPTION
Follow-up of #7 / #8, refs #61. Supersedes #80 (auto-closed when its branch was amended).

## What
Adds a "Console & network debugging (read-only; require `--session`)" section to both `skill/SKILL.md` and `crates/bsk-cli/skill/SKILL.md` (kept byte-identical via build.rs copy):

- `bsk console`: buffered console messages / JS exceptions / browser log entries (`--include-stack` for stacks)
- `bsk network`: buffered responses (status/method/URL/MIME/resource type) and failures (`net::ERR_*` reasons)
- Shared pagination params: `--since` (use `next_since` cursor), `--limit` (default 50, max 200), `--max-text-chars` (default 1000, max 4096), `--tab-id`
- Explicit read-only boundary: no interception, no traffic modification, no headers/body/timing capture

Docs only, no code changes.