### PR TITLE
fix(daemon): use hash-only Windows named-pipe name

### DIFF
--- a/crates/bsk-cli/src/daemon/paths.rs
+++ b/crates/bsk-cli/src/daemon/paths.rs
@@ -103,19 +103,34 @@ pub fn record_session_path() -> Result<PathBuf> {
 /// Windows named-pipe name. Include the resolved `BSK_HOME` path in the
 /// token so test homes and custom installs do not share a predictable
 /// per-username pipe.
+///
+/// The name is hash-only (`bsk-daemon-<hex>`): the hash already covers
+/// user + home, so uniqueness and per-user isolation are unchanged, and
+/// the pipe name never contains raw username characters. Usernames with
+/// apostrophes/spaces/non-ASCII characters (e.g. `z'z'f'l'g'y`) make
+/// NPFS misbehave — `CreateNamedPipeW` reports success yet clients get
+/// `ERROR_FILE_NOT_FOUND` opening the very same name (issue #75).
 #[cfg(windows)]
 pub fn pipe_name() -> String {
-    use std::collections::hash_map::DefaultHasher;
-    use std::hash::{Hash, Hasher};
-
     let user = env::var("USERNAME").unwrap_or_else(|_| "default".to_string());
     let home = bsk_home()
         .map(|path| path.to_string_lossy().into_owned())
         .unwrap_or_else(|_| "unknown-home".to_string());
+    render_pipe_name(&user, &home)
+}
+
+/// Render the Windows named-pipe name for a user/home pair. Kept
+/// platform-agnostic so unit tests on any host can pin the output
+/// character set.
+#[cfg(any(windows, test))]
+fn render_pipe_name(user: &str, home: &str) -> String {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+
     let mut hasher = DefaultHasher::new();
     user.hash(&mut hasher);
     home.hash(&mut hasher);
-    format!(r"\\.\pipe\bsk-daemon-{user}-{:016x}", hasher.finish())
+    format!(r"\\.\pipe\bsk-daemon-{:016x}", hasher.finish())
 }
 
 #[cfg(test)]
@@ -173,5 +188,39 @@ mod tests {
                 home.join("record-session.json")
             );
         });
+    }
+
+    /// Issue #75: usernames with apostrophes/spaces/non-ASCII characters
+    /// must not leak into the pipe name — NPFS misbehaves on such names
+    /// (CreateNamedPipeW succeeds, yet clients opening the same name get
+    /// ERROR_FILE_NOT_FOUND). The name must be hash-only.
+    #[test]
+    fn pipe_name_uses_safe_charset_for_special_usernames() {
+        for user in ["z'z'f'l'g'y", "user name", "用户", "a\"b\\c", "plain"] {
+            let name = render_pipe_name(user, r"C:\Users\whatever\.bsk");
+            let suffix = name
+                .strip_prefix(r"\\.\pipe\bsk-daemon-")
+                .unwrap_or_else(|| panic!("unexpected pipe name shape: {name}"));
+            assert_eq!(
+                suffix.len(),
+                16,
+                "pipe name {name} must carry a 16-hex-char hash"
+            );
+            assert!(
+                suffix.chars().all(|c| c.is_ascii_hexdigit()),
+                "pipe name {name} must be hash-only (did user {user:?} leak?)"
+            );
+        }
+    }
+
+    /// The hash-only name stays unique per (user, home) and deterministic
+    /// across calls (daemon and CLI exchange it via daemon.json, but a
+    /// stable value keeps logs/diagnostics comparable).
+    #[test]
+    fn pipe_name_is_deterministic_and_scoped() {
+        let a = render_pipe_name("alice", r"C:\Users\alice\.bsk");
+        assert_eq!(a, render_pipe_name("alice", r"C:\Users\alice\.bsk"));
+        assert_ne!(a, render_pipe_name("bob", r"C:\Users\alice\.bsk"));
+        assert_ne!(a, render_pipe_name("alice", r"D:\alt-home\.bsk"));
     }
 }


### PR DESCRIPTION
## Motivation

Fixes #75 — on Windows machines whose username contains an apostrophe (e.g. `z'z'f'l'g'y`), the CLI can never reach the daemon over its named-pipe IPC. The daemon logs that it is listening on `\\.\pipe\bsk-daemon-z'z'f'l'g'y-<hash>`, yet every client `CreateFileW` on that exact name fails with `ERROR_FILE_NOT_FOUND` / `ERROR_PATH_NOT_FOUND`.

## Root cause

`crates/bsk-cli/src/daemon/paths.rs` embedded `%USERNAME%` verbatim in the pipe name (`\\.\pipe\bsk-daemon-{user}-{hash}`). Although Microsoft documentation says any character except backslash is legal in a pipe name, NPFS behaviour for such names diverges in practice between create and open: `CreateNamedPipeW` succeeds while clients opening the same name get FILE_NOT_FOUND. Both sides were verified to use byte-identical names (the CLI reads the name from `daemon.json`, never recomputes it), so the divergence sits at the Win32/NPFS boundary with the raw special characters.

## Changes

- The pipe name is now **hash-only**: `\\.\pipe\bsk-daemon-{hash}`. The hash already covers `user + bsk_home`, so uniqueness and per-user / per-`BSK_HOME` isolation are exactly as before — but no raw username characters (apostrophes, spaces, non-ASCII) ever reach NPFS.
- The pure name-rendering is factored into a `render_pipe_name(user, home)` helper so its output charset is unit-testable on any host.
- New unit tests: safe-charset assertion for usernames with apostrophes/spaces/Unicode/backslashes, plus determinism and per-(user, home) uniqueness.

## Backward compatibility

The pipe name is exchanged exclusively through `daemon.json` (written by the daemon, read by the CLI — the CLI never computes `pipe_name()` itself; verified there are only two call sites, both inside the daemon process). So any old/new CLI↔daemon combination keeps working: whichever side runs the new code simply writes/reads a different name string.

## Other username-in-name sites

Grepped the whole CLI/protocol crates for `%USERNAME%`, `USER`, `LOGNAME`, `whoami`, `user*name`: this was the only place embedding the OS username into an IPC/filesystem name. Unix socket paths live under `$HOME/.bsk/run/` where apostrophes are legal path characters, so no change needed there.

## Test plan

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked` (new `daemon::paths` tests included)
- CI has only Ubuntu runners; the NPFS behaviour itself can only be exercised on Windows. The fix is verified by unit tests pinning the output charset plus the code-path analysis above — a confirmation from the issue reporter on a real affected machine would be appreciated.