### PR TITLE
test(dsh-plugin): use renamed screenshot tool

### DIFF
--- a/packages/dsh-plugin-browserskill/tests/tools.test.ts
+++ b/packages/dsh-plugin-browserskill/tests/tools.test.ts
@@ -1004,7 +1004,7 @@ describe("inspect.screenshot", () => {
         options: {},
       },
     });
-    const screenshot = tools.get("browser_screenshot");
+    const screenshot = tools.get("inspect.screenshot");
     const value = (await screenshot?.execute({}, exec)) as {
       image?: { attachmentId: string; mediaType: string };
     };


### PR DESCRIPTION
## 背景

合并截图媒体类型修复与 DSH 工具重命名后，JPEG 截图测试仍使用旧工具名 `browser_screenshot`，导致 CI 无法获取工具并报错。

## 修改

将测试中的工具名更新为 `inspect.screenshot`，与当前实现保持一致。

## 验证

- dsh-plugin 测试通过：179/179
- TypeScript、Biome、Stylelint 检查通过