### PR TITLE
fix(extension): support UUID generation on insecure origins

### DIFF
--- a/apps/extension/src/content/__tests__/record-frame-agent.test.ts
+++ b/apps/extension/src/content/__tests__/record-frame-agent.test.ts
@@ -45,8 +45,30 @@ function portHarness() {
 
 describe("RecordFrameAgent", () => {
   afterEach(() => {
+    vi.unstubAllGlobals();
     document.documentElement.removeAttribute(RECORD_DOCUMENT_ATTRIBUTE);
     document.body.replaceChildren();
+  });
+
+  it("starts when crypto.randomUUID is unavailable", async () => {
+    const harness = portHarness();
+    const getRandomValues = vi.fn((bytes: Uint8Array) => {
+      bytes.fill(0x11);
+      return bytes;
+    });
+    vi.stubGlobal("crypto", { getRandomValues });
+    vi.stubGlobal("chrome", {
+      runtime: {
+        connect: vi.fn(() => harness.port),
+        sendMessage: vi.fn(),
+      },
+    });
+    const agent = new RecordFrameAgent();
+
+    await expect(
+      agent.start({ type: RECORD_FRAME_START, requestId: "rec-http", startedAtMs: 10 }),
+    ).resolves.toEqual({ ok: true });
+    expect(getRandomValues).toHaveBeenCalled();
   });
 
   it("keeps a failed stop retryable and flushes the final dirty fill", async () => {

--- a/apps/extension/src/content/record-step-delivery.ts
+++ b/apps/extension/src/content/record-step-delivery.ts
@@ -1,3 +1,4 @@
+import { createRandomUuid } from "@/lib/random-uuid";
 import {
   isAcceptedRecordStepAck,
   RECORD_STEP,
@@ -18,7 +19,7 @@ export class RecordStepDelivery {
   constructor(
     requestId: string,
     send: SendRecordStepMessage = (message) => chrome.runtime.sendMessage(message),
-    producerId: string = crypto.randomUUID(),
+    producerId: string = createRandomUuid(),
   ) {
     this.#requestId = requestId;
     this.#producerId = producerId;

--- a/apps/extension/src/content/recording/frame-agent.ts
+++ b/apps/extension/src/content/recording/frame-agent.ts
@@ -1,3 +1,4 @@
+import { createRandomUuid } from "@/lib/random-uuid";
 import {
   markRecordingDocument,
   type RecordingDocumentMarker,
@@ -67,7 +68,7 @@ export class RecordFrameAgent {
   async #start(
     message: RecordFrameStartMessage,
   ): Promise<{ ok: true } | { ok: false; error: string }> {
-    const producerId = crypto.randomUUID();
+    const producerId = createRandomUuid();
     const root = await waitForDocumentElement();
     if (this.#disposed) return { ok: false, error: "recording document is disposed" };
     const marker = markRecordingDocument(producerId, root);

--- a/apps/extension/src/lib/__tests__/random-uuid.test.ts
+++ b/apps/extension/src/lib/__tests__/random-uuid.test.ts
@@ -1,0 +1,30 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createRandomUuid } from "../random-uuid";
+
+describe("createRandomUuid", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("uses crypto.randomUUID when it is available", () => {
+    const randomUUID = vi.fn(() => "00000000-0000-4000-8000-000000000000");
+    vi.stubGlobal("crypto", { randomUUID, getRandomValues: vi.fn() });
+
+    expect(createRandomUuid()).toBe("00000000-0000-4000-8000-000000000000");
+    expect(randomUUID).toHaveBeenCalledOnce();
+  });
+
+  it("falls back to getRandomValues and sets UUID v4 bits", () => {
+    const bytes = new Uint8Array(16).fill(0xff);
+    const getRandomValues = vi.fn((target: Uint8Array) => {
+      target.set(bytes);
+      return target;
+    });
+    vi.stubGlobal("crypto", { getRandomValues });
+
+    const uuid = createRandomUuid();
+
+    expect(uuid).toBe("ffffffff-ffff-4fff-bfff-ffffffffffff");
+    expect(getRandomValues).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/extension/src/lib/random-uuid.ts
+++ b/apps/extension/src/lib/random-uuid.ts
@@ -1,0 +1,26 @@
+/**
+ * Generate a UUID v4 in browser contexts where randomUUID() is unavailable.
+ *
+ * Crypto.randomUUID() is restricted to secure contexts, while
+ * crypto.getRandomValues() is available to content scripts on ordinary HTTP
+ * origins. BrowserSkill records many intranet pages served over HTTP, so the
+ * fallback is required for recording to work on those pages.
+ */
+export function createRandomUuid(): string {
+  const cryptoApi = globalThis.crypto;
+  if (typeof cryptoApi.randomUUID === "function") return cryptoApi.randomUUID();
+
+  const bytes = new Uint8Array(16);
+  cryptoApi.getRandomValues(bytes);
+  bytes[6] = (bytes[6]! & 0x0f) | 0x40;
+  bytes[8] = (bytes[8]! & 0x3f) | 0x80;
+
+  const hex = Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
+  return [
+    hex.slice(0, 8),
+    hex.slice(8, 12),
+    hex.slice(12, 16),
+    hex.slice(16, 20),
+    hex.slice(20),
+  ].join("-");
+}

--- a/apps/extension/src/lib/recording/frame-coordinator.ts
+++ b/apps/extension/src/lib/recording/frame-coordinator.ts
@@ -1,3 +1,4 @@
+import { createRandomUuid } from "../random-uuid";
 import {
   isRecordFrameQueryMessage,
   RECORD_FRAME_PORT,
@@ -188,7 +189,7 @@ export class RecordFrameCoordinator {
     const recording = this.#recordings.get(requestId);
     if (!recording) return true;
     recording.finishing = true;
-    const commandId = crypto.randomUUID();
+    const commandId = createRandomUuid();
     const results = await Promise.all(
       [...recording.agents.values()].map((agent) => this.#stopAgent(agent, requestId, commandId)),
     );


### PR DESCRIPTION
## Summary

Fix recording initialization on ordinary HTTP intranet pages where
`crypto.randomUUID()` is unavailable.

## Changes

- Add a UUID v4 helper using `crypto.getRandomValues()` as fallback.
- Replace all three extension-side `crypto.randomUUID()` call sites.
- Add tests for native and fallback UUID generation.

## Validation

- 74 test files passed
- 800 tests passed
- TypeScript compilation passed
- WXT production build passed
- Biome check passed