### PR TITLE
Allow configuring the daemon WebSocket URL at runtime

### DIFF
--- a/apps/extension/src/entrypoints/background.ts
+++ b/apps/extension/src/entrypoints/background.ts
@@ -4,7 +4,11 @@ import { ConnectionController } from "@/lib/connection-controller";
 import { startHeartbeat } from "@/lib/heartbeat";
 import {
   getConnectionEnabled,
+  getDaemonWsUrl,
+  isDaemonWsUrl,
   setConnectionEnabled as persistConnectionEnabled,
+  setDaemonWsUrl as persistDaemonWsUrl,
+  STORAGE_KEYS,
   setLabel,
 } from "@/lib/instance-id";
 import { startKeepalive } from "@/lib/keepalive";
@@ -277,22 +281,43 @@ export default defineBackground(() => {
     chrome.idle.setDetectionInterval?.(60);
   }
 
+  if (typeof chrome.storage?.onChanged?.addListener === "function") {
+    chrome.storage.onChanged.addListener((changes, areaName) => {
+      if (areaName !== "local") return;
+      const change = changes[STORAGE_KEYS.DAEMON_WS_URL];
+      if (!change) return;
+      if (typeof change.newValue !== "string") return;
+      void applyDaemonWsUrl(change.newValue, { persist: false });
+    });
+  }
+
   void (async () => {
     const connectionEnabled = await getConnectionEnabled();
-    await controller.attach(transport, detectBrowserMeta(), connectionEnabled, {
-      beforeDisconnect: async () => {
-        const report = await cleanupAfterDisconnect();
-        if (report.failures.length > 0) {
-          console.warn("[browser-skill] session cleanup before disconnect was incomplete", report);
-        }
+    const daemonWsUrl = await getDaemonWsUrl();
+    await transport.setUrl(daemonWsUrl);
+    await controller.attach(
+      transport,
+      detectBrowserMeta(),
+      connectionEnabled,
+      {
+        beforeDisconnect: async () => {
+          const report = await cleanupAfterDisconnect();
+          if (report.failures.length > 0) {
+            console.warn(
+              "[browser-skill] session cleanup before disconnect was incomplete",
+              report,
+            );
+          }
+        },
+        onDisconnected: async () => {
+          const report = await cleanupAfterDisconnect();
+          if (report.failures.length > 0) {
+            console.warn("[browser-skill] session cleanup after disconnect was incomplete", report);
+          }
+        },
       },
-      onDisconnected: async () => {
-        const report = await cleanupAfterDisconnect();
-        if (report.failures.length > 0) {
-          console.warn("[browser-skill] session cleanup after disconnect was incomplete", report);
-        }
-      },
-    });
+      daemonWsUrl,
+    );
   })().catch((err) => {
     console.error("[browser-skill] controller failed to attach", err);
   });
@@ -346,10 +371,11 @@ export default defineBackground(() => {
         if (msg.kind === "set_label") {
           void setLabel(msg.value).then(() => controller.refreshLabel());
         } else if (msg.kind === "set_port") {
-          // Placeholder for the future custom-port UI; warn loudly so
-          // any reintroduced popup control is caught instead of
-          // silently doing nothing (review M4/M5 C2).
+          // Legacy placeholder; the popup's runtime endpoint control sends
+          // set_daemon_ws_url with the full ws:// or wss:// address.
           console.warn("[browser-skill] set_port is not wired yet; ignoring", msg.value);
+        } else if (msg.kind === "set_daemon_ws_url") {
+          void applyDaemonWsUrl(msg.value);
         } else if (msg.kind === "set_connection_enabled") {
           void controller
             .setConnectionEnabled(msg.value)
@@ -359,6 +385,26 @@ export default defineBackground(() => {
     });
     connection.onDisconnect.addListener(() => unsubscribe());
   });
+
+  async function applyDaemonWsUrl(
+    value: string,
+    options: { persist?: boolean } = {},
+  ): Promise<void> {
+    try {
+      const nextUrl = value.trim();
+      if (!isDaemonWsUrl(nextUrl)) {
+        throw new Error("daemon WebSocket URL must start with ws:// or wss:// and include a host");
+      }
+      if (options.persist !== false) {
+        await persistDaemonWsUrl(nextUrl);
+      }
+      controller.setDaemonWsUrl(nextUrl);
+      await transport.setUrl(nextUrl);
+      reconnectIfNeeded();
+    } catch (err) {
+      console.warn("[browser-skill] invalid daemon WebSocket URL; ignoring", err);
+    }
+  }
 
   // Stash on globalThis so the SW DevTools can poke at internals.
   // Dev-only to avoid leaking internals to inspectors in shipped builds

--- a/apps/extension/src/entrypoints/popup/App.test.tsx
+++ b/apps/extension/src/entrypoints/popup/App.test.tsx
@@ -20,6 +20,7 @@ const baseSnapshot: SnapshotInfo = {
   instanceId: "",
   label: "",
   extensionVersion: EXTENSION_VERSION,
+  daemonWsUrl: "ws://127.0.0.1:52800",
   handshake: null,
   lastError: null,
   connectionEnabled: true,
@@ -33,6 +34,7 @@ function openRecordView() {
 describe("App", () => {
   const setLabel = vi.fn();
   const setConnectionEnabled = vi.fn();
+  const setDaemonWsUrl = vi.fn();
 
   beforeEach(() => {
     mockUseConnectionState.mockReturnValue({
@@ -40,6 +42,7 @@ describe("App", () => {
       statusState: "disconnected",
       setLabel,
       setConnectionEnabled,
+      setDaemonWsUrl,
     });
     Object.defineProperty(window, "matchMedia", {
       configurable: true,
@@ -116,6 +119,7 @@ describe("App", () => {
       statusState: "connected",
       setLabel,
       setConnectionEnabled,
+      setDaemonWsUrl,
     });
 
     render(<App />);
@@ -155,6 +159,7 @@ describe("App", () => {
       statusState: "disabled",
       setLabel,
       setConnectionEnabled,
+      setDaemonWsUrl,
     });
 
     render(<App />);
@@ -180,6 +185,7 @@ describe("App", () => {
       statusState: "connected",
       setLabel,
       setConnectionEnabled,
+      setDaemonWsUrl,
     });
 
     render(<App />);
@@ -223,6 +229,7 @@ describe("App", () => {
       statusState: "connected",
       setLabel,
       setConnectionEnabled,
+      setDaemonWsUrl,
     });
 
     render(<App />);
@@ -263,6 +270,7 @@ describe("App", () => {
       statusState: "version_skew",
       setLabel,
       setConnectionEnabled,
+      setDaemonWsUrl,
     });
 
     render(<App />);
@@ -281,6 +289,36 @@ describe("App", () => {
     expect(copyButton.getAttribute("disabled")).toBeNull();
     fireEvent.click(copyButton);
     expect(navigator.clipboard.writeText).toHaveBeenCalledTimes(1);
+  });
+
+  it("applies a runtime daemon WebSocket URL from the popup", () => {
+    render(<App />);
+
+    const input = screen.getByLabelText("Daemon 连接地址");
+    fireEvent.change(input, { target: { value: "ws://127.0.0.1:52801" } });
+    fireEvent.click(screen.getByRole("button", { name: "保存并重连 daemon WebSocket" }));
+
+    expect(setDaemonWsUrl).toHaveBeenCalledWith("ws://127.0.0.1:52801");
+  });
+
+  it("shows daemon connection failures as localized popup copy", () => {
+    mockUseConnectionState.mockReturnValue({
+      snapshot: {
+        ...baseSnapshot,
+        lastError: "Cannot reach daemon WebSocket endpoint ws://127.0.0.1:52800",
+      },
+      statusState: "disconnected",
+      setLabel,
+      setConnectionEnabled,
+      setDaemonWsUrl,
+    });
+
+    render(<App />);
+
+    expect(
+      screen.getByText("无法连接到 ws://127.0.0.1:52800。请启动 bsk，或检查 SSH 隧道。"),
+    ).toBeTruthy();
+    expect(screen.queryByText(/Cannot reach daemon WebSocket endpoint/)).toBeNull();
   });
 });
 
@@ -354,7 +392,7 @@ describe("control hints toggle", () => {
 
     const info = await screen.findByRole("button", { name: "控制提示说明" });
     expect(info).toBeTruthy();
-    const tooltip = screen.getByRole("tooltip");
+    const tooltip = screen.getByText("Agent 控制页面时显示提示条和橙色闪光。");
     expect(tooltip.textContent).toBe("Agent 控制页面时显示提示条和橙色闪光。");
     // Hidden until the info button is hovered or focused.
     expect(tooltip.className).toContain("opacity-0");

--- a/apps/extension/src/entrypoints/popup/App.tsx
+++ b/apps/extension/src/entrypoints/popup/App.tsx
@@ -8,6 +8,7 @@ import {
   RiInformationLine,
 } from "@remixicon/react";
 import { type ChangeEvent, useEffect, useState } from "react";
+import { isDaemonWsUrl } from "@/lib/instance-id";
 import { PROTOCOL_VERSION } from "@/transport/handshake";
 import functionIconUrl from "../../../assets/function.svg";
 import { ConnectionStatusIndicator } from "./connection-status-indicator";
@@ -30,6 +31,8 @@ const STATE_BADGE_KEYS = {
   disabled: "popup.stateBadge.disabled",
 } as const satisfies Record<PopupStatusState, string>;
 
+const DAEMON_CONNECT_ERROR_PREFIX = "Cannot reach daemon WebSocket endpoint ";
+
 function getLogoSrc() {
   if (typeof chrome !== "undefined" && chrome.runtime?.getURL) {
     return chrome.runtime.getURL("icon/logo.png");
@@ -39,12 +42,13 @@ function getLogoSrc() {
 
 export function App() {
   const { t } = useTranslation("extension");
-  const { snapshot, statusState, setConnectionEnabled } = useConnectionState();
+  const { snapshot, statusState, setConnectionEnabled, setDaemonWsUrl } = useConnectionState();
   const [controlHintsHidden, setControlHintsHidden] = useControlHintsHidden();
   const [view, setView] = useState<PopupView>("main");
   const [copiedInstanceId, setCopiedInstanceId] = useState(false);
   const [purposeDraft, setPurposeDraft] = useState("");
   const [startUrlDraft, setStartUrlDraft] = useState("");
+  const [daemonUrlDraft, setDaemonUrlDraft] = useState(__BSK_DAEMON_WS_URL__);
   // Bumped on every successful copy so the "copied" toast re-shows (and its
   // auto-hide timer restarts) even when the copied content is unchanged.
   const [copiedTick, setCopiedTick] = useState(0);
@@ -66,6 +70,10 @@ export function App() {
     setCopiedTick(0);
   }, [snapshot.instanceId]);
 
+  useEffect(() => {
+    setDaemonUrlDraft(snapshot.daemonWsUrl || __BSK_DAEMON_WS_URL__);
+  }, [snapshot.daemonWsUrl]);
+
   // Hide the copied toast when the command changes (topic / start URL edits).
   useEffect(() => {
     setCopiedTick(0);
@@ -84,6 +92,19 @@ export function App() {
   const daemonProtocol = snapshot.handshake?.protocol_version ?? "—";
   const extensionVersion = snapshot.extensionVersion || "—";
   const instanceId = snapshot.instanceId || "—";
+  const daemonUrlCurrent = snapshot.daemonWsUrl || __BSK_DAEMON_WS_URL__;
+  const daemonUrlTrimmed = daemonUrlDraft.trim();
+  const daemonUrlDirty = daemonUrlTrimmed !== daemonUrlCurrent;
+  const daemonUrlValid = isDaemonWsUrl(daemonUrlTrimmed);
+  const canApplyDaemonUrl = daemonUrlDirty && daemonUrlValid;
+  const daemonUrlActionTitle = !daemonUrlValid
+    ? t("popup.daemonWsUrlInvalid")
+    : daemonUrlDirty
+      ? t("popup.daemonWsUrlApply")
+      : t("popup.daemonWsUrlCurrent");
+  const popupError = snapshot.lastError?.startsWith(DAEMON_CONNECT_ERROR_PREFIX)
+    ? t("popup.daemonWsUrlConnectError", { url: daemonUrlCurrent })
+    : snapshot.lastError;
 
   const copyInstanceId = async () => {
     if (!snapshot.instanceId || !navigator.clipboard?.writeText) return;
@@ -113,6 +134,11 @@ export function App() {
     if (!recordReady || !navigator.clipboard?.writeText) return;
     await navigator.clipboard.writeText(recordPrompt);
     setCopiedTick((tick) => tick + 1);
+  };
+
+  const applyDaemonUrl = () => {
+    if (!canApplyDaemonUrl) return;
+    setDaemonWsUrl(daemonUrlTrimmed);
   };
 
   const headerTitle =
@@ -253,12 +279,72 @@ export function App() {
             </div>
           </section>
 
-          {snapshot.lastError && (
+          <section
+            className="rounded-xl border border-border/80 bg-card/60 px-3 py-2.5"
+            data-slot="popup-daemon-url-card"
+          >
+            <div className="mb-1.5 flex items-center justify-between gap-2">
+              <span className="flex min-w-0 items-center gap-1">
+                <Label htmlFor="bsk-daemon-ws-url" className="truncate text-sm font-medium">
+                  {t("popup.daemonWsUrlTitle")}
+                </Label>
+                <span className="group relative inline-flex shrink-0">
+                  <button
+                    type="button"
+                    aria-label={t("popup.daemonWsUrlInfoLabel")}
+                    data-slot="popup-daemon-url-info"
+                    className="flex size-4 items-center justify-center rounded-full text-muted-foreground/70 transition-colors hover:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+                  >
+                    <RiInformationLine className="size-3.5" aria-hidden />
+                  </button>
+                  <span
+                    id="bsk-daemon-ws-url-hint"
+                    role="tooltip"
+                    className="pointer-events-none absolute bottom-full left-0 z-10 mb-1.5 w-56 whitespace-normal rounded-md bg-foreground/65 px-2 py-1 text-[10px] font-medium leading-snug text-background opacity-0 shadow-md backdrop-blur-sm transition-opacity group-hover:opacity-100 group-focus-within:opacity-100"
+                  >
+                    {t("popup.daemonWsUrlHint")}
+                  </span>
+                </span>
+              </span>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                className="size-6 shrink-0 rounded-md"
+                disabled={!canApplyDaemonUrl}
+                aria-label={t("popup.daemonWsUrlApply")}
+                title={daemonUrlActionTitle}
+                onClick={applyDaemonUrl}
+                data-slot="popup-daemon-url-apply"
+              >
+                <RiCheckLine className="size-3.5" aria-hidden />
+              </Button>
+            </div>
+            <Input
+              id="bsk-daemon-ws-url"
+              type="url"
+              value={daemonUrlDraft}
+              onChange={(event: ChangeEvent<HTMLInputElement>) =>
+                setDaemonUrlDraft(event.target.value)
+              }
+              onKeyDown={(event) => {
+                if (event.key === "Enter") applyDaemonUrl();
+              }}
+              aria-invalid={!daemonUrlValid}
+              aria-describedby="bsk-daemon-ws-url-hint"
+              title={daemonUrlValid ? t("popup.daemonWsUrlHint") : t("popup.daemonWsUrlInvalid")}
+              placeholder="ws://127.0.0.1:52800"
+              className="mt-0 h-8 font-mono text-xs"
+              data-slot="popup-daemon-url-input"
+            />
+          </section>
+
+          {popupError && (
             <div
-              className="rounded-lg border border-destructive/25 bg-destructive/10 px-3 py-2 text-xs leading-snug text-destructive"
+              className="break-words rounded-lg border border-destructive/25 bg-destructive/10 px-3 py-2 text-xs leading-snug text-destructive"
               data-slot="popup-error"
             >
-              {snapshot.lastError}
+              {popupError}
             </div>
           )}
 

--- a/apps/extension/src/entrypoints/popup/use-connection-state.ts
+++ b/apps/extension/src/entrypoints/popup/use-connection-state.ts
@@ -35,24 +35,21 @@ const FALLBACK_SNAPSHOT: SnapshotInfo = {
   handshake: null,
   lastError: null,
   connectionEnabled: true,
+  daemonWsUrl: __BSK_DAEMON_WS_URL__,
 };
 
 /**
  * Live snapshot of the background's `ConnectionController` for popup UI.
  *
- * Posts `set_label` mutations back to the background; the incoming
- * snapshot stream reflects the canonical state. The `set_port` channel
- * is defined by the popup-bridge but is not currently routed to the
- * background — wiring it requires `ConnectionController` to swap its
- * Transport URL and persist the chosen port. Tracked for a follow-up
- * milestone; the popup intentionally does not expose a control until
- * the underlying support lands (review M4/M5 C2).
+ * Posts setting mutations back to the background; the incoming snapshot
+ * stream reflects the canonical state.
  */
 export function useConnectionState(): {
   snapshot: SnapshotInfo;
   statusState: PopupStatusState;
   setLabel: (value: string) => void;
   setConnectionEnabled: (value: boolean) => void;
+  setDaemonWsUrl: (value: string) => void;
 } {
   const [snapshot, setSnapshot] = useState<SnapshotInfo>(FALLBACK_SNAPSHOT);
   const portRef = useRef<chrome.runtime.Port | null>(null);
@@ -99,5 +96,6 @@ export function useConnectionState(): {
     statusState,
     setLabel: (value: string) => post({ kind: "set_label", value }),
     setConnectionEnabled: (value: boolean) => post({ kind: "set_connection_enabled", value }),
+    setDaemonWsUrl: (value: string) => post({ kind: "set_daemon_ws_url", value }),
   };
 }

--- a/apps/extension/src/lib/__tests__/connection-controller.test.ts
+++ b/apps/extension/src/lib/__tests__/connection-controller.test.ts
@@ -119,9 +119,9 @@ function makeMockTransport(initialState: ConnectionState = "disconnected") {
       stateHandlers.add(handler);
       return { dispose: () => stateHandlers.delete(handler) };
     }),
-    emitState(next: ConnectionState) {
+    emitState(next: ConnectionState, error?: Error) {
       state = next;
-      for (const h of stateHandlers) h(next);
+      for (const h of stateHandlers) h(next, error);
     },
     emitMessage(frame: ProtocolFrame) {
       for (const handler of messageHandlers) handler(frame);
@@ -193,6 +193,21 @@ describe("ConnectionController connectionEnabled", () => {
     await vi.waitFor(() => expect(onDisconnected).toHaveBeenCalledTimes(1));
   });
 
+  it("surfaces transport connection errors in the popup snapshot", async () => {
+    const controller = new ConnectionController();
+    const transport = makeMockTransport();
+    await controller.attach(transport, { name: "Chrome", version: "120" }, true);
+
+    transport.emitState(
+      "disconnected",
+      new Error("Cannot reach daemon WebSocket endpoint ws://127.0.0.1:52800"),
+    );
+
+    expect(controller.snapshot().lastError).toBe(
+      "Cannot reach daemon WebSocket endpoint ws://127.0.0.1:52800",
+    );
+  });
+
   it("reconnects when connection is re-enabled", async () => {
     const controller = new ConnectionController();
     const transport = makeMockTransport();
@@ -201,6 +216,25 @@ describe("ConnectionController connectionEnabled", () => {
 
     expect(transport.connect).toHaveBeenCalled();
     expect(controller.snapshot().connectionEnabled).toBe(true);
+  });
+
+  it("surfaces the configured daemon WebSocket URL in snapshots", async () => {
+    const controller = new ConnectionController();
+    const transport = makeMockTransport();
+    await controller.attach(
+      transport,
+      { name: "Chrome", version: "120" },
+      false,
+      {},
+      "ws://127.0.0.1:52801",
+    );
+
+    expect(controller.snapshot().daemonWsUrl).toBe("ws://127.0.0.1:52801");
+
+    controller.setDaemonWsUrl("ws://127.0.0.1:52802");
+    expect(controller.snapshot().daemonWsUrl).toBe("ws://127.0.0.1:52802");
+    expect(controller.snapshot().handshake).toBeNull();
+    expect(controller.snapshot().lastError).toBeNull();
   });
 
   it("ignores transport state changes while disabled", async () => {

--- a/apps/extension/src/lib/__tests__/instance-id.test.ts
+++ b/apps/extension/src/lib/__tests__/instance-id.test.ts
@@ -2,11 +2,15 @@ import { describe, expect, it, vi } from "vitest";
 import {
   getConnectionEnabled,
   getControlHintsHidden,
+  getDaemonWsUrl,
   getLabel,
   getOrCreateInstanceId,
+  isDaemonWsUrl,
+  normalizeDaemonWsUrl,
   STORAGE_KEYS,
   setConnectionEnabled,
   setControlHintsHidden,
+  setDaemonWsUrl,
   setLabel,
 } from "../instance-id";
 
@@ -94,6 +98,36 @@ describe("instance-id", () => {
     await setConnectionEnabled(false, backend);
     expect(store[STORAGE_KEYS.CONNECTION_ENABLED]).toBe(false);
     expect(await getConnectionEnabled(backend)).toBe(false);
+  });
+
+  it("validates daemon WebSocket URLs", () => {
+    expect(isDaemonWsUrl("ws://127.0.0.1:52800")).toBe(true);
+    expect(isDaemonWsUrl("wss://example.com/bsk")).toBe(true);
+    expect(isDaemonWsUrl("http://127.0.0.1:52800")).toBe(false);
+    expect(isDaemonWsUrl("ws://user:pass@example.com")).toBe(false);
+    expect(isDaemonWsUrl("")).toBe(false);
+  });
+
+  it("getDaemonWsUrl falls back when unset or invalid", async () => {
+    const fallback = "ws://127.0.0.1:52800";
+    const { backend } = fakeStorage();
+    expect(await getDaemonWsUrl(backend, fallback)).toBe(fallback);
+
+    const invalid = fakeStorage({ [STORAGE_KEYS.DAEMON_WS_URL]: "http://example.com" });
+    expect(await getDaemonWsUrl(invalid.backend, fallback)).toBe(fallback);
+    expect(normalizeDaemonWsUrl("  ws://127.0.0.1:52801  ", fallback)).toBe("ws://127.0.0.1:52801");
+  });
+
+  it("setDaemonWsUrl persists a valid runtime URL and rejects invalid values", async () => {
+    const { backend, store } = fakeStorage();
+    await expect(setDaemonWsUrl(" ws://127.0.0.1:52801 ", backend)).resolves.toBe(
+      "ws://127.0.0.1:52801",
+    );
+    expect(store[STORAGE_KEYS.DAEMON_WS_URL]).toBe("ws://127.0.0.1:52801");
+
+    await expect(setDaemonWsUrl("http://127.0.0.1:52801", backend)).rejects.toThrow(
+      /WebSocket URL/,
+    );
   });
 
   it("getControlHintsHidden returns false when storage is empty", async () => {

--- a/apps/extension/src/lib/connection-controller.ts
+++ b/apps/extension/src/lib/connection-controller.ts
@@ -16,6 +16,7 @@ export interface SnapshotInfo {
   instanceId: string;
   label: string;
   extensionVersion: string;
+  daemonWsUrl: string;
   handshake: HandshakeResult | null;
   lastError: string | null;
   connectionEnabled: boolean;
@@ -42,6 +43,7 @@ export class ConnectionController {
   private handshake: HandshakeResult | null = null;
   private instanceId = "";
   private label = "";
+  private daemonWsUrl = __BSK_DAEMON_WS_URL__;
   private lastError: string | null = null;
   private connectionEnabled = true;
   private listeners = new Set<Listener>();
@@ -72,6 +74,7 @@ export class ConnectionController {
       instanceId: this.instanceId,
       label: this.label,
       extensionVersion: EXTENSION_VERSION,
+      daemonWsUrl: this.daemonWsUrl,
       handshake: this.handshake,
       lastError: this.lastError,
       connectionEnabled: this.connectionEnabled,
@@ -83,14 +86,19 @@ export class ConnectionController {
     browser: { name: string; version: string },
     connectionEnabled = true,
     lifecycleHooks: ConnectionLifecycleHooks = {},
+    daemonWsUrl = __BSK_DAEMON_WS_URL__,
   ): Promise<void> {
     this.transport = transport;
     this.connectionEnabled = connectionEnabled;
     this.lifecycleHooks = lifecycleHooks;
+    this.daemonWsUrl = daemonWsUrl;
     this.instanceId = await getOrCreateInstanceId();
     this.label = await getLabel();
 
-    transport.onConnectionStateChange((s) => {
+    transport.onConnectionStateChange((s, error) => {
+      if (error && this.connectionEnabled) {
+        this.lastError = error.message;
+      }
       if (s === "disconnected") {
         // An in-flight handshake belongs to the dead connection — cancel it so
         // a late resolution can never clobber the next attempt.
@@ -110,6 +118,7 @@ export class ConnectionController {
       }
       if (!this.connectionEnabled) return;
       if (s === "connected") {
+        this.lastError = null;
         this.startHandshake(browser);
         return;
       }
@@ -153,6 +162,14 @@ export class ConnectionController {
 
   async refreshLabel(): Promise<void> {
     this.label = await getLabel();
+    this.fire();
+  }
+
+  setDaemonWsUrl(url: string): void {
+    if (this.daemonWsUrl === url) return;
+    this.daemonWsUrl = url;
+    this.handshake = null;
+    this.lastError = null;
     this.fire();
   }
 

--- a/apps/extension/src/lib/instance-id.ts
+++ b/apps/extension/src/lib/instance-id.ts
@@ -2,6 +2,7 @@ const STORAGE_KEY = "bsk_instance_id";
 const LABEL_STORAGE_KEY = "bh_label";
 const CONNECTION_ENABLED_KEY = "bh_connection_enabled";
 const CONTROL_HINTS_HIDDEN_KEY = "bsk_control_hints_hidden";
+const DAEMON_WS_URL_STORAGE_KEY = "BSK_DAEMON_WS_URL";
 
 export interface StorageBackend {
   get(keys: string | string[]): Promise<Record<string, unknown>>;
@@ -106,6 +107,46 @@ export async function setConnectionEnabled(
   await storage.set({ [CONNECTION_ENABLED_KEY]: enabled });
 }
 
+export function isDaemonWsUrl(value: string): boolean {
+  const trimmed = value.trim();
+  if (!trimmed) return false;
+  try {
+    const parsed = new URL(trimmed);
+    if (parsed.protocol !== "ws:" && parsed.protocol !== "wss:") return false;
+    if (!parsed.host) return false;
+    if (parsed.username || parsed.password) return false;
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function normalizeDaemonWsUrl(value: unknown, fallback: string): string {
+  if (typeof value !== "string") return fallback;
+  const trimmed = value.trim();
+  return isDaemonWsUrl(trimmed) ? trimmed : fallback;
+}
+
+export async function getDaemonWsUrl(
+  storage: StorageBackend = defaultStorage(),
+  fallback: string = __BSK_DAEMON_WS_URL__,
+): Promise<string> {
+  const items = await storage.get(DAEMON_WS_URL_STORAGE_KEY);
+  return normalizeDaemonWsUrl(items[DAEMON_WS_URL_STORAGE_KEY], fallback);
+}
+
+export async function setDaemonWsUrl(
+  url: string,
+  storage: StorageBackend = defaultStorage(),
+): Promise<string> {
+  const trimmed = url.trim();
+  if (!isDaemonWsUrl(trimmed)) {
+    throw new Error("daemon WebSocket URL must start with ws:// or wss:// and include a host");
+  }
+  await storage.set({ [DAEMON_WS_URL_STORAGE_KEY]: trimmed });
+  return trimmed;
+}
+
 /**
  * User preference for the in-page control hints (status pill + orange glow
  * shown while the Agent controls a tab). Defaults to shown when unset or
@@ -132,4 +173,5 @@ export const STORAGE_KEYS = {
   LABEL: LABEL_STORAGE_KEY,
   CONNECTION_ENABLED: CONNECTION_ENABLED_KEY,
   CONTROL_HINTS_HIDDEN: CONTROL_HINTS_HIDDEN_KEY,
+  DAEMON_WS_URL: DAEMON_WS_URL_STORAGE_KEY,
 } as const;

--- a/apps/extension/src/lib/popup-bridge.ts
+++ b/apps/extension/src/lib/popup-bridge.ts
@@ -5,12 +5,8 @@ import type { SnapshotInfo } from "./connection-controller";
  *  - Background pushes `{ kind: "snapshot", data: SnapshotInfo }`.
  *  - Popup sends `{ kind: "set_label" }`, `{ kind: "set_connection_enabled" }`, etc.
  *
- * NOTE(review M4/M5 C2): the `set_port` variant is defined as a
- * placeholder so the future custom-port UI does not have to re-design
- * the bridge, but the popup does NOT render a control that emits it
- * yet and the background does NOT route it. The wiring requires
- * ConnectionController to dispose its current Transport and persist
- * the port in chrome.storage; tracked as a follow-up.
+ * `set_port` is a legacy placeholder; the popup uses `set_daemon_ws_url`
+ * for the runtime endpoint control.
  */
 
 export const POPUP_PORT_NAME = "popup";
@@ -18,6 +14,7 @@ export const POPUP_PORT_NAME = "popup";
 export type PopupOutbound =
   | { kind: "set_label"; value: string }
   | { kind: "set_port"; value: number }
+  | { kind: "set_daemon_ws_url"; value: string }
   | { kind: "set_connection_enabled"; value: boolean };
 
 export type PopupInbound = { kind: "snapshot"; data: SnapshotInfo };

--- a/apps/extension/src/transport/__tests__/ws-transport.test.ts
+++ b/apps/extension/src/transport/__tests__/ws-transport.test.ts
@@ -67,13 +67,29 @@ function lastSocket(): FakeSocket {
   return s;
 }
 
+async function drainMicrotasks(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+const globalWithWebSocketStream = globalThis as { WebSocketStream?: unknown };
+let originalWebSocketStream: unknown;
+
 describe("WSTransport", () => {
   beforeEach(() => {
     vi.useFakeTimers({ shouldAdvanceTime: false });
+    originalWebSocketStream = globalWithWebSocketStream.WebSocketStream;
+    globalWithWebSocketStream.WebSocketStream = undefined;
     FakeSocket.instances = [];
   });
 
   afterEach(() => {
+    if (originalWebSocketStream === undefined) {
+      delete globalWithWebSocketStream.WebSocketStream;
+    } else {
+      globalWithWebSocketStream.WebSocketStream = originalWebSocketStream;
+    }
     vi.useRealTimers();
   });
 
@@ -88,6 +104,85 @@ describe("WSTransport", () => {
     lastSocket().open();
     await connectPromise;
     expect(t.state).toBe("connected");
+  });
+
+  it("skips classic WebSocket construction when the quiet open probe cannot connect", async () => {
+    const openProbe = vi.fn(async () => false);
+    const errors: string[] = [];
+    const t = new WSTransport({
+      url: "ws://127.0.0.1:52800",
+      reconnect: { initialDelayMs: 1_000, maxDelayMs: 1_000 },
+      openProbe,
+      webSocketFactory: (url) => new FakeSocket(url) as unknown as WebSocket,
+    });
+    t.onConnectionStateChange((_state, error) => {
+      if (error) errors.push(error.message);
+    });
+
+    void t.connect();
+    await drainMicrotasks();
+
+    expect(openProbe).toHaveBeenCalledWith("ws://127.0.0.1:52800");
+    expect(FakeSocket.instances).toHaveLength(0);
+    expect(t.state).toBe("disconnected");
+    expect(errors[0]).toContain("Cannot reach daemon WebSocket endpoint ws://127.0.0.1:52800");
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    await Promise.resolve();
+    expect(openProbe).toHaveBeenCalledTimes(2);
+    expect(FakeSocket.instances).toHaveLength(0);
+  });
+
+  it("uses WebSocketStream as the default quiet open probe when available", async () => {
+    const openedUrls: string[] = [];
+    class RejectingWebSocketStream {
+      opened = Promise.reject(new Error("connection refused"));
+
+      constructor(url: string) {
+        openedUrls.push(url);
+      }
+    }
+    globalWithWebSocketStream.WebSocketStream = RejectingWebSocketStream;
+
+    const t = new WSTransport({
+      url: "ws://127.0.0.1:52800",
+      webSocketFactory: (url) => new FakeSocket(url) as unknown as WebSocket,
+    });
+
+    void t.connect();
+    await drainMicrotasks();
+
+    expect(openedUrls).toEqual(["ws://127.0.0.1:52800"]);
+    expect(FakeSocket.instances).toHaveLength(0);
+    expect(t.state).toBe("disconnected");
+  });
+
+  it("closes a successful WebSocketStream probe before opening the real socket", async () => {
+    const openedUrls: string[] = [];
+    const closeProbe = vi.fn();
+    class OpeningWebSocketStream {
+      opened = Promise.resolve({});
+      close = closeProbe;
+
+      constructor(url: string) {
+        openedUrls.push(url);
+      }
+    }
+    globalWithWebSocketStream.WebSocketStream = OpeningWebSocketStream;
+
+    const t = new WSTransport({
+      url: "ws://127.0.0.1:52800",
+      webSocketFactory: (url) => new FakeSocket(url) as unknown as WebSocket,
+    });
+
+    const connectPromise = t.connect();
+    await drainMicrotasks();
+
+    expect(openedUrls).toEqual(["ws://127.0.0.1:52800"]);
+    expect(closeProbe).toHaveBeenCalledWith({ closeCode: 1000, reason: "probe complete" });
+    expect(FakeSocket.instances).toHaveLength(1);
+    lastSocket().open();
+    await connectPromise;
   });
 
   it("emits connection state transitions disconnected → connecting → connected", async () => {
@@ -143,6 +238,26 @@ describe("WSTransport", () => {
 
     await vi.advanceTimersByTimeAsync(5_000);
     expect(FakeSocket.instances.length).toBe(1);
+  });
+
+  it("uses the updated URL after setUrl()", async () => {
+    const t = new WSTransport({
+      url: "ws://127.0.0.1:52800",
+      webSocketFactory: (url) => new FakeSocket(url) as unknown as WebSocket,
+    });
+    const firstConnect = t.connect();
+    const first = lastSocket();
+    first.open();
+    await firstConnect;
+
+    await t.setUrl("ws://127.0.0.1:52801");
+    expect(first.closeCalls).toBeGreaterThan(0);
+
+    const secondConnect = t.connect();
+    expect(lastSocket().url).toBe("ws://127.0.0.1:52801");
+    lastSocket().open();
+    await secondConnect;
+    expect(t.state).toBe("connected");
   });
 
   it("backs off exponentially across consecutive failed reconnects (1s, 2s, 4s, …, capped at 5s)", async () => {

--- a/apps/extension/src/transport/transport.ts
+++ b/apps/extension/src/transport/transport.ts
@@ -5,7 +5,7 @@ export interface Disposable {
 }
 
 export type FrameHandler = (msg: ProtocolFrame) => void;
-export type ConnectionStateHandler = (state: ConnectionState) => void;
+export type ConnectionStateHandler = (state: ConnectionState, error?: Error) => void;
 
 /**
  * Abstraction over a bidirectional protocol channel (§4.7).

--- a/apps/extension/src/transport/ws-transport.ts
+++ b/apps/extension/src/transport/ws-transport.ts
@@ -3,8 +3,10 @@ import type { ConnectionState, ProtocolFrame } from "./types";
 
 const DEFAULT_INITIAL_DELAY_MS = 1_000;
 const DEFAULT_MAX_DELAY_MS = 5_000;
+const DEFAULT_OPEN_PROBE_TIMEOUT_MS = 1_000;
 
 export type WebSocketFactory = (url: string) => WebSocket;
+export type WebSocketOpenProbe = (url: string) => boolean | Promise<boolean>;
 
 export interface ReconnectOptions {
   initialDelayMs?: number;
@@ -18,6 +20,13 @@ export interface WSTransportOptions {
    * Inject a fake WebSocket constructor in tests; defaults to `globalThis.WebSocket`.
    */
   webSocketFactory?: WebSocketFactory;
+  /**
+   * Optional quiet availability check before constructing `WebSocket`.
+   * Chrome reports failed classic WebSocket handshakes in chrome://extensions,
+   * so the default uses `WebSocketStream` when available and falls back to
+   * allowing the classic connection on browsers without that API.
+   */
+  openProbe?: WebSocketOpenProbe | null;
 }
 
 interface CloseLikeEvent {
@@ -27,6 +36,47 @@ interface CloseLikeEvent {
 
 interface MessageLikeEvent {
   data: unknown;
+}
+
+interface WebSocketStreamLike {
+  opened: Promise<unknown>;
+  close?: (options?: { closeCode?: number; reason?: string }) => void;
+}
+
+type WebSocketStreamConstructor = new (
+  url: string,
+  options?: { signal?: AbortSignal },
+) => WebSocketStreamLike;
+
+function defaultOpenProbe(url: string): boolean | Promise<boolean> {
+  const ctor = (globalThis as { WebSocketStream?: WebSocketStreamConstructor }).WebSocketStream;
+  if (!ctor) return true;
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), DEFAULT_OPEN_PROBE_TIMEOUT_MS);
+  let stream: WebSocketStreamLike;
+  try {
+    stream = new ctor(url, { signal: controller.signal });
+  } catch {
+    clearTimeout(timer);
+    return Promise.resolve(false);
+  }
+
+  return stream.opened.then(
+    () => {
+      clearTimeout(timer);
+      try {
+        stream.close?.({ closeCode: 1000, reason: "probe complete" });
+      } catch {
+        // ignore
+      }
+      return true;
+    },
+    () => {
+      clearTimeout(timer);
+      return false;
+    },
+  );
 }
 
 /**
@@ -40,12 +90,14 @@ interface MessageLikeEvent {
  *    (1s, 2s, 4s, …, capped at 5s) until `disconnect()` is called.
  */
 export class WSTransport implements Transport {
-  private readonly url: string;
+  private url: string;
   private readonly factory: WebSocketFactory;
+  private readonly openProbe: WebSocketOpenProbe | null;
   private readonly initialDelayMs: number;
   private readonly maxDelayMs: number;
 
   private socket: WebSocket | null = null;
+  private openingSocket = false;
   private currentState: ConnectionState = "disconnected";
   private explicitlyClosed = false;
   private reconnectAttempt = 0;
@@ -54,6 +106,7 @@ export class WSTransport implements Transport {
   private connectingPromise: Promise<void> | null = null;
   private resolveConnect: ((value: void) => void) | null = null;
   private rejectConnect: ((reason: Error) => void) | null = null;
+  private lastSocketError: Error | null = null;
 
   private readonly messageHandlers = new Set<FrameHandler>();
   private readonly stateHandlers = new Set<ConnectionStateHandler>();
@@ -61,12 +114,20 @@ export class WSTransport implements Transport {
   constructor(options: WSTransportOptions) {
     this.url = options.url;
     this.factory = options.webSocketFactory ?? ((url: string) => new WebSocket(url));
+    this.openProbe = options.openProbe === undefined ? defaultOpenProbe : options.openProbe;
     this.initialDelayMs = options.reconnect?.initialDelayMs ?? DEFAULT_INITIAL_DELAY_MS;
     this.maxDelayMs = options.reconnect?.maxDelayMs ?? DEFAULT_MAX_DELAY_MS;
   }
 
   get state(): ConnectionState {
     return this.currentState;
+  }
+
+  async setUrl(url: string): Promise<void> {
+    const next = url.trim();
+    if (this.url === next) return;
+    this.url = next;
+    await this.disconnect();
   }
 
   connect(): Promise<void> {
@@ -81,7 +142,7 @@ export class WSTransport implements Transport {
     if (this.connectingPromise) {
       // A previous physical attempt closed before reaching OPEN. Keep the
       // original caller's promise, but start the next socket generation.
-      if (!this.socket) this.openSocket();
+      if (!this.socket && !this.openingSocket) void this.openSocket();
       return this.connectingPromise;
     }
 
@@ -89,7 +150,7 @@ export class WSTransport implements Transport {
       this.resolveConnect = resolve;
       this.rejectConnect = reject;
     });
-    this.openSocket();
+    void this.openSocket();
     return this.connectingPromise;
   }
 
@@ -147,14 +208,47 @@ export class WSTransport implements Transport {
     };
   }
 
-  private openSocket(): void {
+  private async openSocket(): Promise<void> {
+    if (this.openingSocket) return;
+    this.openingSocket = true;
     this.setState("connecting");
     const generation = ++this.socketGeneration;
-    const socket = this.factory(this.url);
+    const probeResult = this.canOpenSocket();
+    const canOpen = typeof probeResult === "boolean" ? probeResult : await probeResult;
+    if (!this.isCurrentGeneration(generation)) {
+      this.openingSocket = false;
+      return;
+    }
+    if (!canOpen) {
+      this.openingSocket = false;
+      this.setState("disconnected", this.connectionError());
+      this.scheduleReconnect();
+      return;
+    }
+    let socket: WebSocket;
+    try {
+      socket = this.factory(this.url);
+    } catch (err) {
+      this.openingSocket = false;
+      this.setState("disconnected", this.connectionError(err));
+      this.scheduleReconnect();
+      return;
+    }
+    if (!this.isCurrentGeneration(generation)) {
+      this.openingSocket = false;
+      try {
+        socket.close();
+      } catch {
+        // ignore
+      }
+      return;
+    }
     this.socket = socket;
+    this.openingSocket = false;
 
     socket.addEventListener("open", () => {
       if (!this.isCurrentSocket(socket, generation)) return;
+      this.lastSocketError = null;
       this.reconnectAttempt = 0;
       this.setState("connected");
       const resolve = this.resolveConnect;
@@ -174,6 +268,8 @@ export class WSTransport implements Transport {
     });
 
     socket.addEventListener("error", () => {
+      if (!this.isCurrentSocket(socket, generation)) return;
+      this.lastSocketError = this.connectionError();
       // The 'close' handler always fires after 'error' in browsers, so we
       // just record the error and let close drive reconnect logic.
     });
@@ -203,7 +299,9 @@ export class WSTransport implements Transport {
       this.setState("disconnected");
       return;
     }
-    this.setState("disconnected");
+    const error = this.lastSocketError;
+    this.lastSocketError = null;
+    this.setState("disconnected", error ?? undefined);
     this.scheduleReconnect();
   }
 
@@ -224,12 +322,32 @@ export class WSTransport implements Transport {
     return this.socket === socket && this.socketGeneration === generation;
   }
 
-  private setState(next: ConnectionState): void {
+  private isCurrentGeneration(generation: number): boolean {
+    return this.socketGeneration === generation && !this.explicitlyClosed;
+  }
+
+  private canOpenSocket(): boolean | Promise<boolean> {
+    if (!this.openProbe) return true;
+    try {
+      return this.openProbe(this.url);
+    } catch {
+      return false;
+    }
+  }
+
+  private connectionError(cause?: unknown): Error {
+    const suffix = cause instanceof Error && cause.message ? ` (${cause.message})` : "";
+    return new Error(
+      `Cannot reach daemon WebSocket endpoint ${this.url}. Start bsk or check the SSH tunnel.${suffix}`,
+    );
+  }
+
+  private setState(next: ConnectionState, error?: Error): void {
     if (this.currentState === next) return;
     this.currentState = next;
     for (const h of this.stateHandlers) {
       try {
-        h(next);
+        h(next, error);
       } catch (err) {
         console.error("[WSTransport] state handler threw", err);
       }

--- a/packages/i18n/src/locales/en-US/extension.json
+++ b/packages/i18n/src/locales/en-US/extension.json
@@ -26,6 +26,13 @@
     "controlHintsToggleTitle": "Control hints",
     "controlHintsToggleHint": "Show the status pill and orange glow while the Agent controls a page.",
     "controlHintsInfoLabel": "About control hints",
+    "daemonWsUrlTitle": "Daemon endpoint",
+    "daemonWsUrlHint": "For a remote daemon, we recommend forwarding the port with an SSH tunnel, then entering the matching WebSocket URL. Saving reconnects automatically.",
+    "daemonWsUrlInfoLabel": "About the daemon endpoint",
+    "daemonWsUrlApply": "Save and reconnect daemon WebSocket",
+    "daemonWsUrlCurrent": "This endpoint is already active",
+    "daemonWsUrlInvalid": "Enter a ws:// or wss:// URL with a host",
+    "daemonWsUrlConnectError": "Cannot connect to {{url}}. Start bsk or check the SSH tunnel.",
     "versionSkewWarning": "Extension protocol v{{extensionProtocol}}, CLI protocol v{{cliProtocol}}. Protocol versions differ — please upgrade.",
     "upgradeAvailable": "Upgradable",
     "launcher": {

--- a/packages/i18n/src/locales/zh-CN/extension.json
+++ b/packages/i18n/src/locales/zh-CN/extension.json
@@ -26,6 +26,13 @@
     "controlHintsToggleTitle": "控制提示",
     "controlHintsToggleHint": "Agent 控制页面时显示提示条和橙色闪光。",
     "controlHintsInfoLabel": "控制提示说明",
+    "daemonWsUrlTitle": "Daemon 连接地址",
+    "daemonWsUrlHint": "连接远程 daemon 时，推荐使用 SSH 隧道转发端口，再填写对应的 WebSocket 地址。保存后会自动重连。",
+    "daemonWsUrlInfoLabel": "Daemon 连接地址说明",
+    "daemonWsUrlApply": "保存并重连 daemon WebSocket",
+    "daemonWsUrlCurrent": "当前已使用该地址",
+    "daemonWsUrlInvalid": "请输入 ws:// 或 wss:// 开头且包含主机的地址",
+    "daemonWsUrlConnectError": "无法连接到 {{url}}。请启动 bsk，或检查 SSH 隧道。",
     "versionSkewWarning": "扩展协议 v{{extensionProtocol}}，CLI 协议 v{{cliProtocol}}。协议版本不同，请及时升级。",
     "upgradeAvailable": "可升级",
     "launcher": {


### PR DESCRIPTION
## What changed

This PR lets the extension switch the bsk daemon WebSocket address from the popup, so users can connect through a forwarded endpoint without rebuilding the extension.

The address is validated and saved locally, and the extension reconnects after saving. When the daemon endpoint cannot be reached, the popup now shows a friendly error instead of relying on Chrome extension error noise. The popup copy also recommends an encrypted SSH tunnel when the daemon is running on another machine.