### PR TITLE
fix(record): preserve committed empty fill steps

### DIFF
--- a/apps/extension/src/lib/__tests__/trace-reducer.test.ts
+++ b/apps/extension/src/lib/__tests__/trace-reducer.test.ts
@@ -104,6 +104,27 @@ describe("reduceTraceSteps", () => {
     });
   });
 
+  it("keeps committed empty fill steps", () => {
+    const { steps } = reduceTraceSteps(
+      [
+        {
+          op: "fill",
+          target: { tag: "input", role: "textbox", name: "Search query" },
+          value: "",
+          page_url: "https://example.com/search",
+        },
+      ],
+      "https://example.com/search",
+    );
+
+    expect(steps).toEqual([
+      expect.objectContaining({
+        op: "fill",
+        value: "",
+      }),
+    ]);
+  });
+
   it("maps select navigated_to onto effect.navigated_to (page id)", () => {
     const { pages, steps } = reduceTraceSteps(
       [

--- a/apps/extension/src/lib/trace-reducer.ts
+++ b/apps/extension/src/lib/trace-reducer.ts
@@ -18,7 +18,6 @@ export function shouldRecordPress(
 }
 
 function shouldIncludeDraft(step: DraftTraceStep): boolean {
-  if (step.op === "fill" && !(step.value ?? "").trim() && !step.redacted) return false;
   if (step.op === "press" && !shouldRecordPress(step.key, step.modifiers)) return false;
   return true;
 }


### PR DESCRIPTION
## Summary
- preserve committed empty fill steps in exported recording traces
- add a regression test for intentionally cleared input values

Closes #58

## Test plan
- [x] `pnpm ext:test` (648 tests)
- [x] `pnpm --filter @browser-skill/extension compile`
- [x] `pnpm lint`

Made with [Cursor](https://cursor.com)