### PR TITLE
Fix/dsh plugin id and edge store

### DIFF
--- a/.github/workflows/release-dsh-plugin.yml
+++ b/.github/workflows/release-dsh-plugin.yml
@@ -66,8 +66,8 @@ jobs:
   publish:
     needs: [resolve, guard]
     runs-on: ubuntu-latest
-    # Secret NPM_TOKEN is stored on the GitHub Environment also named NPM_TOKEN.
-    environment: NPM_TOKEN
+    # Secret NPM_TOKEN is stored on the "npm-publish" GitHub Environment.
+    environment: npm-publish
     permissions:
       contents: read
     steps:

--- a/AGENT_INSTALL.md
+++ b/AGENT_INSTALL.md
@@ -34,13 +34,17 @@ where only `extension connected` fails is expected; go to Step 3.
 ## 3. Open the extension install page
 
 If `extension connected` is `FAIL` (`0 browsers connected`), the user likely
-has not installed or enabled the browser extension yet. Open the
-[Chrome Web Store install page](https://chromewebstore.google.com/detail/hhcmgoofomhgciiibhipgmgkgnoenaoi)
-in the user's browser, then tell the user:
+has not installed or enabled the browser extension yet. Open the install page
+matching the user's browser —
+[Chrome Web Store](https://chromewebstore.google.com/detail/hhcmgoofomhgciiibhipgmgkgnoenaoi)
+for Chrome and other Chromium browsers,
+[Edge Add-ons](https://microsoftedge.microsoft.com/addons/detail/browserskill/emacgiaaaiojkkpkddmmdfhmokgmnikg)
+for Microsoft Edge — then tell the user:
 
 > Install **BrowserSkill** from the
-> [Chrome Web Store](https://chromewebstore.google.com/detail/hhcmgoofomhgciiibhipgmgkgnoenaoi),
-> open the popup, and wait until it turns green. Reply when done.
+> [Chrome Web Store](https://chromewebstore.google.com/detail/hhcmgoofomhgciiibhipgmgkgnoenaoi)
+> (or [Edge Add-ons](https://microsoftedge.microsoft.com/addons/detail/browserskill/emacgiaaaiojkkpkddmmdfhmokgmnikg)
+> on Edge), open the popup, and wait until it turns green. Reply when done.
 
 If opening the page fails, give the user the same link. Then run `bsk doctor`
 once more. All `ok`/`na` → tell the user it's ready.

--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ Set up browser-skill on this machine by following https://raw.githubusercontent.
 
 <br>
 
-Install the CLI, then install the extension from the [Chrome Web Store](https://chromewebstore.google.com/detail/hhcmgoofomhgciiibhipgmgkgnoenaoi).
+Install the CLI, then install the extension from the [Chrome Web Store](https://chromewebstore.google.com/detail/hhcmgoofomhgciiibhipgmgkgnoenaoi)
+or [Edge Add-ons](https://microsoftedge.microsoft.com/addons/detail/browserskill/emacgiaaaiojkkpkddmmdfhmokgmnikg).
 
 #### 1. Install the `bsk` CLI
 
@@ -91,7 +92,14 @@ bsk --version
 
 #### 2. Install the browser extension
 
-Install BrowserSkill from the [Chrome Web Store](https://chromewebstore.google.com/detail/hhcmgoofomhgciiibhipgmgkgnoenaoi).
+Install BrowserSkill from your browser's store:
+
+| Browser | Store listing |
+| --- | --- |
+| Chrome | [Chrome Web Store](https://chromewebstore.google.com/detail/hhcmgoofomhgciiibhipgmgkgnoenaoi) |
+| Microsoft Edge | [Edge Add-ons](https://microsoftedge.microsoft.com/addons/detail/browserskill/emacgiaaaiojkkpkddmmdfhmokgmnikg) |
+
+On other Chromium-based browsers, install the Chrome Web Store build.
 
 #### 3. Install the skill
 
@@ -136,13 +144,23 @@ Start a new Agent session and write a prompt that needs the browser, for example
 
 ## DeepSeek Harness plugin
 
-A [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) plugin that
-injects native `browser_*` tools (no shelling out to `bsk`) and a live Web UI
+Using [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) (`dsh`)?
+BrowserSkill ships a first-class dsh plugin on npm as
+[`@wxg-prc-cpg/browser-skill-dsh-plugin`](https://www.npmjs.com/package/@wxg-prc-cpg/browser-skill-dsh-plugin).
+It injects native `browser_*` tools (no shelling out to `bsk`) and a live Web UI
 overlay of each Agent Window.
+
+Add it to a dsh profile, then start that profile:
 
 ```sh
 dsh plugin --profile web add @wxg-prc-cpg/browser-skill-dsh-plugin
+dsh --profile web
 ```
+
+The plugin carries its own copy of the skill, so `bsk install-skill` is not needed
+for dsh — but the `bsk` CLI and the browser extension are still prerequisites. See
+the [plugin README](packages/dsh-plugin-browserskill/README.md) for the tool list,
+configuration, and the observation overlay.
 
 ## How It Works
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -54,7 +54,8 @@ BrowserSkill 由两个本地运行组件组成：`bsk` CLI/daemon 和浏览器�
 
 <br>
 
-先安装 CLI，再从 [Chrome Web Store](https://chromewebstore.google.com/detail/hhcmgoofomhgciiibhipgmgkgnoenaoi) 安装浏览器扩展。
+先安装 CLI，再从 [Chrome Web Store](https://chromewebstore.google.com/detail/hhcmgoofomhgciiibhipgmgkgnoenaoi)
+或 [Edge 加载项商店](https://microsoftedge.microsoft.com/addons/detail/browserskill/emacgiaaaiojkkpkddmmdfhmokgmnikg) 安装浏览器扩展。
 
 #### 1. 安装 `bsk` CLI
 
@@ -64,8 +65,11 @@ BrowserSkill 由两个本地运行组件组成：`bsk` CLI/daemon 和浏览器�
 curl -fsSL https://raw.githubusercontent.com/Tencent/BrowserSkill/main/install.sh | sh
 ```
 
-**Windows**：从 [最新 CLI release](https://github.com/Tencent/BrowserSkill/releases/latest)
-下载 `bsk-v<version>-x86_64-pc-windows-msvc.zip`，解压后将 `bsk.exe` 加入 `PATH`。
+**Windows**（PowerShell，安装到 `~/.local/bin`）：
+
+```powershell
+irm https://raw.githubusercontent.com/Tencent/BrowserSkill/main/install.ps1 | iex
+```
 
 验证二进制：
 
@@ -75,7 +79,14 @@ bsk --version
 
 #### 2. 安装浏览器扩展
 
-从 [Chrome Web Store](https://chromewebstore.google.com/detail/hhcmgoofomhgciiibhipgmgkgnoenaoi) 安装 BrowserSkill。
+在对应浏览器的商店安装 BrowserSkill：
+
+| 浏览器 | 商店页面 |
+| --- | --- |
+| Chrome | [Chrome Web Store](https://chromewebstore.google.com/detail/hhcmgoofomhgciiibhipgmgkgnoenaoi) |
+| Microsoft Edge | [Edge 加载项商店](https://microsoftedge.microsoft.com/addons/detail/browserskill/emacgiaaaiojkkpkddmmdfhmokgmnikg) |
+
+其他基于 Chromium 的浏览器，安装 Chrome Web Store 版本即可。
 
 #### 3. 安装 skill
 
@@ -114,11 +125,16 @@ bsk install-skill
 
 ## DeepSeek Harness 插件
 
-[DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) 插件：注入原生 `browser_*` 工具（无需再通过 Shell 调用 `bsk`），并在 Web UI 中实时观察每个 Agent Window。
+在用 [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)（`dsh`）？BrowserSkill 提供了官方 dsh 插件，已发布到 npm：[`@wxg-prc-cpg/browser-skill-dsh-plugin`](https://www.npmjs.com/package/@wxg-prc-cpg/browser-skill-dsh-plugin)。它会注入原生 `browser_*` 工具（无需再通过 Shell 调用 `bsk`），并在 Web UI 中实时观察每个 Agent Window。
+
+把它装进某个 dsh profile，然后启动该 profile：
 
 ```sh
 dsh plugin --profile web add @wxg-prc-cpg/browser-skill-dsh-plugin
+dsh --profile web
 ```
+
+插件自带 skill，所以在 dsh 下无需执行 `bsk install-skill`；但 `bsk` CLI 和浏览器扩展仍是前置条件。工具清单、配置项与观察浮层见[插件 README](packages/dsh-plugin-browserskill/README.md)。
 
 ## 工作原理
 

--- a/apps/extension/src/tools/__tests__/borrow-confirmation.test.ts
+++ b/apps/extension/src/tools/__tests__/borrow-confirmation.test.ts
@@ -612,4 +612,14 @@ describe("isInjectableContentScriptUrl", () => {
     ).toBe(false);
     expect(isInjectableContentScriptUrl("https://chromewebstore.google.com/")).toBe(false);
   });
+
+  it("rejects the Edge Add-ons store", () => {
+    expect(
+      isInjectableContentScriptUrl(
+        "https://microsoftedge.microsoft.com/addons/detail/browserskill/emacgiaaaiojkkpkddmmdfhmokgmnikg",
+      ),
+    ).toBe(false);
+    // Non-store paths on the same host stay injectable.
+    expect(isInjectableContentScriptUrl("https://microsoftedge.microsoft.com/")).toBe(true);
+  });
 });

--- a/apps/extension/src/tools/borrow-confirmation.ts
+++ b/apps/extension/src/tools/borrow-confirmation.ts
@@ -250,9 +250,10 @@ const DEFAULT_NOTIFICATION_COPY: BorrowNotificationCopy = {
 // URL injection-eligibility test
 // ---------------------------------------------------------------------------
 
-const CHROME_WEB_STORE_RES = [
+const EXTENSION_STORE_RES = [
   /^https:\/\/chrome\.google\.com\/webstore/i,
   /^https:\/\/chromewebstore\.google\.com/i,
+  /^https:\/\/microsoftedge\.microsoft\.com\/addons/i,
 ];
 
 /**
@@ -264,14 +265,15 @@ const CHROME_WEB_STORE_RES = [
  *   - `ftp://` no longer hosts content scripts reliably in modern Chrome.
  *   - `about:` / `chrome:` / `chrome-extension:` / `edge:` / `devtools:` /
  *     `view-source:` / `data:` / `blob:` are blocked by the platform.
- *   - The Chrome Web Store (both legacy and new domains) is also blocked.
+ *   - Extension storefronts are blocked by their own browser: the Chrome Web
+ *     Store (legacy and new domains) under Chrome, and Edge Add-ons under Edge.
  *
  * Mirrors the implicit scheme list documented in
  * https://developer.chrome.com/docs/extensions/develop/concepts/match-patterns.
  */
 export function isInjectableContentScriptUrl(url: string | undefined): boolean {
   if (!url) return false;
-  for (const re of CHROME_WEB_STORE_RES) {
+  for (const re of EXTENSION_STORE_RES) {
     if (re.test(url)) return false;
   }
   return /^https?:\/\//i.test(url);

--- a/crates/bsk-cli/src/cli/doctor.rs
+++ b/crates/bsk-cli/src/cli/doctor.rs
@@ -18,6 +18,12 @@ use crate::daemon::state::PROTOCOL_VERSION;
 const EXTENSION_STORE_URL: &str =
     "https://chromewebstore.google.com/detail/hhcmgoofomhgciiibhipgmgkgnoenaoi";
 
+/// Edge Add-ons listing for the browser-skill extension.
+const EXTENSION_STORE_URL_EDGE: &str = "https://microsoftedge.microsoft.com/addons/detail/browserskill/emacgiaaaiojkkpkddmmdfhmokgmnikg";
+
+/// Store listings highlighted in repair hints, in the order they appear.
+const EXTENSION_STORE_URLS: [&str; 2] = [EXTENSION_STORE_URL, EXTENSION_STORE_URL_EDGE];
+
 /// Status of a single doctor check. `Ok` / `Fail` are the legacy two
 /// states; `NotApplicable` (review M2) is reported as "N/A" in human
 /// output and as `"status": "na"` in `--json` output, so a check that
@@ -420,7 +426,10 @@ fn check_extension_connected(status: Option<&StatusResult>) -> CheckResult {
         CheckResult::fail(
             name,
             "0 browsers connected",
-            format!("install the extension from {EXTENSION_STORE_URL} and load it in Chromium"),
+            format!(
+                "install the extension from {EXTENSION_STORE_URL} (Chrome) \
+                 or {EXTENSION_STORE_URL_EDGE} (Edge) and load it in the browser"
+            ),
         )
     }
 }
@@ -428,17 +437,14 @@ fn check_extension_connected(status: Option<&StatusResult>) -> CheckResult {
 /// Highlight known URLs in repair hints for terminal output. Plain
 /// text is preserved in `--json` and in stored [`CheckResult::hint`].
 fn style_hint(hint: &str) -> String {
-    if !hint.contains(EXTENSION_STORE_URL) {
-        return hint.to_string();
+    let mut styled = hint.to_string();
+    for url in EXTENSION_STORE_URLS {
+        if !styled.contains(url) {
+            continue;
+        }
+        styled = styled.replace(url, &style(url).cyan().bold().underlined().to_string());
     }
-    hint.replace(
-        EXTENSION_STORE_URL,
-        &style(EXTENSION_STORE_URL)
-            .cyan()
-            .bold()
-            .underlined()
-            .to_string(),
-    )
+    styled
 }
 
 fn render_human(checks: &[CheckResult]) {
@@ -504,6 +510,26 @@ mod m2_tests {
             hint.contains(EXTENSION_STORE_URL),
             "hint should include Chrome Web Store URL: {hint}"
         );
+        assert!(
+            hint.contains(EXTENSION_STORE_URL_EDGE),
+            "hint should include Edge Add-ons URL: {hint}"
+        );
+    }
+
+    #[test]
+    fn style_hint_preserves_every_store_url() {
+        let hint = check_extension_connected(Some(&fake_status(Vec::new(), Vec::new())))
+            .hint
+            .expect("extension disconnected should include a hint");
+        let styled = style_hint(&hint);
+        // Whether or not the terminal accepts colors, styling must never drop or
+        // mangle a URL the user has to click.
+        for url in EXTENSION_STORE_URLS {
+            assert!(
+                styled.contains(url),
+                "styled hint should still contain {url}: {styled}"
+            );
+        }
     }
 
     #[test]

--- a/packages/dsh-plugin-browserskill/README.md
+++ b/packages/dsh-plugin-browserskill/README.md
@@ -187,8 +187,8 @@ git tag dsh-plugin-v0.1.0
 git push origin dsh-plugin-v0.1.0
 ```
 
-Or run the workflow from the Actions tab (`workflow_dispatch`). The job reads
-`NPM_TOKEN` from the GitHub Environment of the same name.
+Or run the workflow from the Actions tab (`workflow_dispatch`). The job reads the
+`NPM_TOKEN` secret from the `npm-publish` GitHub Environment.
 
 ## License
 

--- a/packages/dsh-plugin-browserskill/README.md
+++ b/packages/dsh-plugin-browserskill/README.md
@@ -6,7 +6,7 @@ A [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) (dsh) tool
 [BrowserSkill](https://github.com/Tencent/BrowserSkill) (`bsk`) browser automation to the model.
 
 Each tool maps to one `bsk <cmd> --json` invocation: the plugin spawns the bsk CLI, parses its
-structured JSON output, and returns a canonical typed value. The bsk daemon, browser, and Chrome
+structured JSON output, and returns a canonical typed value. The bsk daemon, browser, and browser
 extension keep owning the actual browser control — this package is a thin, well-typed bridge.
 
 ## Tools
@@ -64,9 +64,10 @@ dsh plugin --profile <name> add @wxg-prc-cpg/browser-skill-dsh-plugin
 dsh --profile <name>
 ```
 
-Prerequisite: the `bsk` CLI must be installed and on `PATH`, and the BrowserSkill Chrome extension
-must be connected — see the [BrowserSkill README](https://github.com/Tencent/BrowserSkill). When bsk
-is missing, tool calls fail with install guidance instead of a bare spawn error.
+Prerequisite: the `bsk` CLI must be installed and on `PATH`, and the BrowserSkill browser extension
+(Chrome or Edge) must be connected — see the
+[BrowserSkill README](https://github.com/Tencent/BrowserSkill). When bsk is missing, tool calls fail
+with install guidance instead of a bare spawn error.
 
 ## Configuration
 

--- a/packages/dsh-plugin-browserskill/README.md
+++ b/packages/dsh-plugin-browserskill/README.md
@@ -77,7 +77,7 @@ All fields are optional and validated through the plugin's Schemastery `Config`:
 # cordis.patch.yml override example
 - insert:
     - id: browserskill
-      name: dsh-plugin-browserskill
+      name: "@wxg-prc-cpg/browser-skill-dsh-plugin"
       config:
         bskPath: bsk          # path to the bsk binary (default: resolve from PATH)
         defaultTimeoutMs: 120000

--- a/packages/dsh-plugin-browserskill/cordis.patch.yml
+++ b/packages/dsh-plugin-browserskill/cordis.patch.yml
@@ -1,3 +1,5 @@
 - insert:
     - id: browserskill
-      name: dsh-plugin-browserskill
+      # Must be the published package name — the loader imports this specifier.
+      # Quoted because YAML reserves a leading '@' in plain scalars.
+      name: "@wxg-prc-cpg/browser-skill-dsh-plugin"

--- a/packages/dsh-plugin-browserskill/package.json
+++ b/packages/dsh-plugin-browserskill/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wxg-prc-cpg/browser-skill-dsh-plugin",
   "description": "DeepSeek Harness tool plugin that exposes BrowserSkill (bsk) browser automation to the model",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "license": "MIT",
   "publishConfig": {
     "access": "public",

--- a/packages/dsh-plugin-browserskill/tsdown.config.ts
+++ b/packages/dsh-plugin-browserskill/tsdown.config.ts
@@ -2,6 +2,7 @@ import { readFile } from "node:fs/promises";
 import { basename, dirname, resolve as resolvePath } from "node:path";
 import { transform } from "lightningcss";
 import { defineConfig, type UserConfig } from "tsdown";
+import pkg from "./package.json" with { type: "json" };
 
 /**
  * Two build faces of the dual-face package:
@@ -33,7 +34,10 @@ const VENDORED_LIBRARY = /^@deepseek-ai\/(cosmokit|schemastery)(\/|$)/;
 
 const CSS_VIRTUAL_PREFIX = "\0bsk-css:";
 const CSS_VIRTUAL_SUFFIX = ".mjs";
-const CLIENT_ID = "dsh-plugin-browserskill";
+// The web shell resolves client bundles from its module table by package name
+// (dsh's own bundles register the same way), so this must never drift from
+// package.json.
+const CLIENT_ID = pkg.name;
 
 const client: UserConfig = {
   name: `${CLIENT_ID}/client`,


### PR DESCRIPTION
本 PR 包含三块相互独立的改动，对应三个 commit。

### 现有问题

**1. 已发布的 dsh 插件使用问题。** 包名从 `dsh-plugin-browserskill` 改成 `@wxg-prc-cpg/browser-skill-dsh-plugin` 时，有两个"按名字解析"的标识符没跟着改：

- `cordis.patch.yml` 里的 `name` 是 loader 直接 import 的 specifier，所以 dsh 启动时报 `ERR_MODULE_NOT_FOUND`，并且连带整个插件树加载失败、进程退出。也就是说 npm 上的 0.1.0 装了之后 dsh 直接起不来。
- client bundle 通过 `window.__ModuleLoader__.load({ id })` 注册，而 Web shell 是按包名去 module table 取的（dsh 自己的 bundle 也是这么注册的，可对照 `@deepseek-ai/dsh-client-runtime` 的产物）。所以即使主体能加载，`browser_screenshot` 的 toolview 和观察浮层也取不到。
 
 关联issue：https://github.com/Tencent/BrowserSkill/issues/111

**2. 扩展已上架 Edge 加载项商店，目前安装路径只指向 Chrome Web Store。** 除文档外还有两处代码只认 Chrome：`bsk doctor` 在"0 browsers connected"时只给 Chrome 链接；借用标签页的确认浮层只把 Chrome Web Store 域名视为不可注入，而 Edge 同样禁止在自家商店页面注入 content script，导致 Edge 用户正停在商店页时确认浮层会静默失败。

**3. 之前发布用的 GitHub Environment 名字是 secret 名。** publish job 的 `environment` 写成了 `NPM_TOKEN`，，仓库的 Deployments 列表里因此多出一个名为 `NPM_TOKEN`  ，这个不合理。

<img width="332" height="111" alt="image" src="https://github.com/user-attachments/assets/b2e121e4-3de2-4932-b1a4-e1deee67c9fc" />

### 解决方案

**插件标识（`fix(dsh-plugin-browserskill)`）**：`cordis.patch.yml` 的 `name` 改为已发布包名；client bundle id 改为直接读 `package.json`，不再重复书写包名，避免再次漂移；版本 bump 到 `0.1.1`。YAML 里必须加引号，因为 `@` 是 plain scalar 的保留起始字符，不加引号会直接解析失败。

**Edge 上架配套（`docs`）**：两个 README 和 `AGENT_INSTALL.md` 改为按浏览器列出商店；`bsk doctor` 的修复提示同时给出两个商店链接（`style_hint` 相应改为遍历链接列表，两个都会高亮）；`microsoftedge.microsoft.com/addons` 加入不可注入域名，并补了单测覆盖"商店页不可注入、同域非商店路径仍可注入"。顺带同步了中文 README 里仍在描述 `install.ps1` 之前的 Windows 手动安装步骤，并给 DeepSeek Harness 章节补上 npm 包链接和启动 profile 的步骤。

**发布流程（`ci(dsh-plugin)`）**：environment 改为 `npm-publish`，其中的 secret 仍叫 `NPM_TOKEN`。

### 验证

- `cargo fmt --check`、`cargo clippy --workspace --all-targets -- -D warnings`、`cargo test --workspace` 通过，其中 doctor 单测 9 个（含新增的 hint 保真测试）。
- 扩展 `vitest`：57 个文件 / 681 个测试通过；`tsc --noEmit` 干净。
- dsh 插件 `vitest`：11 个文件 / 130 个测试通过；`pnpm lint`（biome + stylelint + typecheck）退出码 0。
- 构建产物核对：`lib/client.cjs` 现在注册为 `id: "@wxg-prc-cpg/browser-skill-dsh-plugin"`。
- 用 YAML parser 实测确认 `cordis.patch.yml` 解析出的 `name` 为已发布包名，且不加引号会报 `Plain value cannot start with reserved character @`。

### 合并后需要的操作

1. 打 tag `dsh-plugin-v0.1.1` 触发发布（`npm-publish` 环境需已配置 `NPM_TOKEN`）。
2. 废弃有问题的 0.1.0，让已安装的用户看到升级提示：`npm deprecate @wxg-prc-cpg/browser-skill-dsh-plugin@0.1.0 "Broken plugin id in cordis.patch.yml prevents dsh from starting; upgrade to 0.1.1"`