### PR TITLE
feat(vom): support screenshot-bound point clicks on canvas surfaces | 支持基于截图坐标点击 canvas surface

### DIFF
--- a/apps/extension/src/session-manager/__tests__/surface-capture-store.test.ts
+++ b/apps/extension/src/session-manager/__tests__/surface-capture-store.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { type SurfaceCaptureInput, SurfaceCaptureStore } from "../surface-capture-store";
+
+function input(): SurfaceCaptureInput {
+  return {
+    sessionId: "aa11",
+    tabId: 7,
+    navigationIdentity: "navigation",
+    surface: {
+      ref: "e3",
+      frameId: "main",
+      backendNodeId: 99,
+      observationGeneration: 2,
+    },
+    topViewportRect: { x: 10, y: 20, w: 100, h: 50 },
+    imageWidth: 200,
+    imageHeight: 100,
+    viewportSignature: "viewport",
+    frameProjectionSignature: "frame",
+  };
+}
+
+describe("SurfaceCaptureStore", () => {
+  it("creates metadata-only, short-lived captures and consumes them once", () => {
+    let now = 1_000;
+    const store = new SurfaceCaptureStore({
+      now: () => now,
+      ttlMs: 500,
+      createId: () => "sc_test",
+    });
+    const capture = store.create(input());
+
+    expect(capture).toMatchObject({
+      id: "sc_test",
+      createdAt: 1_000,
+      expiresAt: 1_500,
+      consumed: false,
+    });
+    expect(capture).not.toHaveProperty("imageBase64");
+    expect(store.consume("sc_test")).toMatchObject({ ok: true });
+    expect(store.consume("sc_test")).toEqual({ ok: false, reason: "consumed" });
+
+    now = 1_600;
+    expect(store.size()).toBe(0);
+  });
+
+  it("rejects expired and unknown captures", () => {
+    let now = 1_000;
+    const store = new SurfaceCaptureStore({
+      now: () => now,
+      ttlMs: 10,
+      createId: () => "sc_expired",
+    });
+    store.create(input());
+    now = 1_010;
+
+    expect(store.consume("sc_expired")).toEqual({ ok: false, reason: "expired" });
+    expect(store.consume("sc_missing")).toEqual({ ok: false, reason: "not_found" });
+  });
+
+  it("clears every capture on session cleanup", () => {
+    const store = new SurfaceCaptureStore({ createId: () => "sc_clear" });
+    store.create(input());
+    store.clear();
+    expect(store.size()).toBe(0);
+  });
+});

--- a/apps/extension/src/session-manager/manager.ts
+++ b/apps/extension/src/session-manager/manager.ts
@@ -1,10 +1,12 @@
 import { AGENT_WINDOW_HOME, type AgentWindowApi, chromeAgentWindowApi } from "./agent-window";
 import { RefStore } from "./ref-store";
+import { SurfaceCaptureStore } from "./surface-capture-store";
 
 export interface SessionContext {
   sessionId: string;
   agentWindowId: number;
   refStore: RefStore;
+  surfaceCaptures: SurfaceCaptureStore;
   borrowedTabs: Map<number, BorrowedTab>;
   /**
    * Tabs explicitly claimed by the agent because it created them. This
@@ -210,6 +212,7 @@ export class SessionManager {
         sessionId,
         agentWindowId: windowId,
         refStore: new RefStore(),
+        surfaceCaptures: new SurfaceCaptureStore({ now: this.now }),
         borrowedTabs: new Map(),
         // The home tab is the session's first explicit claim. Every other
         // tab remains free until `tab_create` or `tab_borrow` identifies it

--- a/apps/extension/src/session-manager/surface-capture-store.ts
+++ b/apps/extension/src/session-manager/surface-capture-store.ts
@@ -1,0 +1,100 @@
+import type { Rect } from "@browser-skill/vom";
+
+export const SURFACE_CAPTURE_TTL_MS = 30_000;
+
+export interface SurfaceCapture {
+  id: string;
+  sessionId: string;
+  tabId: number;
+  navigationIdentity: string;
+  surface: {
+    ref: string;
+    frameId?: string;
+    backendNodeId: number;
+    observationGeneration: number;
+  };
+  topViewportRect: Rect;
+  imageWidth: number;
+  imageHeight: number;
+  viewportSignature: string;
+  frameProjectionSignature: string;
+  createdAt: number;
+  expiresAt: number;
+  consumed: boolean;
+}
+
+export type SurfaceCaptureInput = Omit<
+  SurfaceCapture,
+  "id" | "createdAt" | "expiresAt" | "consumed"
+>;
+
+export type SurfaceCaptureConsumeResult =
+  | { ok: true; capture: SurfaceCapture }
+  | { ok: false; reason: "not_found" | "expired" | "consumed" };
+
+export interface SurfaceCaptureStoreOptions {
+  now?: () => number;
+  ttlMs?: number;
+  createId?: () => string;
+}
+
+function randomCaptureId(): string {
+  const bytes = crypto.getRandomValues(new Uint8Array(12));
+  return `sc_${Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("")}`;
+}
+
+/** Per-session, metadata-only store for short-lived screenshot coordinate transactions. */
+export class SurfaceCaptureStore {
+  private readonly captures = new Map<string, SurfaceCapture>();
+  private readonly now: () => number;
+  private readonly ttlMs: number;
+  private readonly createId: () => string;
+
+  constructor(options: SurfaceCaptureStoreOptions = {}) {
+    this.now = options.now ?? Date.now;
+    this.ttlMs = options.ttlMs ?? SURFACE_CAPTURE_TTL_MS;
+    this.createId = options.createId ?? randomCaptureId;
+  }
+
+  create(input: SurfaceCaptureInput): SurfaceCapture {
+    this.purgeExpired();
+    const createdAt = this.now();
+    const capture: SurfaceCapture = {
+      ...input,
+      id: this.createId(),
+      createdAt,
+      expiresAt: createdAt + this.ttlMs,
+      consumed: false,
+    };
+    this.captures.set(capture.id, capture);
+    return capture;
+  }
+
+  consume(id: string): SurfaceCaptureConsumeResult {
+    const capture = this.captures.get(id);
+    if (!capture) return { ok: false, reason: "not_found" };
+    if (capture.expiresAt <= this.now()) {
+      this.captures.delete(id);
+      return { ok: false, reason: "expired" };
+    }
+    if (capture.consumed) return { ok: false, reason: "consumed" };
+    capture.consumed = true;
+    return { ok: true, capture };
+  }
+
+  clear(): void {
+    this.captures.clear();
+  }
+
+  size(): number {
+    this.purgeExpired();
+    return this.captures.size;
+  }
+
+  private purgeExpired(): void {
+    const now = this.now();
+    for (const [id, capture] of this.captures) {
+      if (capture.expiresAt <= now) this.captures.delete(id);
+    }
+  }
+}

--- a/apps/extension/src/tools/__tests__/interaction.test.ts
+++ b/apps/extension/src/tools/__tests__/interaction.test.ts
@@ -11,6 +11,7 @@ import {
   parseKeySpec,
   resolveKeyDescriptor,
 } from "../interaction";
+import { captureSurfaceEnvironment } from "../surface-target";
 
 function fakeAgentWindow(ids: number[]) {
   let i = 0;
@@ -52,6 +53,61 @@ function makeFakeCdp(handlers: Record<string, (params: unknown) => unknown>) {
     query: vi.fn(async () => [{ id: 4, windowId: 100, active: true } as chrome.tabs.Tab]),
   };
   return { cdp, tabsApi, sent };
+}
+
+async function makeSurfaceClickFixture(onMouse?: (params: Record<string, unknown>) => void) {
+  const manager = new SessionManager({ agentWindow: fakeAgentWindow([100]) });
+  const context = await manager.start("aa11");
+  context.refStore.set("e3", 99, {
+    tabId: 4,
+    kind: "surface",
+    visibleRect: { x: 10, y: 20, w: 100, h: 40 },
+  });
+  const fake = makeFakeCdp({
+    "Page.getFrameTree": () => ({
+      frameTree: {
+        frame: { id: "main", loaderId: "loader-1", url: "https://fixture.test/" },
+      },
+    }),
+    "Page.getLayoutMetrics": () => ({
+      cssLayoutViewport: { clientWidth: 800, clientHeight: 600, pageX: 0, pageY: 0 },
+      cssVisualViewport: {
+        clientWidth: 800,
+        clientHeight: 600,
+        pageX: 0,
+        pageY: 0,
+        scale: 1,
+      },
+    }),
+    "DOM.getContentQuads": () => ({ quads: [[10, 20, 110, 20, 110, 60, 10, 60]] }),
+    "Runtime.evaluate": () => ({
+      result: { value: { overlayHostPresent: false, overlayHostConnected: false } },
+    }),
+    "Input.dispatchMouseEvent": (params) => {
+      onMouse?.(params as Record<string, unknown>);
+      return {};
+    },
+  });
+  const environment = await captureSurfaceEnvironment(fake.cdp, 4, undefined);
+  if ("code" in environment) throw new Error(environment.message);
+  const entry = context.refStore.resolveEntry("e3");
+  if (!entry) throw new Error("missing Surface ref");
+  const capture = context.surfaceCaptures.create({
+    sessionId: "aa11",
+    tabId: 4,
+    navigationIdentity: environment.navigationIdentity,
+    surface: {
+      ref: "e3",
+      backendNodeId: 99,
+      observationGeneration: entry.generation,
+    },
+    topViewportRect: { x: 10, y: 20, w: 100, h: 40 },
+    imageWidth: 200,
+    imageHeight: 80,
+    viewportSignature: environment.viewportSignature,
+    frameProjectionSignature: environment.frameProjectionSignature,
+  });
+  return { manager, context, fake, capture };
 }
 
 describe("modifiersBitfield", () => {
@@ -188,6 +244,74 @@ describe("handleClick", () => {
       button: "left",
       clickCount: 2,
     });
+  });
+
+  it.each([
+    "left",
+    "middle",
+    "right",
+  ] as const)("uses the common click executor for a %s-button Surface click", async (button) => {
+    const { manager, fake, capture } = await makeSurfaceClickFixture();
+    const result = await handleClick(
+      manager,
+      {
+        session_id: "aa11",
+        ref: "@e3",
+        capture_id: capture.id,
+        image_x: 50,
+        image_y: 20,
+        button,
+        click_count: 2,
+        modifiers: ["ctrl", "shift"],
+      },
+      { cdp: fake.cdp, tabsApi: fake.tabsApi },
+    );
+
+    if ("code" in result) throw new Error(JSON.stringify(result));
+    expect(result).toMatchObject({
+      used_ref: "e3",
+      capture_id: capture.id,
+      image_x: 50,
+      image_y: 20,
+      x: 35,
+      y: 30,
+    });
+    const mouse = fake.sent.filter((call) => call.method === "Input.dispatchMouseEvent");
+    expect(mouse).toHaveLength(3);
+    expect(mouse[1].params).toMatchObject({
+      type: "mousePressed",
+      button,
+      clickCount: 2,
+      modifiers: 2 | 8,
+    });
+    expect(mouse[2].params).toMatchObject({
+      type: "mouseReleased",
+      button,
+      clickCount: 2,
+    });
+  });
+
+  it("consumes a Surface capture when the common click executor fails", async () => {
+    let mouseCalls = 0;
+    const { manager, fake, capture } = await makeSurfaceClickFixture((params) => {
+      mouseCalls += 1;
+      if (params.type === "mousePressed") throw new Error("input failed");
+    });
+    const params = {
+      session_id: "aa11",
+      ref: "@e3",
+      capture_id: capture.id,
+      image_x: 50,
+      image_y: 20,
+    };
+
+    expect(
+      await handleClick(manager, params, { cdp: fake.cdp, tabsApi: fake.tabsApi }),
+    ).toMatchObject({ code: "cdp_failed" });
+    expect(mouseCalls).toBe(2);
+    expect(
+      await handleClick(manager, params, { cdp: fake.cdp, tabsApi: fake.tabsApi }),
+    ).toMatchObject({ data: { reason: "surface_capture_consumed" } });
   });
 
   it("resolves frame refs in their CDP session and dispatches input in top coordinates", async () => {

--- a/apps/extension/src/tools/__tests__/mouse-input.test.ts
+++ b/apps/extension/src/tools/__tests__/mouse-input.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it, vi } from "vitest";
+import { dispatchMouseClick } from "../mouse-input";
+import type { CdpRunner } from "../shared";
+
+function fakeCdp(onSend?: (method: string, params: Record<string, unknown>) => void): {
+  cdp: CdpRunner;
+  events: Record<string, unknown>[];
+} {
+  const events: Record<string, unknown>[] = [];
+  return {
+    events,
+    cdp: {
+      send: vi.fn(async (_tabId, method, params) => {
+        const event = params as Record<string, unknown>;
+        events.push(event);
+        onSend?.(method, event);
+        return {} as never;
+      }),
+    },
+  };
+}
+
+describe("dispatchMouseClick", () => {
+  it("emits one move, press, and release sequence", async () => {
+    const { cdp, events } = fakeCdp();
+
+    expect(
+      await dispatchMouseClick(
+        cdp,
+        4,
+        { x: 12, y: 34 },
+        {
+          button: "left",
+          clickCount: 1,
+          modifiers: 0,
+          moveSettleMs: 0,
+        },
+      ),
+    ).toBe("completed");
+
+    expect(events).toEqual([
+      {
+        type: "mouseMoved",
+        x: 12,
+        y: 34,
+        modifiers: 0,
+      },
+      {
+        type: "mousePressed",
+        x: 12,
+        y: 34,
+        button: "left",
+        clickCount: 1,
+        modifiers: 0,
+      },
+      {
+        type: "mouseReleased",
+        x: 12,
+        y: 34,
+        button: "left",
+        clickCount: 1,
+        modifiers: 0,
+      },
+    ]);
+  });
+
+  it("releases a pressed button when cancellation arrives", async () => {
+    const controller = new AbortController();
+    const { cdp, events } = fakeCdp((_method, event) => {
+      if (event.type === "mousePressed") controller.abort();
+    });
+
+    expect(
+      await dispatchMouseClick(
+        cdp,
+        4,
+        { x: 1, y: 2 },
+        {
+          button: "left",
+          clickCount: 1,
+          modifiers: 0,
+          signal: controller.signal,
+          moveSettleMs: 0,
+        },
+      ),
+    ).toBe("cancelled");
+    expect(events.at(-1)).toMatchObject({ type: "mouseReleased" });
+  });
+
+  it("settles pointer-move hit testing before pressing", async () => {
+    vi.useFakeTimers();
+    try {
+      const { cdp, events } = fakeCdp();
+      const click = dispatchMouseClick(
+        cdp,
+        4,
+        { x: 1, y: 2 },
+        {
+          button: "left",
+          clickCount: 1,
+          modifiers: 0,
+          moveSettleMs: 32,
+        },
+      );
+
+      await vi.advanceTimersByTimeAsync(31);
+      expect(events.map((event) => event.type)).toEqual(["mouseMoved"]);
+      await vi.advanceTimersByTimeAsync(1);
+      await click;
+      expect(events.map((event) => event.type)).toEqual([
+        "mouseMoved",
+        "mousePressed",
+        "mouseReleased",
+      ]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/apps/extension/src/tools/__tests__/observation.test.ts
+++ b/apps/extension/src/tools/__tests__/observation.test.ts
@@ -392,6 +392,7 @@ describe("handleScreenshot", () => {
     };
     expect(clip.clip).toMatchObject({ x: 25, y: 30, width: 50, height: 40 });
     expect(res).toMatchObject({ width: 100, height: 80 });
+    expect(res.capture?.id).toMatch(/^sc_/);
   });
 
   it("routes OOPIF surface geometry through its child session and captures top coordinates", async () => {

--- a/apps/extension/src/tools/__tests__/observation.test.ts
+++ b/apps/extension/src/tools/__tests__/observation.test.ts
@@ -75,6 +75,9 @@ function makeFakeCdp(handlers: Record<string, (params?: object) => unknown>) {
     if (!handler && method === "Page.getLayoutMetrics") {
       return { cssLayoutViewport: { clientWidth: 1280, clientHeight: 720 } };
     }
+    if (!handler && method === "Page.getFrameTree") {
+      return { frameTree: { frame: { id: "main", loaderId: "loader-1", url: "https://test/" } } };
+    }
     if (!handler) throw new Error(`unexpected CDP call ${method}`);
     return handler(params);
   });
@@ -357,6 +360,11 @@ describe("handleScreenshot", () => {
     };
     expect(clip.clip).toMatchObject({ width: 4096, height: 4096 });
     expect(clip.clip?.scale).toBeCloseTo(Math.sqrt(4_000_000 / (4096 * 4096)));
+    expect(res.capture).toMatchObject({
+      surface_ref: "@e5",
+      coordinate_space: "capture-image-pixel",
+    });
+    expect(ctx.surfaceCaptures.size()).toBe(1);
   });
 
   it("crops a visual surface screenshot to its observation-time visible region", async () => {

--- a/apps/extension/src/tools/__tests__/session.test.ts
+++ b/apps/extension/src/tools/__tests__/session.test.ts
@@ -278,12 +278,23 @@ describe("handleSessionStop with auto-return", () => {
     expect(aw.remove).not.toHaveBeenCalled();
   });
 
-  it("clears the RefStore before window teardown", async () => {
+  it("clears refs and Surface captures before window teardown", async () => {
     const aw = fakeAgentWindow([100]);
     const sm = new SessionManager({ agentWindow: aw });
     const ctx = await sm.start("aa11");
     // Insert a fake ref so we can verify clear() ran.
     ctx.refStore.set("e1", 123, { tabId: 7 });
+    ctx.surfaceCaptures.create({
+      sessionId: "aa11",
+      tabId: 7,
+      navigationIdentity: "navigation",
+      surface: { ref: "e1", backendNodeId: 123, observationGeneration: 0 },
+      topViewportRect: { x: 0, y: 0, w: 100, h: 50 },
+      imageWidth: 100,
+      imageHeight: 50,
+      viewportSignature: "viewport",
+      frameProjectionSignature: "frame",
+    });
     const state: FakeState = {
       tabs: new Map(),
       windowsClosed: new Set(),
@@ -292,6 +303,7 @@ describe("handleSessionStop with auto-return", () => {
     const { tabs, windows } = makeApis(state);
     await handleSessionStop(sm, { session_id: "aa11" }, { tabManagement: { tabs, windows } });
     expect(ctx.refStore.isEmpty()).toBe(true);
+    expect(ctx.surfaceCaptures.size()).toBe(0);
   });
 
   it.each([

--- a/apps/extension/src/tools/__tests__/snapshot-ref.test.ts
+++ b/apps/extension/src/tools/__tests__/snapshot-ref.test.ts
@@ -26,12 +26,14 @@ describe("lookupSnapshotRef", () => {
       refKey: "e3",
       kind: "dom",
       capabilities: ["interact", "screenshot"],
+      generation: 0,
     });
     expect(lookupSnapshotRef(ctx, "e3", 4)).toEqual({
       backendNodeId: 1234,
       refKey: "e3",
       kind: "dom",
       capabilities: ["interact", "screenshot"],
+      generation: 0,
     });
   });
 
@@ -68,6 +70,7 @@ describe("resolveSnapshotRef", () => {
       cdpSessionId: "child-session",
       kind: "dom" as const,
       capabilities: ["interact", "screenshot"] as const,
+      generation: 0,
     };
     expect(lookupSnapshotRef(ctx, "@e3", 4)).toEqual(expected);
     expect(resolveSnapshotRef(ctx, "@e3", 4)).toEqual(expected);
@@ -115,6 +118,7 @@ describe("resolveSnapshotRef", () => {
       refKey: "e3",
       kind: "dom",
       capabilities: ["interact", "screenshot"],
+      generation: 0,
     });
   });
 

--- a/apps/extension/src/tools/__tests__/surface-coordinate.test.ts
+++ b/apps/extension/src/tools/__tests__/surface-coordinate.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import {
+  mapImagePointToViewport,
+  pointInRegion,
+  sameRect,
+  surfaceVisibleRect,
+} from "../surface-coordinate";
+
+describe("surface coordinate mapping", () => {
+  it("maps capture image pixels through the actual screenshot dimensions", () => {
+    expect(mapImagePointToViewport({ x: 100, y: 50, w: 400, h: 200 }, 800, 400, 200, 100)).toEqual({
+      x: 200,
+      y: 100,
+    });
+  });
+
+  it("rejects invalid image coordinates and dimensions", () => {
+    const rect = { x: 0, y: 0, w: 100, h: 50 };
+    expect(mapImagePointToViewport(rect, 100, 50, -1, 0)).toBeNull();
+    expect(mapImagePointToViewport(rect, 100, 50, 100, 0)).toBeNull();
+    expect(mapImagePointToViewport(rect, 100, 50, 0, 50)).toBeNull();
+    expect(mapImagePointToViewport(rect, 100, 50, Number.NaN, 0)).toBeNull();
+    expect(mapImagePointToViewport(rect, 100, 50, Number.POSITIVE_INFINITY, 0)).toBeNull();
+    expect(mapImagePointToViewport(rect, 0, 50, 0, 0)).toBeNull();
+  });
+
+  it("intersects live and observed visible regions and compares them strictly", () => {
+    const clipped = surfaceVisibleRect(
+      { x: 0, y: 0, width: 200, height: 100 },
+      { x: 25, y: 30, w: 50, h: 40 },
+    );
+    expect(clipped).toEqual({ x: 25, y: 30, w: 50, h: 40 });
+    expect(sameRect(clipped as NonNullable<typeof clipped>, { x: 25, y: 30, w: 50, h: 40 })).toBe(
+      true,
+    );
+    expect(sameRect(clipped as NonNullable<typeof clipped>, { x: 26, y: 30, w: 50, h: 40 })).toBe(
+      false,
+    );
+  });
+
+  it("checks the projected visible region rather than only its bounding box", () => {
+    const triangle = [
+      [
+        { x: 0, y: 0 },
+        { x: 100, y: 0 },
+        { x: 0, y: 100 },
+      ],
+    ];
+    expect(pointInRegion({ x: 20, y: 20 }, triangle)).toBe(true);
+    expect(pointInRegion({ x: 90, y: 90 }, triangle)).toBe(false);
+  });
+});

--- a/apps/extension/src/tools/__tests__/surface-point-action.test.ts
+++ b/apps/extension/src/tools/__tests__/surface-point-action.test.ts
@@ -1,0 +1,313 @@
+import { describe, expect, it, vi } from "vitest";
+import { SessionManager } from "@/session-manager/manager";
+import type { CdpRunner } from "../shared";
+import { captureSurfaceEnvironment, handleSurfacePointClick } from "../surface-point-action";
+
+function fakeAgentWindow() {
+  return {
+    create: vi.fn(async () => 100),
+    remove: vi.fn(async () => {}),
+    ensureActiveTab: vi.fn(async () => {}),
+  };
+}
+
+function fakeBrowser() {
+  let loaderId = "loader-1";
+  let pageY = 0;
+  let quad = [10, 20, 110, 20, 110, 60, 10, 60];
+  let dispatchFails = false;
+  const sent: Array<{ method: string; params?: object }> = [];
+  const cdp: CdpRunner = {
+    send: vi.fn(async (_tabId: number, method: string, params?: object) => {
+      sent.push({ method, params });
+      if (method === "Page.getFrameTree") {
+        return {
+          frameTree: { frame: { id: "main", loaderId, url: "https://fixture.test/" } },
+        } as never;
+      }
+      if (method === "Page.getLayoutMetrics") {
+        return {
+          cssLayoutViewport: { clientWidth: 800, clientHeight: 600, pageX: 0, pageY },
+          cssVisualViewport: {
+            clientWidth: 800,
+            clientHeight: 600,
+            pageX: 0,
+            pageY,
+            scale: 1,
+          },
+        } as never;
+      }
+      if (method === "DOM.getContentQuads") return { quads: [quad] } as never;
+      if (method === "Input.dispatchMouseEvent") {
+        if (dispatchFails) throw new Error("input failed");
+        return {} as never;
+      }
+      throw new Error(`unexpected CDP call ${method}`);
+    }) as CdpRunner["send"],
+    trackSessionTab: vi.fn(),
+  };
+  const tabsApi = {
+    get: vi.fn(
+      async (tabId: number) => ({ id: tabId, windowId: 100, active: true }) as chrome.tabs.Tab,
+    ),
+    query: vi.fn(async () => [{ id: 4, windowId: 100, active: true } as chrome.tabs.Tab]),
+  };
+  return {
+    cdp,
+    tabsApi,
+    sent,
+    setLoaderId: (value: string) => {
+      loaderId = value;
+    },
+    setPageY: (value: number) => {
+      pageY = value;
+    },
+    setQuad: (value: number[]) => {
+      quad = value;
+    },
+    failDispatch: () => {
+      dispatchFails = true;
+    },
+  };
+}
+
+async function setupCapture() {
+  const manager = new SessionManager({ agentWindow: fakeAgentWindow() });
+  const context = await manager.start("aa11");
+  context.refStore.set("e3", 99, {
+    tabId: 4,
+    kind: "surface",
+    visibleRect: { x: 10, y: 20, w: 100, h: 40 },
+  });
+  const browser = fakeBrowser();
+  const environment = await captureSurfaceEnvironment(browser.cdp, 4, undefined);
+  if ("code" in environment) throw new Error(environment.message);
+  const entry = context.refStore.resolveEntry("e3");
+  if (!entry) throw new Error("missing ref");
+  const capture = context.surfaceCaptures.create({
+    sessionId: "aa11",
+    tabId: 4,
+    navigationIdentity: environment.navigationIdentity,
+    surface: {
+      ref: "e3",
+      backendNodeId: 99,
+      observationGeneration: entry.generation,
+    },
+    topViewportRect: { x: 10, y: 20, w: 100, h: 40 },
+    imageWidth: 200,
+    imageHeight: 80,
+    viewportSignature: environment.viewportSignature,
+    frameProjectionSignature: environment.frameProjectionSignature,
+  });
+  return { manager, context, browser, capture };
+}
+
+function pointParams(captureId: string) {
+  return {
+    session_id: "aa11",
+    ref: "@e3",
+    capture_id: captureId,
+    image_x: 50,
+    image_y: 20,
+  };
+}
+
+describe("Surface screenshot-bound point click", () => {
+  it("maps one fresh capture coordinate and dispatches exactly one trusted click", async () => {
+    const { manager, browser, capture } = await setupCapture();
+    const result = await handleSurfacePointClick(manager, pointParams(capture.id), browser);
+
+    if ("code" in result) throw new Error(JSON.stringify(result));
+    expect(result).toMatchObject({
+      used_ref: "e3",
+      capture_id: capture.id,
+      image_x: 50,
+      image_y: 20,
+      x: 35,
+      y: 30,
+    });
+    expect(browser.sent.filter((call) => call.method === "Input.dispatchMouseEvent")).toHaveLength(
+      3,
+    );
+
+    const repeated = await handleSurfacePointClick(manager, pointParams(capture.id), browser);
+    expect(repeated).toMatchObject({
+      code: "permission_denied",
+      data: { reason: "surface_capture_consumed" },
+    });
+  });
+
+  it("rejects a new observation generation before sending input", async () => {
+    const { manager, context, browser, capture } = await setupCapture();
+    context.refStore.replace([
+      [
+        "e3",
+        {
+          backendNodeId: 99,
+          tabId: 4,
+          kind: "surface" as const,
+          visibleRect: { x: 10, y: 20, w: 100, h: 40 },
+        },
+      ],
+    ]);
+
+    const result = await handleSurfacePointClick(manager, pointParams(capture.id), browser);
+    expect(result).toMatchObject({
+      code: "permission_denied",
+      data: { reason: "surface_capture_stale" },
+    });
+    expect(browser.sent.some((call) => call.method === "Input.dispatchMouseEvent")).toBe(false);
+  });
+
+  it("rejects navigation, scroll, and visible geometry changes", async () => {
+    for (const mutate of [
+      (browser: ReturnType<typeof fakeBrowser>) => browser.setLoaderId("loader-2"),
+      (browser: ReturnType<typeof fakeBrowser>) => browser.setPageY(20),
+      (browser: ReturnType<typeof fakeBrowser>) =>
+        browser.setQuad([11, 20, 111, 20, 111, 60, 11, 60]),
+    ]) {
+      const { manager, browser, capture } = await setupCapture();
+      mutate(browser);
+      const result = await handleSurfacePointClick(manager, pointParams(capture.id), browser);
+      expect(result).toMatchObject({
+        code: "permission_denied",
+        data: { reason: "surface_capture_stale" },
+      });
+      expect(browser.sent.some((call) => call.method === "Input.dispatchMouseEvent")).toBe(false);
+    }
+  });
+
+  it("consumes the capture when coordinates or input dispatch fail", async () => {
+    const invalid = await setupCapture();
+    const outside = await handleSurfacePointClick(
+      invalid.manager,
+      { ...pointParams(invalid.capture.id), image_x: 200 },
+      invalid.browser,
+    );
+    expect(outside).toMatchObject({
+      code: "invalid_params",
+      data: { reason: "surface_coordinate_invalid" },
+    });
+    expect(
+      await handleSurfacePointClick(
+        invalid.manager,
+        pointParams(invalid.capture.id),
+        invalid.browser,
+      ),
+    ).toMatchObject({ data: { reason: "surface_capture_consumed" } });
+
+    const failed = await setupCapture();
+    failed.browser.failDispatch();
+    expect(
+      await handleSurfacePointClick(failed.manager, pointParams(failed.capture.id), failed.browser),
+    ).toMatchObject({ code: "cdp_failed" });
+    expect(
+      await handleSurfacePointClick(failed.manager, pointParams(failed.capture.id), failed.browser),
+    ).toMatchObject({ data: { reason: "surface_capture_consumed" } });
+  });
+
+  it("maps image coordinates through an OOPIF frame projection", async () => {
+    const manager = new SessionManager({ agentWindow: fakeAgentWindow() });
+    const context = await manager.start("aa11");
+    context.refStore.set("e3", 99, {
+      tabId: 4,
+      frameId: "child",
+      cdpSessionId: "child-session",
+      kind: "surface",
+      visibleRect: { x: 120, y: 110, w: 100, h: 40 },
+    });
+    const graph = {
+      rootFrameId: "main",
+      frames: [
+        { frameId: "main", target: { tabId: 4 } },
+        {
+          frameId: "child",
+          parentFrameId: "main",
+          ownerBackendNodeId: 77,
+          target: { tabId: 4, sessionId: "child-session" },
+        },
+      ],
+    };
+    const sent: Array<{ method: string; params?: object }> = [];
+    const cdp: CdpRunner = {
+      send: vi.fn(async (_tabId: number, method: string, params?: object) => {
+        sent.push({ method, params });
+        if (method === "Page.getFrameTree") {
+          return {
+            frameTree: {
+              frame: { id: "main", loaderId: "loader-1", url: "https://fixture.test/" },
+            },
+          } as never;
+        }
+        if (method === "Page.getLayoutMetrics") {
+          return {
+            cssLayoutViewport: { clientWidth: 800, clientHeight: 600, pageX: 0, pageY: 0 },
+            cssVisualViewport: {
+              clientWidth: 800,
+              clientHeight: 600,
+              pageX: 0,
+              pageY: 0,
+              scale: 1,
+            },
+          } as never;
+        }
+        if (method === "DOM.getBoxModel") {
+          return { model: { content: [100, 100, 300, 100, 300, 200, 100, 200] } } as never;
+        }
+        if (method === "Input.dispatchMouseEvent") return {} as never;
+        throw new Error(`unexpected root CDP call ${method}`);
+      }) as CdpRunner["send"],
+      sendToTarget: vi.fn(async (_target, method) => {
+        if (method === "DOM.getContentQuads") {
+          return { quads: [[20, 10, 120, 10, 120, 50, 20, 50]] } as never;
+        }
+        if (method === "Page.getLayoutMetrics") {
+          return { cssLayoutViewport: { clientWidth: 200, clientHeight: 100 } } as never;
+        }
+        throw new Error(`unexpected child CDP call ${method}`);
+      }) as CdpRunner["sendToTarget"],
+      getFrameGraph: vi.fn(async () => graph),
+      trackSessionTab: vi.fn(),
+    };
+    const tabsApi = {
+      get: vi.fn(async () => ({ id: 4, windowId: 100, active: true }) as chrome.tabs.Tab),
+      query: vi.fn(async () => [{ id: 4, windowId: 100, active: true } as chrome.tabs.Tab]),
+    };
+    const environment = await captureSurfaceEnvironment(cdp, 4, "child");
+    if ("code" in environment) throw new Error(environment.message);
+    const entry = context.refStore.resolveEntry("e3");
+    if (!entry) throw new Error("missing ref");
+    const capture = context.surfaceCaptures.create({
+      sessionId: "aa11",
+      tabId: 4,
+      navigationIdentity: environment.navigationIdentity,
+      surface: {
+        ref: "e3",
+        frameId: "child",
+        backendNodeId: 99,
+        observationGeneration: entry.generation,
+      },
+      topViewportRect: { x: 120, y: 110, w: 100, h: 40 },
+      imageWidth: 200,
+      imageHeight: 80,
+      viewportSignature: environment.viewportSignature,
+      frameProjectionSignature: environment.frameProjectionSignature,
+    });
+
+    const result = await handleSurfacePointClick(
+      manager,
+      {
+        session_id: "aa11",
+        ref: "@e3",
+        capture_id: capture.id,
+        image_x: 100,
+        image_y: 40,
+      },
+      { cdp, tabsApi },
+    );
+
+    if ("code" in result) throw new Error(JSON.stringify(result));
+    expect(result).toMatchObject({ x: 170, y: 130 });
+    expect(sent.filter((call) => call.method === "Input.dispatchMouseEvent")).toHaveLength(3);
+  });
+});

--- a/apps/extension/src/tools/__tests__/surface-target.test.ts
+++ b/apps/extension/src/tools/__tests__/surface-target.test.ts
@@ -1,13 +1,17 @@
 import { describe, expect, it, vi } from "vitest";
 import { SessionManager } from "@/session-manager/manager";
 import type { CdpRunner } from "../shared";
-import { captureSurfaceEnvironment, handleSurfacePointClick } from "../surface-point-action";
+import {
+  captureSurfaceEnvironment,
+  resolveSurfacePointerTarget,
+  SURFACE_POINTER_MOVE_SETTLE_MS,
+} from "../surface-target";
 
 function fakeAgentWindow() {
   return {
     create: vi.fn(async () => 100),
     remove: vi.fn(async () => {}),
-    ensureActiveTab: vi.fn(async () => {}),
+    ensureActiveTab: vi.fn(async () => 1),
   };
 }
 
@@ -15,7 +19,6 @@ function fakeBrowser() {
   let loaderId = "loader-1";
   let pageY = 0;
   let quad = [10, 20, 110, 20, 110, 60, 10, 60];
-  let dispatchFails = false;
   const sent: Array<{ method: string; params?: object }> = [];
   const cdp: CdpRunner = {
     send: vi.fn(async (_tabId: number, method: string, params?: object) => {
@@ -38,23 +41,12 @@ function fakeBrowser() {
         } as never;
       }
       if (method === "DOM.getContentQuads") return { quads: [quad] } as never;
-      if (method === "Input.dispatchMouseEvent") {
-        if (dispatchFails) throw new Error("input failed");
-        return {} as never;
-      }
       throw new Error(`unexpected CDP call ${method}`);
     }) as CdpRunner["send"],
     trackSessionTab: vi.fn(),
   };
-  const tabsApi = {
-    get: vi.fn(
-      async (tabId: number) => ({ id: tabId, windowId: 100, active: true }) as chrome.tabs.Tab,
-    ),
-    query: vi.fn(async () => [{ id: 4, windowId: 100, active: true } as chrome.tabs.Tab]),
-  };
   return {
     cdp,
-    tabsApi,
     sent,
     setLoaderId: (value: string) => {
       loaderId = value;
@@ -64,9 +56,6 @@ function fakeBrowser() {
     },
     setQuad: (value: number[]) => {
       quad = value;
-    },
-    failDispatch: () => {
-      dispatchFails = true;
     },
   };
 }
@@ -104,33 +93,38 @@ async function setupCapture() {
 
 function pointParams(captureId: string) {
   return {
-    session_id: "aa11",
     ref: "@e3",
-    capture_id: captureId,
-    image_x: 50,
-    image_y: 20,
+    captureId,
+    imageX: 50,
+    imageY: 20,
   };
 }
 
-describe("Surface screenshot-bound point click", () => {
-  it("maps one fresh capture coordinate and dispatches exactly one trusted click", async () => {
-    const { manager, browser, capture } = await setupCapture();
-    const result = await handleSurfacePointClick(manager, pointParams(capture.id), browser);
+describe("Surface screenshot-bound pointer target", () => {
+  it("maps one fresh capture coordinate without executing an action", async () => {
+    const { context, browser, capture } = await setupCapture();
+    const result = await resolveSurfacePointerTarget(
+      context,
+      { tabId: 4 },
+      pointParams(capture.id),
+      { cdp: browser.cdp },
+    );
 
     if ("code" in result) throw new Error(JSON.stringify(result));
     expect(result).toMatchObject({
-      used_ref: "e3",
-      capture_id: capture.id,
-      image_x: 50,
-      image_y: 20,
-      x: 35,
-      y: 30,
+      usedRef: "e3",
+      point: { x: 35, y: 30 },
+      moveSettleMs: SURFACE_POINTER_MOVE_SETTLE_MS,
+      capture: { id: capture.id, imageX: 50, imageY: 20 },
     });
-    expect(browser.sent.filter((call) => call.method === "Input.dispatchMouseEvent")).toHaveLength(
-      3,
-    );
+    expect(browser.sent.some((call) => call.method === "Input.dispatchMouseEvent")).toBe(false);
 
-    const repeated = await handleSurfacePointClick(manager, pointParams(capture.id), browser);
+    const repeated = await resolveSurfacePointerTarget(
+      context,
+      { tabId: 4 },
+      pointParams(capture.id),
+      { cdp: browser.cdp },
+    );
     expect(repeated).toMatchObject({
       code: "permission_denied",
       data: { reason: "surface_capture_consumed" },
@@ -138,7 +132,7 @@ describe("Surface screenshot-bound point click", () => {
   });
 
   it("rejects a new observation generation before sending input", async () => {
-    const { manager, context, browser, capture } = await setupCapture();
+    const { context, browser, capture } = await setupCapture();
     context.refStore.replace([
       [
         "e3",
@@ -151,7 +145,12 @@ describe("Surface screenshot-bound point click", () => {
       ],
     ]);
 
-    const result = await handleSurfacePointClick(manager, pointParams(capture.id), browser);
+    const result = await resolveSurfacePointerTarget(
+      context,
+      { tabId: 4 },
+      pointParams(capture.id),
+      { cdp: browser.cdp },
+    );
     expect(result).toMatchObject({
       code: "permission_denied",
       data: { reason: "surface_capture_stale" },
@@ -166,9 +165,14 @@ describe("Surface screenshot-bound point click", () => {
       (browser: ReturnType<typeof fakeBrowser>) =>
         browser.setQuad([11, 20, 111, 20, 111, 60, 11, 60]),
     ]) {
-      const { manager, browser, capture } = await setupCapture();
+      const { context, browser, capture } = await setupCapture();
       mutate(browser);
-      const result = await handleSurfacePointClick(manager, pointParams(capture.id), browser);
+      const result = await resolveSurfacePointerTarget(
+        context,
+        { tabId: 4 },
+        pointParams(capture.id),
+        { cdp: browser.cdp },
+      );
       expect(result).toMatchObject({
         code: "permission_denied",
         data: { reason: "surface_capture_stale" },
@@ -177,32 +181,25 @@ describe("Surface screenshot-bound point click", () => {
     }
   });
 
-  it("consumes the capture when coordinates or input dispatch fail", async () => {
+  it("consumes the capture when coordinate validation fails", async () => {
     const invalid = await setupCapture();
-    const outside = await handleSurfacePointClick(
-      invalid.manager,
-      { ...pointParams(invalid.capture.id), image_x: 200 },
-      invalid.browser,
+    const outside = await resolveSurfacePointerTarget(
+      invalid.context,
+      { tabId: 4 },
+      { ...pointParams(invalid.capture.id), imageX: 200 },
+      { cdp: invalid.browser.cdp },
     );
     expect(outside).toMatchObject({
       code: "invalid_params",
       data: { reason: "surface_coordinate_invalid" },
     });
     expect(
-      await handleSurfacePointClick(
-        invalid.manager,
+      await resolveSurfacePointerTarget(
+        invalid.context,
+        { tabId: 4 },
         pointParams(invalid.capture.id),
-        invalid.browser,
+        { cdp: invalid.browser.cdp },
       ),
-    ).toMatchObject({ data: { reason: "surface_capture_consumed" } });
-
-    const failed = await setupCapture();
-    failed.browser.failDispatch();
-    expect(
-      await handleSurfacePointClick(failed.manager, pointParams(failed.capture.id), failed.browser),
-    ).toMatchObject({ code: "cdp_failed" });
-    expect(
-      await handleSurfacePointClick(failed.manager, pointParams(failed.capture.id), failed.browser),
     ).toMatchObject({ data: { reason: "surface_capture_consumed" } });
   });
 
@@ -269,10 +266,6 @@ describe("Surface screenshot-bound point click", () => {
       getFrameGraph: vi.fn(async () => graph),
       trackSessionTab: vi.fn(),
     };
-    const tabsApi = {
-      get: vi.fn(async () => ({ id: 4, windowId: 100, active: true }) as chrome.tabs.Tab),
-      query: vi.fn(async () => [{ id: 4, windowId: 100, active: true } as chrome.tabs.Tab]),
-    };
     const environment = await captureSurfaceEnvironment(cdp, 4, "child");
     if ("code" in environment) throw new Error(environment.message);
     const entry = context.refStore.resolveEntry("e3");
@@ -294,20 +287,20 @@ describe("Surface screenshot-bound point click", () => {
       frameProjectionSignature: environment.frameProjectionSignature,
     });
 
-    const result = await handleSurfacePointClick(
-      manager,
+    const result = await resolveSurfacePointerTarget(
+      context,
+      { tabId: 4 },
       {
-        session_id: "aa11",
         ref: "@e3",
-        capture_id: capture.id,
-        image_x: 100,
-        image_y: 40,
+        captureId: capture.id,
+        imageX: 100,
+        imageY: 40,
       },
-      { cdp, tabsApi },
+      { cdp },
     );
 
     if ("code" in result) throw new Error(JSON.stringify(result));
-    expect(result).toMatchObject({ x: 170, y: 130 });
-    expect(sent.filter((call) => call.method === "Input.dispatchMouseEvent")).toHaveLength(3);
+    expect(result).toMatchObject({ point: { x: 170, y: 130 } });
+    expect(sent.some((call) => call.method === "Input.dispatchMouseEvent")).toBe(false);
   });
 });

--- a/apps/extension/src/tools/interaction.ts
+++ b/apps/extension/src/tools/interaction.ts
@@ -44,6 +44,7 @@ import {
   resolveTargetTab,
 } from "./shared";
 import { resolveSnapshotRef } from "./snapshot-ref";
+import { handleSurfacePointClick } from "./surface-point-action";
 
 export interface InteractionDeps {
   cdp: CdpRunner;
@@ -247,6 +248,11 @@ export async function handleClick(
   params: ClickParams,
   deps: InteractionDeps = getDefaultDeps(),
 ): Promise<ClickResult | RpcError> {
+  const hasSurfacePointParams =
+    params.capture_id !== undefined || params.image_x !== undefined || params.image_y !== undefined;
+  if (hasSurfacePointParams) {
+    return handleSurfacePointClick(manager, params, deps);
+  }
   const ctxOrErr = lookupSession(manager, params, "click");
   if (isRpcError(ctxOrErr)) return ctxOrErr;
   const ctx = ctxOrErr;

--- a/apps/extension/src/tools/interaction.ts
+++ b/apps/extension/src/tools/interaction.ts
@@ -45,7 +45,7 @@ import {
   resolveTargetTab,
 } from "./shared";
 import { resolveSnapshotRef } from "./snapshot-ref";
-import { handleSurfacePointClick } from "./surface-point-action";
+import { resolveSurfacePointerTarget } from "./surface-target";
 
 export interface InteractionDeps {
   cdp: CdpRunner;
@@ -244,6 +244,18 @@ export async function resolveActionTarget(
 // tool.click
 // ---------------------------------------------------------------------------
 
+interface ResolvedClickPointerTarget {
+  point: { x: number; y: number };
+  usedRef?: string;
+  usedSelector?: string;
+  moveSettleMs: number;
+  capture?: {
+    id: string;
+    imageX: number;
+    imageY: number;
+  };
+}
+
 export async function handleClick(
   manager: SessionManager,
   params: ClickParams,
@@ -251,9 +263,6 @@ export async function handleClick(
 ): Promise<ClickResult | RpcError> {
   const hasSurfacePointParams =
     params.capture_id !== undefined || params.image_x !== undefined || params.image_y !== undefined;
-  if (hasSurfacePointParams) {
-    return handleSurfacePointClick(manager, params, deps);
-  }
   const ctxOrErr = lookupSession(manager, params, "click");
   if (isRpcError(ctxOrErr)) return ctxOrErr;
   const ctx = ctxOrErr;
@@ -263,6 +272,23 @@ export async function handleClick(
   if (isRpcError(target)) return target;
   const denied = enforceAgentWindow(ctx, target, "click");
   if (denied) return denied;
+  if (hasSurfacePointParams) {
+    const dialogCursor = markDialogCursor(deps.cdp, target.tabId);
+    const pointerTarget = await resolveSurfacePointerTarget(
+      ctx,
+      target,
+      {
+        ref: params.ref,
+        selector: params.selector,
+        captureId: params.capture_id,
+        imageX: params.image_x,
+        imageY: params.image_y,
+      },
+      { cdp: deps.cdp, signal: deps.signal },
+    );
+    if (isRpcError(pointerTarget)) return pointerTarget;
+    return executeResolvedClick(ctx, target, pointerTarget, params, deps, dialogCursor);
+  }
   const resolved = await resolveActionTarget(deps.cdp, ctx, target, params, "click");
   if (isRpcError(resolved)) return resolved;
   return clickResolvedTarget(ctx, resolved, params, deps);
@@ -276,11 +302,6 @@ export async function clickResolvedTarget(
 ): Promise<ClickResult | RpcError> {
   const { tab: target } = resolved;
   const dialogCursor = markDialogCursor(deps.cdp, target.tabId);
-
-  if (throwIfAborted(deps.signal)) {
-    return { code: "cancelled", message: "click aborted" };
-  }
-
   deps.cdp.trackSessionTab?.(ctx.sessionId, target.tabId);
   const geometry = await resolveNodeGeometry(
     deps.cdp,
@@ -293,20 +314,47 @@ export async function clickResolvedTarget(
     { scrollIntoView: true },
   );
   if (isRpcError(geometry)) return geometry;
-  const centre = geometry.actionPoint;
+  return executeResolvedClick(
+    ctx,
+    target,
+    {
+      point: geometry.actionPoint,
+      usedRef: resolved.usedRef,
+      usedSelector: resolved.usedSelector,
+      moveSettleMs: 0,
+    },
+    params,
+    deps,
+    dialogCursor,
+  );
+}
 
+async function executeResolvedClick(
+  ctx: SessionContext,
+  target: ResolvedTargetTab,
+  pointerTarget: ResolvedClickPointerTarget,
+  params: Pick<ClickParams, "button" | "click_count" | "modifiers">,
+  deps: InteractionDeps,
+  dialogCursor: number,
+): Promise<ClickResult | RpcError> {
   if (throwIfAborted(deps.signal)) {
     return { code: "cancelled", message: "click aborted" };
   }
 
   const button: MouseButton = params.button ?? "left";
   const clickCount = params.click_count ?? 1;
-  if (clickCount < 1) {
-    return { code: "invalid_params", message: "click_count must be greater than zero" };
+  if (!Number.isSafeInteger(clickCount) || clickCount < 1) {
+    return { code: "invalid_params", message: "click_count must be a positive integer" };
   }
   const modifiers = modifiersBitfield(params.modifiers);
 
-  const overlayBlocking = await checkOverlayAtPoint(deps.cdp, target.tabId, centre.x, centre.y);
+  deps.cdp.trackSessionTab?.(ctx.sessionId, target.tabId);
+  const overlayBlocking = await checkOverlayAtPoint(
+    deps.cdp,
+    target.tabId,
+    pointerTarget.point.x,
+    pointerTarget.point.y,
+  );
   let automationBypassEnabled = false;
   if (overlayBlocking && deps.bypassOverlay) {
     try {
@@ -318,11 +366,12 @@ export async function clickResolvedTarget(
   }
 
   try {
-    const dispatch = await dispatchMouseClick(deps.cdp, target.tabId, centre, {
+    const dispatch = await dispatchMouseClick(deps.cdp, target.tabId, pointerTarget.point, {
       button,
       clickCount,
       modifiers,
       signal: deps.signal,
+      moveSettleMs: pointerTarget.moveSettleMs,
     });
     if (dispatch === "cancelled") {
       return { code: "cancelled", message: "click aborted" };
@@ -344,10 +393,17 @@ export async function clickResolvedTarget(
 
   return attachDialogs(deps.cdp, target.tabId, dialogCursor, {
     tab_id: target.tabId,
-    used_ref: resolved.usedRef,
-    used_selector: resolved.usedSelector,
-    x: centre.x,
-    y: centre.y,
+    used_ref: pointerTarget.usedRef,
+    used_selector: pointerTarget.usedSelector,
+    x: pointerTarget.point.x,
+    y: pointerTarget.point.y,
+    ...(pointerTarget.capture
+      ? {
+          capture_id: pointerTarget.capture.id,
+          image_x: pointerTarget.capture.imageX,
+          image_y: pointerTarget.capture.imageY,
+        }
+      : {}),
   });
 }
 

--- a/apps/extension/src/tools/interaction.ts
+++ b/apps/extension/src/tools/interaction.ts
@@ -32,6 +32,7 @@ import { attachDialogs, markDialogCursor } from "./dialogs";
 import { backendNodeToObject } from "./element-geometry";
 import { rpcError } from "./errors";
 import { resolveNodeGeometry, scrollElementAndFramesIntoView } from "./frame-geometry";
+import { dispatchMouseClick } from "./mouse-input";
 import {
   type CdpRunner,
   type ChromeTabsApi,
@@ -317,47 +318,15 @@ export async function clickResolvedTarget(
   }
 
   try {
-    // Move first so hover state activates, then press → release.
-    await deps.cdp.send(target.tabId, "Input.dispatchMouseEvent", {
-      type: "mouseMoved",
-      x: centre.x,
-      y: centre.y,
-      modifiers,
-    });
-    if (throwIfAborted(deps.signal)) {
-      return { code: "cancelled", message: "click aborted" };
-    }
-    await deps.cdp.send(target.tabId, "Input.dispatchMouseEvent", {
-      type: "mousePressed",
-      x: centre.x,
-      y: centre.y,
+    const dispatch = await dispatchMouseClick(deps.cdp, target.tabId, centre, {
       button,
       clickCount,
       modifiers,
+      signal: deps.signal,
     });
-    if (throwIfAborted(deps.signal)) {
-      try {
-        await deps.cdp.send(target.tabId, "Input.dispatchMouseEvent", {
-          type: "mouseReleased",
-          x: centre.x,
-          y: centre.y,
-          button,
-          clickCount,
-          modifiers,
-        });
-      } catch (err) {
-        console.debug("[bsk interaction] best-effort mouseReleased after abort failed", err);
-      }
+    if (dispatch === "cancelled") {
       return { code: "cancelled", message: "click aborted" };
     }
-    await deps.cdp.send(target.tabId, "Input.dispatchMouseEvent", {
-      type: "mouseReleased",
-      x: centre.x,
-      y: centre.y,
-      button,
-      clickCount,
-      modifiers,
-    });
   } catch (err) {
     return {
       code: "cdp_failed",

--- a/apps/extension/src/tools/mouse-input.ts
+++ b/apps/extension/src/tools/mouse-input.ts
@@ -1,0 +1,96 @@
+import type { MouseButton } from "@/transport/types";
+import type { Point } from "./geometry";
+import type { CdpRunner } from "./shared";
+
+interface MouseClickDispatchOptions {
+  button: MouseButton;
+  clickCount: number;
+  modifiers: number;
+  signal?: AbortSignal;
+  moveSettleMs?: number;
+}
+
+type MouseClickDispatchResult = "completed" | "cancelled";
+
+function waitForSettle(ms: number, signal: AbortSignal | undefined): Promise<boolean> {
+  if (ms <= 0) return Promise.resolve(signal?.aborted !== true);
+  if (signal?.aborted) return Promise.resolve(false);
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (completed: boolean) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      signal?.removeEventListener("abort", onAbort);
+      resolve(completed);
+    };
+    const timer = setTimeout(() => finish(true), ms);
+    const onAbort = () => finish(false);
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+/**
+ * Dispatch one coherent CDP mouse click in top-viewport CSS coordinates.
+ *
+ * Keeping the sequence here prevents DOM and Surface interaction paths from
+ * duplicating cancellation and best-effort release behavior. Callers that
+ * target asynchronously hit-tested content may request a settle interval.
+ */
+export async function dispatchMouseClick(
+  cdp: CdpRunner,
+  tabId: number,
+  point: Point,
+  options: MouseClickDispatchOptions,
+): Promise<MouseClickDispatchResult> {
+  const { button, clickCount, modifiers, signal, moveSettleMs = 0 } = options;
+  let pressed = false;
+  const release = () =>
+    cdp.send(tabId, "Input.dispatchMouseEvent", {
+      type: "mouseReleased",
+      x: point.x,
+      y: point.y,
+      button,
+      clickCount,
+      modifiers,
+    });
+
+  try {
+    await cdp.send(tabId, "Input.dispatchMouseEvent", {
+      type: "mouseMoved",
+      x: point.x,
+      y: point.y,
+      modifiers,
+    });
+    if (!(await waitForSettle(moveSettleMs, signal))) return "cancelled";
+
+    await cdp.send(tabId, "Input.dispatchMouseEvent", {
+      type: "mousePressed",
+      x: point.x,
+      y: point.y,
+      button,
+      clickCount,
+      modifiers,
+    });
+    pressed = true;
+
+    if (signal?.aborted) {
+      await release();
+      pressed = false;
+      return "cancelled";
+    }
+
+    await release();
+    pressed = false;
+    return "completed";
+  } catch (error) {
+    if (pressed) {
+      try {
+        await release();
+      } catch (releaseError) {
+        console.debug("[bsk mouse-input] best-effort mouse release failed", releaseError);
+      }
+    }
+    throw error;
+  }
+}

--- a/apps/extension/src/tools/observation.ts
+++ b/apps/extension/src/tools/observation.ts
@@ -48,6 +48,8 @@ import {
   type ToolEffect,
 } from "./shared";
 import { resolveSnapshotRef } from "./snapshot-ref";
+import { surfaceVisibleRect } from "./surface-coordinate";
+import { captureSurfaceEnvironment } from "./surface-target";
 import {
   type CapturedNode,
   type CapturedSurfaceProbe,
@@ -197,7 +199,9 @@ async function captureElementScreenshot(
   visualSurface = false,
   observedVisibleRect?: Rect,
   signal?: AbortSignal,
-): Promise<{ image_base64: string; width: number; height: number } | RpcError> {
+): Promise<
+  { image_base64: string; width: number; height: number; topViewportRect: Rect } | RpcError
+> {
   if (signal?.aborted) return cancelled("screenshot");
   const geometry = await resolveNodeGeometry(
     cdp,
@@ -207,24 +211,19 @@ async function captureElementScreenshot(
   );
   if (isRpcError(geometry)) return geometry;
   if (signal?.aborted) return cancelled("screenshot");
-  const liveRect = geometry.topBounds;
-  const rect =
-    visualSurface && observedVisibleRect
-      ? (() => {
-          const x = Math.max(liveRect.x, observedVisibleRect.x);
-          const y = Math.max(liveRect.y, observedVisibleRect.y);
-          const right = Math.min(
-            liveRect.x + liveRect.width,
-            observedVisibleRect.x + observedVisibleRect.w,
-          );
-          const bottom = Math.min(
-            liveRect.y + liveRect.height,
-            observedVisibleRect.y + observedVisibleRect.h,
-          );
-          return right > x && bottom > y ? { x, y, width: right - x, height: bottom - y } : null;
-        })()
-      : liveRect;
-  if (!rect) return { code: "permission_denied", message: "surface is no longer visible" };
+  const topViewportRect = surfaceVisibleRect(
+    geometry.topBounds,
+    visualSurface ? observedVisibleRect : undefined,
+  );
+  if (!topViewportRect) {
+    return { code: "permission_denied", message: "surface is no longer visible" };
+  }
+  const rect = {
+    x: topViewportRect.x,
+    y: topViewportRect.y,
+    width: topViewportRect.w,
+    height: topViewportRect.h,
+  };
   const scale = visualSurface
     ? Math.min(
         1,
@@ -377,12 +376,46 @@ export async function handleScreenshot(
     );
     if (isRpcError(captured)) return captured;
     if (signal?.aborted) return cancelled("screenshot");
+    const capture =
+      node.kind === "surface"
+        ? await (async () => {
+            const environment = await captureSurfaceEnvironment(cdp, target.tabId, node.frameId);
+            if (isRpcError(environment)) return environment;
+            return ctx.surfaceCaptures.create({
+              sessionId: ctx.sessionId,
+              tabId: target.tabId,
+              navigationIdentity: environment.navigationIdentity,
+              surface: {
+                ref: node.refKey,
+                ...(node.frameId ? { frameId: node.frameId } : {}),
+                backendNodeId: node.backendNodeId,
+                observationGeneration: node.generation,
+              },
+              topViewportRect: captured.topViewportRect,
+              imageWidth: captured.width,
+              imageHeight: captured.height,
+              viewportSignature: environment.viewportSignature,
+              frameProjectionSignature: environment.frameProjectionSignature,
+            });
+          })()
+        : null;
+    if (capture && isRpcError(capture)) return capture;
     return withShotDialogs({
       image_base64: captured.image_base64,
       width: captured.width,
       height: captured.height,
       format: "png",
       tab_id: target.tabId,
+      ...(capture
+        ? {
+            capture: {
+              id: capture.id,
+              surface_ref: `@${capture.surface.ref}`,
+              coordinate_space: "capture-image-pixel" as const,
+              expires_at: capture.expiresAt,
+            },
+          }
+        : {}),
     });
   }
 

--- a/apps/extension/src/tools/observation.ts
+++ b/apps/extension/src/tools/observation.ts
@@ -254,7 +254,7 @@ async function captureElementScreenshot(
     if (!dims) {
       return { code: "cdp_failed", message: "Page.captureScreenshot returned invalid PNG data" };
     }
-    return { image_base64, width: dims.width, height: dims.height };
+    return { image_base64, width: dims.width, height: dims.height, topViewportRect };
   } catch (err) {
     return {
       code: "cdp_failed",

--- a/apps/extension/src/tools/session.ts
+++ b/apps/extension/src/tools/session.ts
@@ -271,6 +271,7 @@ export async function handleSessionStop(
 
   // Step 2: clear the per-session RefStore (review M6/M7 parity).
   ctx.refStore.clear();
+  ctx.surfaceCaptures.clear();
 
   clearRecordingForSession(params.session_id);
 

--- a/apps/extension/src/tools/snapshot-ref.ts
+++ b/apps/extension/src/tools/snapshot-ref.ts
@@ -16,6 +16,7 @@ export interface SnapshotRefLookup {
   visibleRect?: Rect;
   kind: RefTargetKind;
   capabilities: RefCapability[];
+  generation: number;
 }
 
 function refEntryForTab(ctx: SessionContext, refKey: string, tabId: number) {
@@ -44,6 +45,7 @@ export function lookupSnapshotRef(
     ...(entry.visibleRect ? { visibleRect: entry.visibleRect } : {}),
     kind: entry.kind,
     capabilities: entry.capabilities,
+    generation: entry.generation,
   };
 }
 

--- a/apps/extension/src/tools/surface-coordinate.ts
+++ b/apps/extension/src/tools/surface-coordinate.ts
@@ -1,0 +1,88 @@
+import type { Rect } from "@browser-skill/vom";
+import type { Point, Region, ViewportRect } from "./geometry";
+
+const RECT_EPSILON = 0.01;
+
+export function surfaceVisibleRect(
+  liveRect: ViewportRect,
+  observedRect: Rect | undefined,
+): Rect | null {
+  const observed = observedRect ?? {
+    x: liveRect.x,
+    y: liveRect.y,
+    w: liveRect.width,
+    h: liveRect.height,
+  };
+  const x = Math.max(liveRect.x, observed.x);
+  const y = Math.max(liveRect.y, observed.y);
+  const right = Math.min(liveRect.x + liveRect.width, observed.x + observed.w);
+  const bottom = Math.min(liveRect.y + liveRect.height, observed.y + observed.h);
+  return right > x && bottom > y ? { x, y, w: right - x, h: bottom - y } : null;
+}
+
+export function sameRect(a: Rect, b: Rect): boolean {
+  return (
+    Math.abs(a.x - b.x) <= RECT_EPSILON &&
+    Math.abs(a.y - b.y) <= RECT_EPSILON &&
+    Math.abs(a.w - b.w) <= RECT_EPSILON &&
+    Math.abs(a.h - b.h) <= RECT_EPSILON
+  );
+}
+
+export function mapImagePointToViewport(
+  rect: Rect,
+  imageWidth: number,
+  imageHeight: number,
+  imageX: number,
+  imageY: number,
+): Point | null {
+  if (
+    !Number.isFinite(imageX) ||
+    !Number.isFinite(imageY) ||
+    !Number.isSafeInteger(imageWidth) ||
+    !Number.isSafeInteger(imageHeight) ||
+    imageWidth <= 0 ||
+    imageHeight <= 0 ||
+    imageX < 0 ||
+    imageY < 0 ||
+    imageX >= imageWidth ||
+    imageY >= imageHeight ||
+    !Number.isFinite(rect.x) ||
+    !Number.isFinite(rect.y) ||
+    !Number.isFinite(rect.w) ||
+    !Number.isFinite(rect.h) ||
+    rect.w <= 0 ||
+    rect.h <= 0
+  ) {
+    return null;
+  }
+  return {
+    x: rect.x + (imageX / imageWidth) * rect.w,
+    y: rect.y + (imageY / imageHeight) * rect.h,
+  };
+}
+
+function pointInPolygon(point: Point, polygon: Point[]): boolean {
+  for (let index = 0; index < polygon.length; index += 1) {
+    const a = polygon[index];
+    const b = polygon[(index + 1) % polygon.length];
+    const cross = (point.x - a.x) * (b.y - a.y) - (point.y - a.y) * (b.x - a.x);
+    const withinX = point.x >= Math.min(a.x, b.x) - 1e-9 && point.x <= Math.max(a.x, b.x) + 1e-9;
+    const withinY = point.y >= Math.min(a.y, b.y) - 1e-9 && point.y <= Math.max(a.y, b.y) + 1e-9;
+    if (Math.abs(cross) <= 1e-9 && withinX && withinY) return true;
+  }
+  let inside = false;
+  for (let index = 0, previous = polygon.length - 1; index < polygon.length; previous = index++) {
+    const a = polygon[index];
+    const b = polygon[previous];
+    const intersects =
+      a.y > point.y !== b.y > point.y &&
+      point.x < ((b.x - a.x) * (point.y - a.y)) / (b.y - a.y) + a.x;
+    if (intersects) inside = !inside;
+  }
+  return inside;
+}
+
+export function pointInRegion(point: Point, region: Region): boolean {
+  return region.some((polygon) => polygon.length >= 3 && pointInPolygon(point, polygon));
+}

--- a/apps/extension/src/tools/surface-point-action.ts
+++ b/apps/extension/src/tools/surface-point-action.ts
@@ -1,0 +1,320 @@
+import type { CdpFrameGraph } from "@/browser-driver/frame-graph";
+import type { SessionManager } from "@/session-manager/manager";
+import type { ClickParams, ClickResult, RpcError } from "@/transport/types";
+import { attachDialogs, markDialogCursor } from "./dialogs";
+import { rpcError } from "./errors";
+import { resolveNodeGeometry } from "./frame-geometry";
+import {
+  type CdpRunner,
+  type ChromeTabsApi,
+  enforceAgentWindow,
+  isRpcError,
+  lookupSession,
+  normaliseRef,
+  resolveTargetTab,
+} from "./shared";
+import { resolveSnapshotRef } from "./snapshot-ref";
+import {
+  mapImagePointToViewport,
+  pointInRegion,
+  sameRect,
+  surfaceVisibleRect,
+} from "./surface-coordinate";
+
+export interface SurfaceCaptureEnvironment {
+  navigationIdentity: string;
+  viewportSignature: string;
+  frameProjectionSignature: string;
+}
+
+export interface SurfacePointActionDeps {
+  cdp: CdpRunner;
+  tabsApi: ChromeTabsApi;
+  signal?: AbortSignal;
+  bypassOverlay?: (tabId: number, enabled: boolean) => Promise<void>;
+}
+
+function stale(message: string): RpcError {
+  return rpcError("permission_denied", "surface_capture_stale", message);
+}
+
+function finiteObject(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(finiteObject);
+  if (typeof value !== "object" || value === null) return value;
+  return Object.fromEntries(
+    Object.entries(value)
+      .filter(
+        ([, entry]) => entry !== undefined && (typeof entry !== "number" || Number.isFinite(entry)),
+      )
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([key, entry]) => [key, finiteObject(entry)]),
+  );
+}
+
+function framePathSignature(graph: CdpFrameGraph, frameId: string | undefined): string | null {
+  if (!frameId) return "top";
+  const frames = new Map(graph.frames.map((frame) => [frame.frameId, frame]));
+  const path: Array<{
+    frameId: string;
+    parentFrameId?: string;
+    ownerBackendNodeId?: number;
+    targetSessionId?: string;
+  }> = [];
+  const seen = new Set<string>();
+  let current = frames.get(frameId);
+  while (current) {
+    if (seen.has(current.frameId)) return null;
+    seen.add(current.frameId);
+    path.push({
+      frameId: current.frameId,
+      ...(current.parentFrameId ? { parentFrameId: current.parentFrameId } : {}),
+      ...(current.ownerBackendNodeId !== undefined
+        ? { ownerBackendNodeId: current.ownerBackendNodeId }
+        : {}),
+      ...(current.target.sessionId ? { targetSessionId: current.target.sessionId } : {}),
+    });
+    if (!current.parentFrameId) return JSON.stringify(path);
+    const parent = frames.get(current.parentFrameId);
+    if (!parent) return null;
+    current = parent;
+  }
+  return null;
+}
+
+export async function captureSurfaceEnvironment(
+  cdp: CdpRunner,
+  tabId: number,
+  frameId: string | undefined,
+): Promise<SurfaceCaptureEnvironment | RpcError> {
+  try {
+    const [tree, metrics, graph] = await Promise.all([
+      cdp.send<{
+        frameTree?: { frame?: { id?: string; loaderId?: string; url?: string } };
+      }>(tabId, "Page.getFrameTree", {}),
+      cdp.send<Record<string, unknown>>(tabId, "Page.getLayoutMetrics", {}),
+      frameId && cdp.getFrameGraph ? cdp.getFrameGraph(tabId) : Promise.resolve(null),
+    ]);
+    const root = tree.frameTree?.frame;
+    if (!root?.id || !root.loaderId) {
+      return { code: "cdp_failed", message: "could not identify the current navigation" };
+    }
+    const frameProjectionSignature = frameId
+      ? graph
+        ? framePathSignature(graph, frameId)
+        : null
+      : "top";
+    if (!frameProjectionSignature) {
+      return { code: "cdp_failed", message: `could not identify frame projection for ${frameId}` };
+    }
+    return {
+      navigationIdentity: JSON.stringify({ id: root.id, loaderId: root.loaderId, url: root.url }),
+      viewportSignature: JSON.stringify(
+        finiteObject({
+          cssLayoutViewport: metrics.cssLayoutViewport,
+          cssVisualViewport: metrics.cssVisualViewport,
+        }),
+      ),
+      frameProjectionSignature,
+    };
+  } catch (error) {
+    return { code: "cdp_failed", message: error instanceof Error ? error.message : String(error) };
+  }
+}
+
+function validatePointParams(params: ClickParams): RpcError | null {
+  if (!params.capture_id || typeof params.capture_id !== "string") {
+    return { code: "invalid_params", message: "surface point click requires capture_id" };
+  }
+  if (typeof params.image_x !== "number" || !Number.isFinite(params.image_x)) {
+    return { code: "invalid_params", message: "image_x must be a finite number" };
+  }
+  if (typeof params.image_y !== "number" || !Number.isFinite(params.image_y)) {
+    return { code: "invalid_params", message: "image_y must be a finite number" };
+  }
+  if (!params.ref || params.selector) {
+    return {
+      code: "invalid_params",
+      message: "surface point click requires one Surface ref and does not accept a selector",
+    };
+  }
+  if ((params.button ?? "left") !== "left" || (params.click_count ?? 1) !== 1) {
+    return {
+      code: "invalid_params",
+      message: "surface point click currently supports one left click only",
+    };
+  }
+  if (params.modifiers && params.modifiers.length > 0) {
+    return { code: "invalid_params", message: "surface point click does not accept modifiers" };
+  }
+  return null;
+}
+
+function captureConsumeError(reason: "not_found" | "expired" | "consumed"): RpcError {
+  const code = reason === "not_found" ? "not_found" : "permission_denied";
+  return rpcError(code, `surface_capture_${reason}`, `surface capture is ${reason}`);
+}
+
+function aborted(signal: AbortSignal | undefined): RpcError | null {
+  return signal?.aborted ? { code: "cancelled", message: "surface point click aborted" } : null;
+}
+
+export async function handleSurfacePointClick(
+  manager: SessionManager,
+  params: ClickParams,
+  deps: SurfacePointActionDeps,
+): Promise<ClickResult | RpcError> {
+  const invalid = validatePointParams(params);
+  if (invalid) return invalid;
+  const ctxOrError = lookupSession(manager, params, "click");
+  if (isRpcError(ctxOrError)) return ctxOrError;
+  const ctx = ctxOrError;
+  const earlyAbort = aborted(deps.signal);
+  if (earlyAbort) return earlyAbort;
+  const target = await resolveTargetTab(manager, ctx, params.tab_id, deps.tabsApi);
+  if (isRpcError(target)) return target;
+  const denied = enforceAgentWindow(ctx, target, "click");
+  if (denied) return denied;
+
+  const consumed = ctx.surfaceCaptures.consume(params.capture_id as string);
+  if (!consumed.ok) return captureConsumeError(consumed.reason);
+  const capture = consumed.capture;
+  const postConsumeAbort = aborted(deps.signal);
+  if (postConsumeAbort) return postConsumeAbort;
+
+  if (capture.sessionId !== ctx.sessionId || capture.tabId !== target.tabId) {
+    return stale("surface capture belongs to a different session or tab");
+  }
+  if (normaliseRef(params.ref as string) !== capture.surface.ref) {
+    return stale("surface ref does not match the capture");
+  }
+  const node = resolveSnapshotRef(ctx, params.ref as string, target.tabId, "screenshot");
+  if (isRpcError(node)) return stale(node.message);
+  if (
+    node.kind !== "surface" ||
+    node.backendNodeId !== capture.surface.backendNodeId ||
+    node.frameId !== capture.surface.frameId ||
+    node.generation !== capture.surface.observationGeneration
+  ) {
+    return stale("surface observation generation or node identity changed");
+  }
+
+  deps.cdp.trackSessionTab?.(ctx.sessionId, target.tabId);
+  try {
+    await deps.cdp.ensureAttachedToUrl?.(target.tabId, target.url);
+  } catch (error) {
+    return { code: "cdp_failed", message: error instanceof Error ? error.message : String(error) };
+  }
+  const environment = await captureSurfaceEnvironment(deps.cdp, target.tabId, node.frameId);
+  if (isRpcError(environment)) return environment;
+  if (
+    environment.navigationIdentity !== capture.navigationIdentity ||
+    environment.viewportSignature !== capture.viewportSignature ||
+    environment.frameProjectionSignature !== capture.frameProjectionSignature
+  ) {
+    return stale("navigation, viewport, zoom, scroll, or frame projection changed");
+  }
+
+  const geometry = await resolveNodeGeometry(
+    deps.cdp,
+    target.tabId,
+    {
+      target: {
+        tabId: target.tabId,
+        ...(node.cdpSessionId ? { sessionId: node.cdpSessionId } : {}),
+      },
+      backendNodeId: node.backendNodeId,
+      ...(node.frameId ? { frameId: node.frameId } : {}),
+    },
+    { scrollIntoView: false },
+  );
+  if (isRpcError(geometry)) return stale(geometry.message);
+  const currentRect = surfaceVisibleRect(geometry.topBounds, node.visibleRect);
+  if (!currentRect || !sameRect(currentRect, capture.topViewportRect)) {
+    return stale("surface visible region changed");
+  }
+  const point = mapImagePointToViewport(
+    capture.topViewportRect,
+    capture.imageWidth,
+    capture.imageHeight,
+    params.image_x as number,
+    params.image_y as number,
+  );
+  if (!point || !pointInRegion(point, geometry.topVisibleRegions)) {
+    return rpcError(
+      "invalid_params",
+      "surface_coordinate_invalid",
+      "image coordinate is outside the captured Surface",
+    );
+  }
+
+  const dialogCursor = markDialogCursor(deps.cdp, target.tabId);
+  let bypassEnabled = false;
+  let pressed = false;
+  const release = () =>
+    deps.cdp.send(target.tabId, "Input.dispatchMouseEvent", {
+      type: "mouseReleased",
+      x: point.x,
+      y: point.y,
+      button: "left",
+      clickCount: 1,
+      modifiers: 0,
+    });
+  try {
+    if (deps.bypassOverlay) {
+      await deps.bypassOverlay(target.tabId, true);
+      bypassEnabled = true;
+    }
+    await deps.cdp.send(target.tabId, "Input.dispatchMouseEvent", {
+      type: "mouseMoved",
+      x: point.x,
+      y: point.y,
+      modifiers: 0,
+    });
+    const beforePressAbort = aborted(deps.signal);
+    if (beforePressAbort) return beforePressAbort;
+    await deps.cdp.send(target.tabId, "Input.dispatchMouseEvent", {
+      type: "mousePressed",
+      x: point.x,
+      y: point.y,
+      button: "left",
+      clickCount: 1,
+      modifiers: 0,
+    });
+    pressed = true;
+    const afterPressAbort = aborted(deps.signal);
+    if (afterPressAbort) {
+      await release();
+      pressed = false;
+      return afterPressAbort;
+    }
+    await release();
+    pressed = false;
+  } catch (error) {
+    if (pressed) {
+      try {
+        await release();
+      } catch (releaseError) {
+        console.debug("[bsk surface-point] best-effort mouse release failed", releaseError);
+      }
+    }
+    return { code: "cdp_failed", message: error instanceof Error ? error.message : String(error) };
+  } finally {
+    if (bypassEnabled && deps.bypassOverlay) {
+      try {
+        await deps.bypassOverlay(target.tabId, false);
+      } catch (error) {
+        console.debug("[bsk surface-point] overlay bypass disable failed", error);
+      }
+    }
+  }
+
+  return attachDialogs(deps.cdp, target.tabId, dialogCursor, {
+    tab_id: target.tabId,
+    used_ref: capture.surface.ref,
+    x: point.x,
+    y: point.y,
+    capture_id: capture.id,
+    image_x: params.image_x,
+    image_y: params.image_y,
+  });
+}

--- a/apps/extension/src/tools/surface-point-action.ts
+++ b/apps/extension/src/tools/surface-point-action.ts
@@ -4,6 +4,7 @@ import type { ClickParams, ClickResult, RpcError } from "@/transport/types";
 import { attachDialogs, markDialogCursor } from "./dialogs";
 import { rpcError } from "./errors";
 import { resolveNodeGeometry } from "./frame-geometry";
+import { dispatchMouseClick } from "./mouse-input";
 import {
   type CdpRunner,
   type ChromeTabsApi,
@@ -33,6 +34,10 @@ export interface SurfacePointActionDeps {
   signal?: AbortSignal;
   bypassOverlay?: (tabId: number, enabled: boolean) => Promise<void>;
 }
+
+// Canvas-style controls commonly update their pointer hit-test on the next
+// animation frame. Leave a scheduling boundary after moving and before pressing.
+const SURFACE_POINTER_MOVE_SETTLE_MS = 32;
 
 function stale(message: string): RpcError {
   return rpcError("permission_denied", "surface_capture_stale", message);
@@ -249,54 +254,22 @@ export async function handleSurfacePointClick(
 
   const dialogCursor = markDialogCursor(deps.cdp, target.tabId);
   let bypassEnabled = false;
-  let pressed = false;
-  const release = () =>
-    deps.cdp.send(target.tabId, "Input.dispatchMouseEvent", {
-      type: "mouseReleased",
-      x: point.x,
-      y: point.y,
-      button: "left",
-      clickCount: 1,
-      modifiers: 0,
-    });
   try {
     if (deps.bypassOverlay) {
       await deps.bypassOverlay(target.tabId, true);
       bypassEnabled = true;
     }
-    await deps.cdp.send(target.tabId, "Input.dispatchMouseEvent", {
-      type: "mouseMoved",
-      x: point.x,
-      y: point.y,
-      modifiers: 0,
-    });
-    const beforePressAbort = aborted(deps.signal);
-    if (beforePressAbort) return beforePressAbort;
-    await deps.cdp.send(target.tabId, "Input.dispatchMouseEvent", {
-      type: "mousePressed",
-      x: point.x,
-      y: point.y,
+    const dispatch = await dispatchMouseClick(deps.cdp, target.tabId, point, {
       button: "left",
       clickCount: 1,
       modifiers: 0,
+      signal: deps.signal,
+      moveSettleMs: SURFACE_POINTER_MOVE_SETTLE_MS,
     });
-    pressed = true;
-    const afterPressAbort = aborted(deps.signal);
-    if (afterPressAbort) {
-      await release();
-      pressed = false;
-      return afterPressAbort;
+    if (dispatch === "cancelled") {
+      return { code: "cancelled", message: "surface point click aborted" };
     }
-    await release();
-    pressed = false;
   } catch (error) {
-    if (pressed) {
-      try {
-        await release();
-      } catch (releaseError) {
-        console.debug("[bsk surface-point] best-effort mouse release failed", releaseError);
-      }
-    }
     return { code: "cdp_failed", message: error instanceof Error ? error.message : String(error) };
   } finally {
     if (bypassEnabled && deps.bypassOverlay) {

--- a/apps/extension/src/tools/surface-target.ts
+++ b/apps/extension/src/tools/surface-target.ts
@@ -1,19 +1,9 @@
 import type { CdpFrameGraph } from "@/browser-driver/frame-graph";
-import type { SessionManager } from "@/session-manager/manager";
-import type { ClickParams, ClickResult, RpcError } from "@/transport/types";
-import { attachDialogs, markDialogCursor } from "./dialogs";
+import type { SessionContext } from "@/session-manager/manager";
+import type { RpcError } from "@/transport/types";
 import { rpcError } from "./errors";
 import { resolveNodeGeometry } from "./frame-geometry";
-import { dispatchMouseClick } from "./mouse-input";
-import {
-  type CdpRunner,
-  type ChromeTabsApi,
-  enforceAgentWindow,
-  isRpcError,
-  lookupSession,
-  normaliseRef,
-  resolveTargetTab,
-} from "./shared";
+import { type CdpRunner, isRpcError, normaliseRef } from "./shared";
 import { resolveSnapshotRef } from "./snapshot-ref";
 import {
   mapImagePointToViewport,
@@ -28,16 +18,33 @@ export interface SurfaceCaptureEnvironment {
   frameProjectionSignature: string;
 }
 
-export interface SurfacePointActionDeps {
+export interface SurfaceTargetResolverDeps {
   cdp: CdpRunner;
-  tabsApi: ChromeTabsApi;
   signal?: AbortSignal;
-  bypassOverlay?: (tabId: number, enabled: boolean) => Promise<void>;
+}
+
+export interface SurfacePointerTargetInput {
+  ref?: string;
+  selector?: string;
+  captureId?: string;
+  imageX?: number;
+  imageY?: number;
+}
+
+export interface ResolvedSurfacePointerTarget {
+  point: { x: number; y: number };
+  usedRef: string;
+  moveSettleMs: number;
+  capture: {
+    id: string;
+    imageX: number;
+    imageY: number;
+  };
 }
 
 // Canvas-style controls commonly update their pointer hit-test on the next
 // animation frame. Leave a scheduling boundary after moving and before pressing.
-const SURFACE_POINTER_MOVE_SETTLE_MS = 32;
+export const SURFACE_POINTER_MOVE_SETTLE_MS = 32;
 
 function stale(message: string): RpcError {
   return rpcError("permission_denied", "surface_capture_stale", message);
@@ -126,30 +133,21 @@ export async function captureSurfaceEnvironment(
   }
 }
 
-function validatePointParams(params: ClickParams): RpcError | null {
-  if (!params.capture_id || typeof params.capture_id !== "string") {
+function validatePointParams(input: SurfacePointerTargetInput): RpcError | null {
+  if (!input.captureId || typeof input.captureId !== "string") {
     return { code: "invalid_params", message: "surface point click requires capture_id" };
   }
-  if (typeof params.image_x !== "number" || !Number.isFinite(params.image_x)) {
+  if (typeof input.imageX !== "number" || !Number.isFinite(input.imageX)) {
     return { code: "invalid_params", message: "image_x must be a finite number" };
   }
-  if (typeof params.image_y !== "number" || !Number.isFinite(params.image_y)) {
+  if (typeof input.imageY !== "number" || !Number.isFinite(input.imageY)) {
     return { code: "invalid_params", message: "image_y must be a finite number" };
   }
-  if (!params.ref || params.selector) {
+  if (!input.ref || input.selector) {
     return {
       code: "invalid_params",
       message: "surface point click requires one Surface ref and does not accept a selector",
     };
-  }
-  if ((params.button ?? "left") !== "left" || (params.click_count ?? 1) !== 1) {
-    return {
-      code: "invalid_params",
-      message: "surface point click currently supports one left click only",
-    };
-  }
-  if (params.modifiers && params.modifiers.length > 0) {
-    return { code: "invalid_params", message: "surface point click does not accept modifiers" };
   }
   return null;
 }
@@ -160,27 +158,24 @@ function captureConsumeError(reason: "not_found" | "expired" | "consumed"): RpcE
 }
 
 function aborted(signal: AbortSignal | undefined): RpcError | null {
-  return signal?.aborted ? { code: "cancelled", message: "surface point click aborted" } : null;
+  return signal?.aborted
+    ? { code: "cancelled", message: "surface target resolution aborted" }
+    : null;
 }
 
-export async function handleSurfacePointClick(
-  manager: SessionManager,
-  params: ClickParams,
-  deps: SurfacePointActionDeps,
-): Promise<ClickResult | RpcError> {
-  const invalid = validatePointParams(params);
+/** Resolve one fresh Surface capture coordinate into a validated top-viewport pointer target. */
+export async function resolveSurfacePointerTarget(
+  ctx: SessionContext,
+  target: { tabId: number; url?: string },
+  input: SurfacePointerTargetInput,
+  deps: SurfaceTargetResolverDeps,
+): Promise<ResolvedSurfacePointerTarget | RpcError> {
+  const invalid = validatePointParams(input);
   if (invalid) return invalid;
-  const ctxOrError = lookupSession(manager, params, "click");
-  if (isRpcError(ctxOrError)) return ctxOrError;
-  const ctx = ctxOrError;
   const earlyAbort = aborted(deps.signal);
   if (earlyAbort) return earlyAbort;
-  const target = await resolveTargetTab(manager, ctx, params.tab_id, deps.tabsApi);
-  if (isRpcError(target)) return target;
-  const denied = enforceAgentWindow(ctx, target, "click");
-  if (denied) return denied;
 
-  const consumed = ctx.surfaceCaptures.consume(params.capture_id as string);
+  const consumed = ctx.surfaceCaptures.consume(input.captureId as string);
   if (!consumed.ok) return captureConsumeError(consumed.reason);
   const capture = consumed.capture;
   const postConsumeAbort = aborted(deps.signal);
@@ -189,10 +184,10 @@ export async function handleSurfacePointClick(
   if (capture.sessionId !== ctx.sessionId || capture.tabId !== target.tabId) {
     return stale("surface capture belongs to a different session or tab");
   }
-  if (normaliseRef(params.ref as string) !== capture.surface.ref) {
+  if (normaliseRef(input.ref as string) !== capture.surface.ref) {
     return stale("surface ref does not match the capture");
   }
-  const node = resolveSnapshotRef(ctx, params.ref as string, target.tabId, "screenshot");
+  const node = resolveSnapshotRef(ctx, input.ref as string, target.tabId, "screenshot");
   if (isRpcError(node)) return stale(node.message);
   if (
     node.kind !== "surface" ||
@@ -241,8 +236,8 @@ export async function handleSurfacePointClick(
     capture.topViewportRect,
     capture.imageWidth,
     capture.imageHeight,
-    params.image_x as number,
-    params.image_y as number,
+    input.imageX as number,
+    input.imageY as number,
   );
   if (!point || !pointInRegion(point, geometry.topVisibleRegions)) {
     return rpcError(
@@ -252,42 +247,14 @@ export async function handleSurfacePointClick(
     );
   }
 
-  const dialogCursor = markDialogCursor(deps.cdp, target.tabId);
-  let bypassEnabled = false;
-  try {
-    if (deps.bypassOverlay) {
-      await deps.bypassOverlay(target.tabId, true);
-      bypassEnabled = true;
-    }
-    const dispatch = await dispatchMouseClick(deps.cdp, target.tabId, point, {
-      button: "left",
-      clickCount: 1,
-      modifiers: 0,
-      signal: deps.signal,
-      moveSettleMs: SURFACE_POINTER_MOVE_SETTLE_MS,
-    });
-    if (dispatch === "cancelled") {
-      return { code: "cancelled", message: "surface point click aborted" };
-    }
-  } catch (error) {
-    return { code: "cdp_failed", message: error instanceof Error ? error.message : String(error) };
-  } finally {
-    if (bypassEnabled && deps.bypassOverlay) {
-      try {
-        await deps.bypassOverlay(target.tabId, false);
-      } catch (error) {
-        console.debug("[bsk surface-point] overlay bypass disable failed", error);
-      }
-    }
-  }
-
-  return attachDialogs(deps.cdp, target.tabId, dialogCursor, {
-    tab_id: target.tabId,
-    used_ref: capture.surface.ref,
-    x: point.x,
-    y: point.y,
-    capture_id: capture.id,
-    image_x: params.image_x,
-    image_y: params.image_y,
-  });
+  return {
+    point,
+    usedRef: capture.surface.ref,
+    moveSettleMs: SURFACE_POINTER_MOVE_SETTLE_MS,
+    capture: {
+      id: capture.id,
+      imageX: input.imageX as number,
+      imageY: input.imageY as number,
+    },
+  };
 }

--- a/apps/extension/src/transport/types.ts
+++ b/apps/extension/src/transport/types.ts
@@ -325,7 +325,15 @@ export interface ScreenshotResult {
   height: number;
   format: string;
   tab_id: number;
+  capture?: SurfaceCaptureInfo;
   dialogs?: JavaScriptDialogInfo[];
+}
+
+export interface SurfaceCaptureInfo {
+  id: string;
+  surface_ref: string;
+  coordinate_space: "capture-image-pixel";
+  expires_at: number;
 }
 
 export interface SnapshotParams {
@@ -446,6 +454,9 @@ export interface ClickParams {
   click_count?: number;
   modifiers?: KeyModifier[];
   timeout_ms?: number;
+  capture_id?: string;
+  image_x?: number;
+  image_y?: number;
 }
 
 export interface ClickResult {
@@ -454,6 +465,9 @@ export interface ClickResult {
   used_selector?: string;
   x: number;
   y: number;
+  capture_id?: string;
+  image_x?: number;
+  image_y?: number;
   dialogs?: JavaScriptDialogInfo[];
 }
 

--- a/apps/extension/src/transport/types.ts
+++ b/apps/extension/src/transport/types.ts
@@ -49,6 +49,11 @@ export type RpcErrorReason =
   | "download_capture_failed"
   | "transfer_outcome_unknown"
   | "transfer_timeout"
+  | "surface_capture_not_found"
+  | "surface_capture_expired"
+  | "surface_capture_consumed"
+  | "surface_capture_stale"
+  | "surface_coordinate_invalid"
   | "cleanup_failed";
 
 export type TransferEffectState = "none" | "committed" | "unknown";

--- a/apps/extension/test-fixtures/rendered-surfaces/README.md
+++ b/apps/extension/test-fixtures/rendered-surfaces/README.md
@@ -77,6 +77,14 @@ Expected Surface labels:
 
 The cross-origin frame uses `http://localhost:4173` while the parent uses `http://127.0.0.1:4173`. With Chromium site isolation this exercises the OOPIF path without an external service.
 
+Each frame Canvas also exposes a `pointer status` live region. A successful
+screenshot-bound point click must report
+`down button=0 buttons=1 hoverReady=true; click received` and turn the Canvas
+yellow. The hover flag is set on the animation frame after `pointermove`, so the
+fixture verifies both child-document delivery and the scheduling boundary
+required before `pointerdown`, rather than merely validating projected
+coordinates or a successful CDP response.
+
 ### `viewport.html`
 
 Run with a `900x700` Agent Window.

--- a/apps/extension/test-fixtures/rendered-surfaces/frame.html
+++ b/apps/extension/test-fixtures/rendered-surfaces/frame.html
@@ -8,6 +8,7 @@
       body { padding: 12px; background: #fdfefe; }
       canvas { display: block; width: 220px; height: 90px; background: #d5f5e3; border: 2px solid #1e8449; }
       iframe { width: 280px; height: 150px; margin-top: 10px; border: 2px solid #85929e; }
+      #pointer-status { margin: 8px 0 0; min-height: 20px; }
     </style>
   </head>
   <body>
@@ -16,11 +17,34 @@
       const params = new URLSearchParams(location.search);
       const canvas = document.querySelector("#frame-canvas");
       if (params.get("canvas") === "0") canvas.remove();
-      else canvas.setAttribute("aria-label", params.get("label") || "fixture-frame-default");
+      else {
+        canvas.setAttribute("aria-label", params.get("label") || "fixture-frame-default");
+        if (params.get("interactive") === "1") {
+          const status = document.createElement("p");
+          status.id = "pointer-status";
+          status.setAttribute("aria-live", "polite");
+          status.textContent = "pointer status: idle";
+          canvas.insertAdjacentElement("afterend", status);
+          let hoverReady = false;
+          canvas.addEventListener("pointermove", () => {
+            hoverReady = false;
+            requestAnimationFrame(() => {
+              hoverReady = true;
+            });
+          });
+          canvas.addEventListener("pointerdown", (event) => {
+            status.textContent = `pointer status: down button=${event.button} buttons=${event.buttons} hoverReady=${hoverReady}`;
+            if (event.buttons === 1 && hoverReady) canvas.style.background = "#f9e79f";
+          });
+          canvas.addEventListener("click", () => {
+            status.textContent += "; click received";
+          });
+        }
+      }
       if (params.get("nested") === "1") {
         const iframe = document.createElement("iframe");
         iframe.title = "nested fixture frame";
-        iframe.src = "frame.html?label=fixture-nested-frame";
+        iframe.src = "frame.html?label=fixture-nested-frame&interactive=1";
         document.body.append(iframe);
       }
     </script>

--- a/apps/extension/test-fixtures/rendered-surfaces/frames.html
+++ b/apps/extension/test-fixtures/rendered-surfaces/frames.html
@@ -14,8 +14,8 @@
   <body>
     <h1>Frame matrix</h1>
     <div class="frames">
-      <iframe title="same-origin fixture" src="frame.html?label=fixture-same-origin-frame"></iframe>
-      <iframe title="cross-origin fixture" src="http://localhost:4173/frame.html?label=fixture-cross-origin-frame"></iframe>
+      <iframe title="same-origin fixture" src="frame.html?label=fixture-same-origin-frame&interactive=1"></iframe>
+      <iframe title="cross-origin fixture" src="http://localhost:4173/frame.html?label=fixture-cross-origin-frame&interactive=1"></iframe>
       <iframe title="nested fixture" src="frame.html?canvas=0&nested=1"></iframe>
     </div>
   </body>

--- a/crates/bsk-cli/skill/SKILL.md
+++ b/crates/bsk-cli/skill/SKILL.md
@@ -76,12 +76,24 @@ is cheaper and more precise.
 When `bsk observe` renders
 `@eN surface ... [visual-only; requires=image-understanding; ...]`, the ref identifies rendered
 canvas content that is not represented by the text observation, not an interactable DOM control.
-Keep using any reliable DOM/AX text and controls that appear alongside it. If you can actually
-inspect image output, use `bsk screenshot --ref @eN --session <id>` to obtain the visible crop. If
-you lack multimodal or image-reading capability, do not take a screenshot and pretend to know its
-contents, and never guess coordinates; tell the user that they need to switch to a model with
-image-understanding capability. Do not pass a visual surface ref to click, fill, hover, or select;
-those commands intentionally reject screenshot-only refs.
+Keep using any reliable DOM/AX text and controls that appear alongside it. If you lack multimodal or
+image-reading capability, do not take a screenshot and pretend to know its contents, and never guess
+coordinates; tell the user that they need to switch to a model with image-understanding capability.
+
+If you can actually inspect image output, use `bsk screenshot --ref @eN --session <id>` to obtain
+the visible crop and its short-lived, single-use Surface capture id. Only when the task requires a
+point action and the image provides a clear target, bind that exact screenshot to the click command:
+
+```bash
+bsk click @eN --capture <capture-id> --image-x <px> --image-y <px> --session <id>
+```
+
+Coordinates are pixels in the returned capture image, not viewport CSS coordinates. Re-observing,
+navigating, scrolling, resizing, zooming, changing Frame projection, expiry, or reusing the capture
+makes the action fail; take a new Surface screenshot instead of adjusting or retrying coordinates.
+A point click does not reveal Canvas semantics and must not be followed by an assumed fill/press
+workflow. Without all three capture arguments, visual Surface refs remain screenshot-only and
+click/fill/hover/select reject them.
 
 Escalate page reading only as needed:
 
@@ -135,6 +147,7 @@ Required flags that are easy to get wrong:
 bsk fill <ref> --value <text>      bsk select <ref> --value <option-value>
 bsk screenshot --out <path>        bsk emulate --device <preset-id>
 bsk upload <ref> --file <path>     bsk download <ref> --out <path>
+bsk click <surface-ref> --capture <id> --image-x <px> --image-y <px>
 ```
 
 `select` matches an option's `value` attribute, not its visible label. Device preset ids are

--- a/crates/bsk-cli/src/cli/interaction.rs
+++ b/crates/bsk-cli/src/cli/interaction.rs
@@ -136,6 +136,18 @@ pub struct ClickArgs {
 
     #[arg(long, default_value = "30s", value_parser = parse_timeout_ms)]
     pub timeout: u32,
+
+    /// Capture id returned by `bsk screenshot --ref <surface>`.
+    #[arg(long)]
+    pub capture: Option<String>,
+
+    /// X coordinate in capture-image pixels. Requires `--capture` and `--image-y`.
+    #[arg(long = "image-x", allow_hyphen_values = true)]
+    pub image_x: Option<f64>,
+
+    /// Y coordinate in capture-image pixels. Requires `--capture` and `--image-x`.
+    #[arg(long = "image-y", allow_hyphen_values = true)]
+    pub image_y: Option<f64>,
 }
 
 pub fn dispatch_click(args: ClickArgs, format: Format) -> Result<(), CliError> {
@@ -147,6 +159,14 @@ pub fn dispatch_click(args: ClickArgs, format: Format) -> Result<(), CliError> {
     )?;
     let modifiers = parse_modifiers(&args.modifiers)
         .map_err(|e| CliError::Local(anyhow::anyhow!("--modifiers: {e}")))?;
+    let point_arg_count = usize::from(args.capture.is_some())
+        + usize::from(args.image_x.is_some())
+        + usize::from(args.image_y.is_some());
+    if point_arg_count != 0 && point_arg_count != 3 {
+        return Err(CliError::Local(anyhow::anyhow!(
+            "--capture, --image-x, and --image-y must be given together"
+        )));
+    }
     let params = ClickParams {
         session_id: args.session.clone(),
         ref_,
@@ -160,6 +180,9 @@ pub fn dispatch_click(args: ClickArgs, format: Format) -> Result<(), CliError> {
             Some(modifiers)
         },
         timeout_ms: Some(args.timeout),
+        capture_id: args.capture.clone(),
+        image_x: args.image_x,
+        image_y: args.image_y,
     };
     let reply: ClickResult = call(
         info.sock_path,
@@ -183,6 +206,14 @@ pub fn dispatch_click(args: ClickArgs, format: Format) -> Result<(), CliError> {
                 "click ok tab={} target={target} at=({}, {})",
                 reply.tab_id, reply.x, reply.y
             );
+            if let Some(capture_id) = &reply.capture_id {
+                println!(
+                    "capture={} image=({}, {}) coordinate_space=capture-image-pixel",
+                    capture_id,
+                    reply.image_x.unwrap_or_default(),
+                    reply.image_y.unwrap_or_default()
+                );
+            }
             print_dialog_summaries(&reply.dialogs);
         }
     }

--- a/crates/bsk-cli/src/cli/render_error.rs
+++ b/crates/bsk-cli/src/cli/render_error.rs
@@ -65,6 +65,11 @@ pub mod reason {
     pub const DOWNLOAD_CAPTURE_FAILED: &str = "download_capture_failed";
     pub const TRANSFER_OUTCOME_UNKNOWN: &str = "transfer_outcome_unknown";
     pub const TRANSFER_TIMEOUT: &str = "transfer_timeout";
+    pub const SURFACE_CAPTURE_NOT_FOUND: &str = "surface_capture_not_found";
+    pub const SURFACE_CAPTURE_EXPIRED: &str = "surface_capture_expired";
+    pub const SURFACE_CAPTURE_CONSUMED: &str = "surface_capture_consumed";
+    pub const SURFACE_CAPTURE_STALE: &str = "surface_capture_stale";
+    pub const SURFACE_COORDINATE_INVALID: &str = "surface_coordinate_invalid";
     pub const SESSION_BUSY: &str = crate::rpc_reason::SESSION_BUSY;
     pub const RECORD_START_PAGE_UNREACHABLE: &str = "record_start_page_unreachable";
 }
@@ -303,7 +308,7 @@ pub fn info_for_error(code: ErrorCode, data: Option<&serde_json::Value>) -> Rend
         (ErrorCode::PermissionDenied, reason::REF_CAPABILITY_DENIED) => RenderInfo {
             summary: "snapshot ref does not support this operation",
             hint: Some(
-                "visual surface refs are screenshot-only; inspect `bsk screenshot --ref <ref> --session <id>` with image-understanding capability",
+                "visual Surface refs require image understanding; inspect `bsk screenshot --ref <ref> --session <id>`, then bind its capture id and image coordinates to `bsk click`",
             ),
             exit_code: base.exit_code,
         },
@@ -346,6 +351,41 @@ pub fn info_for_error(code: ErrorCode, data: Option<&serde_json::Value>) -> Rend
             summary: "the browser could not capture the tab image",
             hint: Some(
                 "both the visible-tab capture and the CDP compositor fallback failed inside the browser; this points at a browser-side rendering/readback issue — try reloading the tab, restarting the browser, or upgrading/downgrading Chrome",
+            ),
+            exit_code: base.exit_code,
+        },
+        (ErrorCode::NotFound, reason::SURFACE_CAPTURE_NOT_FOUND) => RenderInfo {
+            summary: "surface capture transaction was not found",
+            hint: Some(
+                "take a fresh surface screenshot and use its capture id with coordinates from that image",
+            ),
+            exit_code: base.exit_code,
+        },
+        (ErrorCode::PermissionDenied, reason::SURFACE_CAPTURE_EXPIRED) => RenderInfo {
+            summary: "surface capture transaction has expired",
+            hint: Some(
+                "take a fresh surface screenshot, then click promptly with that capture id and image coordinates",
+            ),
+            exit_code: base.exit_code,
+        },
+        (ErrorCode::PermissionDenied, reason::SURFACE_CAPTURE_CONSUMED) => RenderInfo {
+            summary: "surface capture transaction was already used",
+            hint: Some(
+                "each capture id is single-use; take a fresh surface screenshot before another point action",
+            ),
+            exit_code: base.exit_code,
+        },
+        (ErrorCode::PermissionDenied, reason::SURFACE_CAPTURE_STALE) => RenderInfo {
+            summary: "page state changed since the surface screenshot",
+            hint: Some(
+                "take a fresh surface screenshot and choose coordinates from the new image before retrying",
+            ),
+            exit_code: base.exit_code,
+        },
+        (ErrorCode::InvalidParams, reason::SURFACE_COORDINATE_INVALID) => RenderInfo {
+            summary: "surface image coordinate is invalid",
+            hint: Some(
+                "use finite pixel coordinates inside the captured image; its top-left corner is (0, 0)",
             ),
             exit_code: base.exit_code,
         },
@@ -578,7 +618,7 @@ mod tests {
         let info = info_for_error(ErrorCode::PermissionDenied, Some(&data));
         assert_eq!(info.summary, "snapshot ref does not support this operation");
         assert!(
-            info.hint.unwrap().contains("screenshot-only"),
+            info.hint.unwrap().contains("capture id"),
             "expected visual-surface-specific hint"
         );
         assert_eq!(info.exit_code, 1);
@@ -682,6 +722,25 @@ mod tests {
         let timeout = serde_json::json!({ "reason": reason::TRANSFER_TIMEOUT });
         let info = info_for_error(ErrorCode::Timeout, Some(&timeout));
         assert!(info.summary.contains("timed out after browser dispatch"));
+    }
+
+    #[test]
+    fn surface_capture_stale_requests_a_fresh_screenshot() {
+        let data = serde_json::json!({ "reason": reason::SURFACE_CAPTURE_STALE });
+        let info = info_for_error(ErrorCode::PermissionDenied, Some(&data));
+        assert_eq!(
+            info.summary,
+            "page state changed since the surface screenshot"
+        );
+        assert!(info.hint.unwrap().contains("fresh surface screenshot"));
+    }
+
+    #[test]
+    fn surface_coordinate_invalid_explains_image_pixel_bounds() {
+        let data = serde_json::json!({ "reason": reason::SURFACE_COORDINATE_INVALID });
+        let info = info_for_error(ErrorCode::InvalidParams, Some(&data));
+        assert_eq!(info.summary, "surface image coordinate is invalid");
+        assert!(info.hint.unwrap().contains("top-left corner is (0, 0)"));
     }
 
     #[test]

--- a/crates/bsk-cli/src/cli/screenshot.rs
+++ b/crates/bsk-cli/src/cli/screenshot.rs
@@ -59,7 +59,7 @@ fn run(sock: PathBuf, args: ScreenshotArgs, format: Format) -> Result<(), CliErr
         .map_err(CliError::Local)?;
     match format {
         Format::Json => {
-            let json = serde_json::json!({
+            let mut json = serde_json::json!({
                 "tab_id": reply.tab_id,
                 "width": reply.width,
                 "height": reply.height,
@@ -67,6 +67,10 @@ fn run(sock: PathBuf, args: ScreenshotArgs, format: Format) -> Result<(), CliErr
                 "path": out_path.to_string_lossy(),
                 "byte_size": bytes.len(),
             });
+            if let Some(capture) = &reply.capture {
+                json["capture"] = serde_json::to_value(capture)
+                    .map_err(|e| CliError::Local(anyhow::anyhow!(e)))?;
+            }
             println!(
                 "{}",
                 serde_json::to_string_pretty(&json)
@@ -75,6 +79,12 @@ fn run(sock: PathBuf, args: ScreenshotArgs, format: Format) -> Result<(), CliErr
         }
         Format::Human => {
             println!("{}", out_path.display());
+            if let Some(capture) = &reply.capture {
+                println!(
+                    "capture={} surface={} coordinate_space={} expires_at={}",
+                    capture.id, capture.surface_ref, capture.coordinate_space, capture.expires_at
+                );
+            }
             print_dialog_summaries(&reply.dialogs);
         }
     }

--- a/crates/bsk-cli/tests/cli_parse.rs
+++ b/crates/bsk-cli/tests/cli_parse.rs
@@ -238,6 +238,29 @@ fn parses_click_count_alias() {
 }
 
 #[test]
+fn parses_surface_capture_image_coordinates() {
+    let cli = parse(&[
+        "bsk",
+        "click",
+        "@e1",
+        "--session",
+        "s1",
+        "--capture",
+        "sc_test",
+        "--image-x",
+        "160.5",
+        "--image-y",
+        "-1",
+    ]);
+    let Command::Click(args) = cli.command else {
+        panic!("expected click command");
+    };
+    assert_eq!(args.capture.as_deref(), Some("sc_test"));
+    assert_eq!(args.image_x, Some(160.5));
+    assert_eq!(args.image_y, Some(-1.0));
+}
+
+#[test]
 fn parses_hover_with_settle() {
     let cli = parse(&[
         "bsk",

--- a/crates/bsk-cli/tests/tools_ipc.rs
+++ b/crates/bsk-cli/tests/tools_ipc.rs
@@ -238,6 +238,7 @@ async fn screenshot_returns_image_base64_with_dimensions() {
                 height: 600,
                 format: "png".into(),
                 tab_id: 7,
+                capture: None,
                 dialogs: vec![],
             })
             .unwrap(),
@@ -286,6 +287,7 @@ async fn screenshot_forwards_ref_to_extension() {
                 height: 60,
                 format: "png".into(),
                 tab_id: 7,
+                capture: None,
                 dialogs: vec![],
             })
             .unwrap(),

--- a/crates/bsk-cli/tests/tools_m7_ipc.rs
+++ b/crates/bsk-cli/tests/tools_m7_ipc.rs
@@ -354,6 +354,9 @@ async fn click_round_trips_ref_and_modifiers() {
                 used_selector: None,
                 x: 12.5,
                 y: 34.0,
+                capture_id: None,
+                image_x: None,
+                image_y: None,
                 dialogs: vec![],
             })
             .unwrap(),
@@ -373,6 +376,9 @@ async fn click_round_trips_ref_and_modifiers() {
             click_count: Some(1),
             modifiers: Some(vec![KeyModifier::Ctrl, KeyModifier::Shift]),
             timeout_ms: Some(5_000),
+            capture_id: None,
+            image_x: None,
+            image_y: None,
         },
     )
     .await
@@ -610,6 +616,9 @@ async fn m7_tools_propagate_extension_errors() {
             click_count: None,
             modifiers: None,
             timeout_ms: Some(5_000),
+            capture_id: None,
+            image_x: None,
+            image_y: None,
         },
     )
     .await

--- a/crates/bsk-protocol/schema/tool_click_params.json
+++ b/crates/bsk-protocol/schema/tool_click_params.json
@@ -16,6 +16,13 @@
         }
       ]
     },
+    "capture_id": {
+      "description": "Short-lived capture id returned by a visual Surface screenshot.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "click_count": {
       "description": "Number of consecutive mouse presses (double-click = 2).",
       "type": [
@@ -24,6 +31,22 @@
       ],
       "format": "uint32",
       "minimum": 1.0
+    },
+    "image_x": {
+      "description": "X coordinate in the capture image's pixel coordinate space.",
+      "type": [
+        "number",
+        "null"
+      ],
+      "format": "double"
+    },
+    "image_y": {
+      "description": "Y coordinate in the capture image's pixel coordinate space.",
+      "type": [
+        "number",
+        "null"
+      ],
+      "format": "double"
     },
     "modifiers": {
       "type": [

--- a/crates/bsk-protocol/schema/tool_click_result.json
+++ b/crates/bsk-protocol/schema/tool_click_result.json
@@ -8,12 +8,32 @@
     "y"
   ],
   "properties": {
+    "capture_id": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "dialogs": {
       "description": "Native JS dialogs observed and auto-handled during this call.",
       "type": "array",
       "items": {
         "$ref": "#/definitions/JavaScriptDialogInfo"
       }
+    },
+    "image_x": {
+      "type": [
+        "number",
+        "null"
+      ],
+      "format": "double"
+    },
+    "image_y": {
+      "type": [
+        "number",
+        "null"
+      ],
+      "format": "double"
     },
     "tab_id": {
       "type": "integer",

--- a/crates/bsk-protocol/schema/tool_screenshot_result.json
+++ b/crates/bsk-protocol/schema/tool_screenshot_result.json
@@ -8,6 +8,16 @@
     "tab_id"
   ],
   "properties": {
+    "capture": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/SurfaceCaptureInfo"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "dialogs": {
       "type": "array",
       "items": {
@@ -109,6 +119,31 @@
         "prompt",
         "beforeunload"
       ]
+    },
+    "SurfaceCaptureInfo": {
+      "type": "object",
+      "required": [
+        "coordinate_space",
+        "expires_at",
+        "id",
+        "surface_ref"
+      ],
+      "properties": {
+        "coordinate_space": {
+          "type": "string"
+        },
+        "expires_at": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "id": {
+          "type": "string"
+        },
+        "surface_ref": {
+          "type": "string"
+        }
+      }
     }
   }
 }

--- a/crates/bsk-protocol/src/tools/interaction.rs
+++ b/crates/bsk-protocol/src/tools/interaction.rs
@@ -67,6 +67,15 @@ pub struct ClickParams {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[schemars(range(min = 1))]
     pub timeout_ms: Option<u32>,
+    /// Short-lived capture id returned by a visual Surface screenshot.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub capture_id: Option<String>,
+    /// X coordinate in the capture image's pixel coordinate space.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub image_x: Option<f64>,
+    /// Y coordinate in the capture image's pixel coordinate space.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub image_y: Option<f64>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
@@ -80,6 +89,12 @@ pub struct ClickResult {
     /// agents can correlate with a follow-up `tool.screenshot`.
     pub x: f64,
     pub y: f64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub capture_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub image_x: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub image_y: Option<f64>,
     /// Native JS dialogs observed and auto-handled during this call.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub dialogs: Vec<JavaScriptDialogInfo>,
@@ -288,6 +303,9 @@ mod tests {
             click_count: Some(1),
             modifiers: Some(vec![KeyModifier::Ctrl]),
             timeout_ms: Some(5_000),
+            capture_id: Some("sc_test".into()),
+            image_x: Some(160.0),
+            image_y: Some(90.0),
         };
         let v = serde_json::to_value(&p).unwrap();
         assert_eq!(v.get("ref").and_then(|v| v.as_str()), Some("@e3"));

--- a/crates/bsk-protocol/src/tools/observation.rs
+++ b/crates/bsk-protocol/src/tools/observation.rs
@@ -233,8 +233,18 @@ pub struct ScreenshotResult {
     /// Always `"png"` in v0.1; reserved for future JPEG / WebP support.
     pub format: String,
     pub tab_id: i64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub capture: Option<SurfaceCaptureInfo>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub dialogs: Vec<JavaScriptDialogInfo>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct SurfaceCaptureInfo {
+    pub id: String,
+    pub surface_ref: String,
+    pub coordinate_space: String,
+    pub expires_at: u64,
 }
 
 #[cfg(test)]
@@ -318,6 +328,12 @@ mod tests {
             height: 600,
             format: "png".into(),
             tab_id: 7,
+            capture: Some(SurfaceCaptureInfo {
+                id: "sc_test".into(),
+                surface_ref: "@e3".into(),
+                coordinate_space: "capture-image-pixel".into(),
+                expires_at: 1_700_000_030_000,
+            }),
             dialogs: vec![],
         };
         let v = serde_json::to_value(&r).unwrap();

--- a/packages/dsh-plugin-browserskill/src/tools.ts
+++ b/packages/dsh-plugin-browserskill/src/tools.ts
@@ -581,9 +581,15 @@ function defineBrowserOperations(deps: ToolDeps, register: DefinitionRegistrar):
           type: "integer",
           description: "Number of consecutive presses (double-click = 2).",
         },
+        modifiers: {
+          type: "array",
+          items: { type: "string", enum: ["alt", "ctrl", "meta", "shift"] },
+          description: "Keyboard modifiers held during the click.",
+        },
         captureId: {
           type: "string",
-          description: "Short-lived Surface capture id returned by browser_screenshot.",
+          description:
+            "Short-lived Surface capture id returned by browser_inspect action=screenshot.",
         },
         imageX: {
           type: "number",
@@ -626,6 +632,9 @@ function defineBrowserOperations(deps: ToolDeps, register: DefinitionRegistrar):
         const cmdArgs = ["click", "--session", sessionId];
         if (args.button !== undefined) cmdArgs.push("--button", args.button);
         if (args.clickCount !== undefined) cmdArgs.push("--click-count", String(args.clickCount));
+        if (args.modifiers !== undefined && args.modifiers.length > 0) {
+          cmdArgs.push("--modifiers", args.modifiers.join(","));
+        }
         if (args.captureId !== undefined) {
           cmdArgs.push(
             "--capture",

--- a/packages/dsh-plugin-browserskill/src/tools.ts
+++ b/packages/dsh-plugin-browserskill/src/tools.ts
@@ -563,7 +563,8 @@ function defineBrowserOperations(deps: ToolDeps, register: DefinitionRegistrar):
       name: "interact.click",
       description:
         "Click an element in the session's active tab. Target is a snapshot ref (@e3) from the " +
-        "last browser_inspect observation, or a CSS selector.",
+        "last browser_inspect observation, or a CSS selector. A visual Surface requires the " +
+        "captureId and image coordinates returned by browser_inspect action=screenshot.",
       parameters: {
         target: {
           type: "string",
@@ -580,6 +581,18 @@ function defineBrowserOperations(deps: ToolDeps, register: DefinitionRegistrar):
           type: "integer",
           description: "Number of consecutive presses (double-click = 2).",
         },
+        captureId: {
+          type: "string",
+          description: "Short-lived Surface capture id returned by browser_screenshot.",
+        },
+        imageX: {
+          type: "number",
+          description: "X coordinate in capture-image pixels; requires captureId and imageY.",
+        },
+        imageY: {
+          type: "number",
+          description: "Y coordinate in capture-image pixels; requires captureId and imageX.",
+        },
       },
       output: {
         schema: {
@@ -590,6 +603,7 @@ function defineBrowserOperations(deps: ToolDeps, register: DefinitionRegistrar):
             tabId: { type: "integer", required: true },
             x: { type: "number", required: true },
             y: { type: "number", required: true },
+            captureId: { type: "string" },
           },
         },
         render: (_args, value) => [
@@ -601,17 +615,41 @@ function defineBrowserOperations(deps: ToolDeps, register: DefinitionRegistrar):
       },
       async execute(args, exec) {
         if (args.target.trim().length === 0) throw new Error("target must be a non-empty string");
+        const pointArgCount =
+          Number(args.captureId !== undefined) +
+          Number(args.imageX !== undefined) +
+          Number(args.imageY !== undefined);
+        if (pointArgCount !== 0 && pointArgCount !== 3) {
+          throw new Error("captureId, imageX, and imageY must be given together");
+        }
         const sessionId = registry.resolve(args.session, "browser_interact(action=click)");
         const cmdArgs = ["click", "--session", sessionId];
         if (args.button !== undefined) cmdArgs.push("--button", args.button);
         if (args.clickCount !== undefined) cmdArgs.push("--click-count", String(args.clickCount));
+        if (args.captureId !== undefined) {
+          cmdArgs.push(
+            "--capture",
+            args.captureId,
+            "--image-x",
+            String(args.imageX),
+            "--image-y",
+            String(args.imageY),
+          );
+        }
         cmdArgs.push(args.target);
         const reply = (await runBsk(deps, exec, cmdArgs, "click", sessionId)) as {
           tab_id: number;
           x: number;
           y: number;
+          capture_id?: string;
         };
-        return { session: sessionId, tabId: reply.tab_id, x: reply.x, y: reply.y };
+        return {
+          session: sessionId,
+          tabId: reply.tab_id,
+          x: reply.x,
+          y: reply.y,
+          ...(reply.capture_id !== undefined ? { captureId: reply.capture_id } : {}),
+        };
       },
       presentCall: (args) => ({
         card: "terminal",
@@ -780,6 +818,8 @@ function defineBrowserOperations(deps: ToolDeps, register: DefinitionRegistrar):
             width: { type: "integer", required: true },
             height: { type: "integer", required: true },
             byteSize: { type: "integer", required: true },
+            captureId: { type: "string" },
+            captureExpiresAt: { type: "integer" },
             image: {
               type: "object",
               additionalProperties: false,
@@ -803,7 +843,11 @@ function defineBrowserOperations(deps: ToolDeps, register: DefinitionRegistrar):
             value.image !== undefined
               ? `[session ${value.session}] screenshot of tab ${value.tabId} (${value.width}x${value.height}px)`
               : `[session ${value.session}] screenshot saved to ${value.path} (${value.width}x${value.height}px, ${value.byteSize} bytes) — this deployment cannot inline images; read the file to view it`;
-          const blocks: ContentBlock[] = [{ type: "text", text }];
+          const captureText =
+            value.captureId !== undefined
+              ? ` Surface capture ${value.captureId} uses capture-image-pixel coordinates and expires at ${value.captureExpiresAt}.`
+              : "";
+          const blocks: ContentBlock[] = [{ type: "text", text: text + captureText }];
           if (value.image !== undefined) {
             blocks.push({
               type: "image",
@@ -842,6 +886,7 @@ function defineBrowserOperations(deps: ToolDeps, register: DefinitionRegistrar):
             height: number;
             path: string;
             byte_size: number;
+            capture?: { id: string; expires_at: number };
           };
           writtenPath = reply.path;
           const data = await readFile(reply.path);
@@ -855,6 +900,9 @@ function defineBrowserOperations(deps: ToolDeps, register: DefinitionRegistrar):
             width: reply.width,
             height: reply.height,
             byteSize: reply.byte_size,
+            ...(reply.capture !== undefined
+              ? { captureId: reply.capture.id, captureExpiresAt: reply.capture.expires_at }
+              : {}),
             ...(ref !== undefined
               ? {
                   image: {

--- a/packages/dsh-plugin-browserskill/tests/tools.test.ts
+++ b/packages/dsh-plugin-browserskill/tests/tools.test.ts
@@ -499,6 +499,41 @@ describe("interaction tools", () => {
     ]);
   });
 
+  it("interact.click forwards a complete Surface capture coordinate transaction", async () => {
+    const { tools, calls } = setup({
+      ...responses,
+      click: {
+        tab_id: 7,
+        used_ref: "e1",
+        x: 110,
+        y: 70,
+        capture_id: "sc_test",
+        image_x: 200,
+        image_y: 100,
+      },
+    });
+    await startSession(tools);
+    const click = tools.get("interact.click");
+    const value = await click?.execute(
+      { target: "@e1", captureId: "sc_test", imageX: 200, imageY: 100 },
+      makeExec(),
+    );
+
+    expect(value).toMatchObject({ captureId: "sc_test", x: 110, y: 70 });
+    expect(calls[1].args).toEqual([
+      "click",
+      "--session",
+      "s1",
+      "--capture",
+      "sc_test",
+      "--image-x",
+      "200",
+      "--image-y",
+      "100",
+      "@e1",
+    ]);
+  });
+
   it("interact.fill passes value and --no-clear", async () => {
     const { tools, calls } = setup(responses);
     await startSession(tools);
@@ -921,6 +956,32 @@ describe("inspect.screenshot", () => {
     expect(calls[1].args).toContain("--ref");
     const rendered = screenshot?.output.render({ session: "s1" }, value as never);
     expect(rendered?.every((block) => block.type === "text")).toBe(true);
+  });
+
+  it("returns Surface capture metadata alongside the screenshot", async () => {
+    const path = pngFile();
+    const { tools } = setup({
+      "session start": START_REPLY("s1"),
+      screenshot: {
+        tab_id: 7,
+        width: 800,
+        height: 600,
+        format: "png",
+        path,
+        byte_size: 8,
+        capture: { id: "sc_test", expires_at: 1700000030000 },
+      },
+    });
+    await startSession(tools);
+    const screenshot = tools.get("browser_screenshot");
+    const value = await screenshot?.execute({ ref: "@e1" }, makeExec());
+
+    expect(value).toMatchObject({
+      captureId: "sc_test",
+      captureExpiresAt: 1700000030000,
+    });
+    const rendered = screenshot?.output.render({ session: "s1" }, value as never);
+    expect(rendered?.[0]).toMatchObject({ type: "text", text: expect.stringContaining("sc_test") });
   });
 
   it("commits the image through the attachment store on an image-capable route", async () => {

--- a/packages/dsh-plugin-browserskill/tests/tools.test.ts
+++ b/packages/dsh-plugin-browserskill/tests/tools.test.ts
@@ -478,12 +478,12 @@ describe("interaction tools", () => {
     emulate: { tab_id: 7, cleared: false },
   };
 
-  it("interact.click maps target, button, and click count", async () => {
+  it("interact.click maps target, button, click count, and modifiers", async () => {
     const { tools, calls } = setup(responses);
     await startSession(tools);
     const click = tools.get("interact.click");
     const value = (await click?.execute(
-      { target: "@e1", button: "right", clickCount: 2 },
+      { target: "@e1", button: "right", clickCount: 2, modifiers: ["ctrl", "shift"] },
       makeExec(),
     )) as { session: string; x: number; y: number };
     expect(value).toMatchObject({ session: "s1", x: 10, y: 20 });
@@ -495,6 +495,8 @@ describe("interaction tools", () => {
       "right",
       "--click-count",
       "2",
+      "--modifiers",
+      "ctrl,shift",
       "@e1",
     ]);
   });
@@ -973,7 +975,7 @@ describe("inspect.screenshot", () => {
       },
     });
     await startSession(tools);
-    const screenshot = tools.get("browser_screenshot");
+    const screenshot = tools.get("inspect.screenshot");
     const value = await screenshot?.execute({ ref: "@e1" }, makeExec());
 
     expect(value).toMatchObject({

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -76,12 +76,24 @@ is cheaper and more precise.
 When `bsk observe` renders
 `@eN surface ... [visual-only; requires=image-understanding; ...]`, the ref identifies rendered
 canvas content that is not represented by the text observation, not an interactable DOM control.
-Keep using any reliable DOM/AX text and controls that appear alongside it. If you can actually
-inspect image output, use `bsk screenshot --ref @eN --session <id>` to obtain the visible crop. If
-you lack multimodal or image-reading capability, do not take a screenshot and pretend to know its
-contents, and never guess coordinates; tell the user that they need to switch to a model with
-image-understanding capability. Do not pass a visual surface ref to click, fill, hover, or select;
-those commands intentionally reject screenshot-only refs.
+Keep using any reliable DOM/AX text and controls that appear alongside it. If you lack multimodal or
+image-reading capability, do not take a screenshot and pretend to know its contents, and never guess
+coordinates; tell the user that they need to switch to a model with image-understanding capability.
+
+If you can actually inspect image output, use `bsk screenshot --ref @eN --session <id>` to obtain
+the visible crop and its short-lived, single-use Surface capture id. Only when the task requires a
+point action and the image provides a clear target, bind that exact screenshot to the click command:
+
+```bash
+bsk click @eN --capture <capture-id> --image-x <px> --image-y <px> --session <id>
+```
+
+Coordinates are pixels in the returned capture image, not viewport CSS coordinates. Re-observing,
+navigating, scrolling, resizing, zooming, changing Frame projection, expiry, or reusing the capture
+makes the action fail; take a new Surface screenshot instead of adjusting or retrying coordinates.
+A point click does not reveal Canvas semantics and must not be followed by an assumed fill/press
+workflow. Without all three capture arguments, visual Surface refs remain screenshot-only and
+click/fill/hover/select reject them.
 
 Escalate page reading only as needed:
 
@@ -135,6 +147,7 @@ Required flags that are easy to get wrong:
 bsk fill <ref> --value <text>      bsk select <ref> --value <option-value>
 bsk screenshot --out <path>        bsk emulate --device <preset-id>
 bsk upload <ref> --file <path>     bsk download <ref> --out <path>
+bsk click <surface-ref> --capture <id> --image-x <px> --image-y <px>
 ```
 
 `select` matches an option's `value` attribute, not its visible label. Device preset ids are


### PR DESCRIPTION
## 问题描述

PR #138 已经能够在 `observe` 中发现 Canvas 可视区域，将其表示为 visual-only Surface，并允许 Agent 按 Surface ref 获取局部截图。但该 PR 只建立了“发现 Canvas → 截图”的链路。即使支持多模态的 Agent 能够从截图中识别目标，仍然无法安全地点击 Canvas 内部的具体位置。

直接使用截图坐标或视口坐标存在以下问题：

- 截图中的像素坐标不等于页面 viewport CSS 坐标。
- Canvas 可能被视口或父容器裁剪，截图只包含其当前可见区域。
- 页面可能存在设备缩放、浏览器缩放和不同 DPR。
- Canvas 可能位于 same-origin iframe、OOPIF 或嵌套 frame 中，需要进行跨 frame 坐标投影。
- 截图之后，页面可能已经发生导航、滚动、缩放、尺寸变化或重新 Observation。
- 如果截图与点击之间没有可靠绑定，Agent 可能使用过期截图点击已经变化的页面。
- Canvas 控件可能依赖 `pointermove` 后的异步 hit-test 更新；直接发送 press/release 不一定能触发正确行为。
- 允许 Agent 直接猜测页面坐标会绕过前序 PR 建立的视觉能力边界。

因此，需要建立一条受约束、可验证的链路，把 Agent 在某次 Surface 截图中选择的图片像素坐标，安全地转换为当前页面中的实际点击位置。

## 解决方案

参考 codex 的实现方法，本 PR 为 Canvas Surface 增加 screenshot-bound point click：

- Surface 截图会返回一个短期、单次使用的 Capture ID。
- Agent 将 Capture ID 和截图像素坐标传给普通 click 命令：

  ```bash
  bsk click @eN \
    --capture <capture-id> \
    --image-x <px> \
    --image-y <px> \
    --session <id>
  ```

- BrowserSkill 将截图坐标转换为顶层 viewport 坐标，并支持 iframe、OOPIF 和嵌套 frame。
- 点击前会校验 session、tab、Surface、页面导航、视口、滚动、缩放和 frame projection 是否仍与截图时一致。
- Capture 过期、重复使用或页面状态变化时，操作会失败，并要求重新观察和截图。
- 点击通过完整的 `mouseMoved → mousePressed → mouseReleased` 序列执行。
- 未提供完整 Capture 参数时，Surface ref 仍然是 screenshot-only；Agent 不能绕过截图直接猜测坐标。

## 边界

前序 PR 负责发现和截图 Canvas；本 PR 负责把“某次截图中的一个像素点”安全、一次性地绑定到 Canvas 点击。