### PR TITLE
fix(record): record a page reload instead of dropping it as a same-URL navigation

### DIFF
--- a/apps/extension/src/lib/__tests__/step-buffer.test.ts
+++ b/apps/extension/src/lib/__tests__/step-buffer.test.ts
@@ -115,6 +115,37 @@ describe("recording-step-buffer", () => {
     });
   });
 
+  it("records a reload of the current page instead of dropping it as a same-URL navigation", () => {
+    const buffer = {
+      steps: [],
+      navigation: { currentUrl: "https://example.com/a", pendingNavigation: false },
+    };
+    const result = observeRecordedNavigation(
+      buffer,
+      "https://example.com/a",
+      undefined,
+      "reload",
+      [],
+    );
+    expect(result).toEqual({ kind: "appended", index: 0 });
+    expect(buffer.steps[0]).toMatchObject({
+      op: "navigate",
+      url: "https://example.com/a",
+      transitionType: "reload",
+    });
+  });
+
+  it("still collapses the completion that follows a reload onto the recorded step", () => {
+    const buffer = {
+      steps: [],
+      navigation: { currentUrl: "https://example.com/a", pendingNavigation: false },
+    };
+    observeRecordedNavigation(buffer, "https://example.com/a", undefined, "reload", []);
+    // webNavigation.onCompleted reports the same URL and carries no transition type.
+    expect(observeRecordedNavigation(buffer, "https://example.com/a")).toEqual({ kind: "noop" });
+    expect(buffer.steps).toHaveLength(1);
+  });
+
   it("asks the recorder to coalesce redirect hops instead of emitting each one", () => {
     const buffer = {
       steps: [],

--- a/apps/extension/src/lib/recording/step-buffer.ts
+++ b/apps/extension/src/lib/recording/step-buffer.ts
@@ -92,7 +92,12 @@ export function observeRecordedNavigation(
   transitionQualifiers?: string[],
 ): NavigationObserveResult {
   const navigation = buffer.navigation;
-  if (!url || url === navigation.currentUrl) return { kind: "noop" };
+  // A reload commits to the URL the tab is already on, so the same-URL guard that
+  // collapses the onCommitted / onCompleted pair of one navigation would drop it
+  // too (issue #139). Only the committed event carries the transition type, so the
+  // completion that follows still collapses onto the recorded reload.
+  const isReload = transitionType === "reload";
+  if (!url || (url === navigation.currentUrl && !isReload)) return { kind: "noop" };
   navigation.currentUrl = url;
 
   const pendingIsCurrent =

--- a/apps/extension/src/tools/__tests__/record-steps.test.ts
+++ b/apps/extension/src/tools/__tests__/record-steps.test.ts
@@ -416,6 +416,39 @@ describe("recorded user steps reach the exported trace", () => {
     expect(step?.result.state).toBeTruthy();
   });
 
+  it("records a reload of the page the recording is on", async () => {
+    // Issue #139: a reload commits to the URL the tab is already on, so it used to
+    // be dropped as the duplicate half of a navigation and the trace had no step
+    // for it, even though replaying the flow may depend on the refresh.
+    const chromeApi = installChrome();
+    const manager = fakeManager();
+    const tabsApi = makeTabsApi();
+    const sendToTab = vi.fn(async () => ({ ok: true }));
+
+    await handleRecordStart(manager, RECORD_START_V3, { tabsApi, sendToTab, cdp: makeFakeCdp() });
+
+    const details = { tabId: TAB_ID, frameId: 0, url: START_URL };
+    chromeApi.webNavigationOnCommitted.emit({
+      ...details,
+      transitionType: "reload",
+      transitionQualifiers: [],
+    } as unknown as chrome.webNavigation.WebNavigationTransitionCallbackDetails);
+    chromeApi.webNavigationOnCompleted.emit(
+      details as unknown as chrome.webNavigation.WebNavigationFramedCallbackDetails,
+    );
+    // Let findRecordingForTab's tab lookup and the settle capture resolve.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const stopped = await handleRecordStop(manager, { session_id: "abcd" }, { tabsApi, sendToTab });
+    const trace = (stopped as RecordStopResult).trace as TraceV3;
+
+    expect(trace.steps).toHaveLength(1);
+    const [step] = trace.steps;
+    expect(step).toMatchObject({ op: "navigate", to: START_URL, cause: "reload" });
+    expect(step?.state).toBeTruthy();
+    expect(step?.result.state).toBeTruthy();
+  });
+
   it("reports an address-bar navigation from the page it started on, not the redirect hop", async () => {
     const chromeApi = installChrome();
     const manager = fakeManager();


### PR DESCRIPTION
## Problem

During recording, a page reload (F5, the reload button, or `location.reload()`) leaves no step in the trace. A flow that only takes effect after a refresh therefore stalls on replay, because the trace never says to reload (#139).

## Root cause

`observeRecordedNavigation` opens with

```ts
if (!url || url === navigation.currentUrl) return { kind: "noop" };
```

The guard is there so the `webNavigation.onCommitted` / `onCompleted` pair of one navigation yields one step. A reload commits to the URL the tab is already on, so the same guard swallows it on the same line. The rest of the pipeline was already prepared for reloads: `trace-reducer-v3.ts` has carried `reload: "reload"` in `TRANSITION_CAUSES`, and the protocol defines `NavigationCause::Reload`, but the buffer never produced a draft that reached either.

Reproduced through the real recorder (start on `https://example.com/`, `onCommitted` with `transitionType: "reload"`, `onCompleted`, stop): on `main` the exported v3 trace has `steps: []`.

## Fix

One condition in `step-buffer.ts`: a commit whose `transitionType` is `reload` passes the same-URL guard. Only the committed event carries the transition type, so the completion that follows (same URL, no type) still collapses onto it and no duplicate is produced. The step reduces to `{ op: "navigate", to: <url>, cause: "reload" }`, the shape the protocol already defines, so whoever replays the trace can issue `bsk reload` at that point.

Everything else is unchanged: action-caused navigations still annotate the action with `navigatedTo`, redirect hops still coalesce, and a reload triggered by pressing Enter in the address bar carries `from_address_bar`, which the reducer already maps to `user_typed`.

One consequence worth stating: Chrome reports `reload` for script-initiated reloads too, so a page that reloads itself is now recorded as well. Replaying `bsk reload` there is harmless and matches what the page actually did.

## Tests

Three tests added (846 → 849), all failing on `main` with `steps: []`:

- `step-buffer.test.ts`: a reload of the current page is appended as a navigate draft with `transitionType: "reload"`; the completion that follows still collapses onto it, so there is no duplicate.
- `record-steps.test.ts`: end to end through `handleRecordStart` → `onCommitted(reload)` → `onCompleted` → `handleRecordStop`, the exported v3 trace has exactly one step, `{ op: "navigate", to: START_URL, cause: "reload" }`, with pre- and post-states.

## Verification

- `pnpm lint` — exit 0 (biome, stylelint, dsh-plugin typecheck and tests)
- `pnpm --filter @browser-skill/extension compile` — clean
- `pnpm ext:test` — 76 files, 849 passed
- `pnpm ext:build` — clean

Not exercised in a live Chrome here; the recorder harness in `record-steps.test.ts` drives the same `webNavigation` listeners the extension installs.

Closes #139
