### PR TITLE
fix(dsh-plugin): use the published package name as the Cordis id

### DIFF
--- a/packages/dsh-plugin-browserskill/README.md
+++ b/packages/dsh-plugin-browserskill/README.md
@@ -198,8 +198,9 @@ pnpm --filter @wxg-prc-cpg/browser-skill-dsh-plugin build    # tsdown -> lib/
 ## Publishing
 
 The GitHub Actions workflow **Release dsh plugin** publishes this package to npm
-as `@wxg-prc-cpg/browser-skill-dsh-plugin`. The Cordis plugin id stays
-`dsh-plugin-browserskill`.
+as `@wxg-prc-cpg/browser-skill-dsh-plugin`. The Cordis plugin id, client
+bundle registration, and `cordis.patch.yml` name are the same specifier so
+dsh can import and materialize the plugin without a ModuleLoader id mismatch.
 
 Trigger it by pushing a tag that matches `package.json`'s `version`:
 

--- a/packages/dsh-plugin-browserskill/package.json
+++ b/packages/dsh-plugin-browserskill/package.json
@@ -50,6 +50,10 @@
         "@deepseek-ai/dsh-client-runtime",
         "@deepseek-ai/dsh-client-ui-tool",
         "@deepseek-ai/dsh-client-ui-layout"
+      ],
+      "external": [
+        "@deepseek-ai/dsh-client-ui-attachment",
+        "@deepseek-ai/dsh-client-ui-primitives"
       ]
     }
   },

--- a/packages/dsh-plugin-browserskill/src/index.ts
+++ b/packages/dsh-plugin-browserskill/src/index.ts
@@ -22,7 +22,7 @@ import { SessionRegistry } from "./sessions";
 import { armAgentScopedBskSkill, registerBskSkill } from "./skill";
 import { type PluginConfig, registerTools } from "./tools";
 
-export const name = "dsh-plugin-browserskill";
+export const name = "@wxg-prc-cpg/browser-skill-dsh-plugin";
 export const inject = ["tools"];
 
 /** Runtime configuration schema (validated and defaulted by Cordis). */

--- a/packages/dsh-plugin-browserskill/tests/plugin-id.test.ts
+++ b/packages/dsh-plugin-browserskill/tests/plugin-id.test.ts
@@ -1,0 +1,32 @@
+// dsh 0.1 keys the client graph and Node import by `export const name`.
+// That string must stay identical to the published package name (and therefore
+// the client.cjs __ModuleLoader__ id, which tsdown reads from package.json).
+
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { name } from "../src/index";
+
+const pkg = JSON.parse(
+  readFileSync(join(dirname(fileURLToPath(import.meta.url)), "..", "package.json"), "utf8"),
+) as {
+  name: string;
+  dsh: { client: { external?: string[] } };
+};
+
+describe("plugin identity", () => {
+  it("uses the published package name as the Cordis plugin id", () => {
+    expect(name).toBe("@wxg-prc-cpg/browser-skill-dsh-plugin");
+    expect(name).toBe(pkg.name);
+  });
+
+  it("declares client require()s so dsh arrives them before materialize", () => {
+    expect(pkg.dsh.client.external).toEqual(
+      expect.arrayContaining([
+        "@deepseek-ai/dsh-client-ui-attachment",
+        "@deepseek-ai/dsh-client-ui-primitives",
+      ]),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- align the Cordis plugin ID with the published package name
- declare required client modules so dsh loads them before materializing the plugin
- add regression coverage for plugin identity and client dependencies

## Validation

- 172 plugin tests passed
- production build succeeded

Related to #113
Follow up  https://github.com/Tencent/BrowserSkill/pull/112