### PR TITLE
docs(skill): add preflight guidance for parallel tasks

### DIFF
--- a/crates/bsk-cli/skill/SKILL.md
+++ b/crates/bsk-cli/skill/SKILL.md
@@ -36,6 +36,8 @@ Drive the user's **real Chromium browser** (with their logins and cookies) throu
 
 Every automation task **must** follow this lifecycle. Do **not** rely on idle timeouts (default session idle is 5 minutes).
 
+**Preflight before parallel tasks.** All sessions in a browser share one cookie jar, so two tasks hitting the same logged-in site overwrite each other's login state silently. Before running tasks in parallel, run `bsk session list` and `bsk tab list --session <id> --scope all --json` to check for domain overlap. If the target domain overlaps an active session's agent tab, run the tasks SERIALLY, or use a separate browser profile (install the extension there, then `bsk session start --browser <instance-id>`), since different profiles have isolated cookie jars. If you expect N parallel tasks, ensure ≥ N active sessions.
+
 ```
 1. bsk session start              → capture the 4-letter session id printed on stdout
 2. … every tool command …        → always pass --session <id>

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -36,6 +36,8 @@ Drive the user's **real Chromium browser** (with their logins and cookies) throu
 
 Every automation task **must** follow this lifecycle. Do **not** rely on idle timeouts (default session idle is 5 minutes).
 
+**Preflight before parallel tasks.** All sessions in a browser share one cookie jar, so two tasks hitting the same logged-in site overwrite each other's login state silently. Before running tasks in parallel, run `bsk session list` and `bsk tab list --session <id> --scope all --json` to check for domain overlap. If the target domain overlaps an active session's agent tab, run the tasks SERIALLY, or use a separate browser profile (install the extension there, then `bsk session start --browser <instance-id>`), since different profiles have isolated cookie jars. If you expect N parallel tasks, ensure ≥ N active sessions.
+
 ```
 1. bsk session start              → capture the 4-letter session id printed on stdout
 2. … every tool command …        → always pass --session <id>


### PR DESCRIPTION
## What

Adds a preflight step to the Mandatory workflow for parallel-task scenarios, addressing the documentation layer of #132.

All sessions in a browser share one cookie jar. Two tasks hitting the same logged-in site will silently overwrite each other's login state — no error, hard to diagnose. This PR tells agents to check for domain overlap before running tasks in parallel.

## Change

One paragraph added to the Mandatory workflow in both `skill/SKILL.md` and `crates/bsk-cli/skill/SKILL.md` (kept in sync):

- Run `bsk session list` + `bsk tab list --session <id> --scope all --json` to check domain overlap.
- If the target domain overlaps an active session's agent tab, run serially or start the new session on a different browser instance (`bsk session start --browser <instance-id>`).
- Ensure ≥ N active sessions for N parallel tasks.

Documentation only — no behavior change. This is the "SKILL.md workflow" option proposed in #132; the `bsk preflight` CLI subcommand and the cookie/storage isolation primitive remain open for discussion there.

Related to #132.