### PR TITLE
fix(dsh-plugin): remove obsolete client runtime host dependency

### DIFF
--- a/packages/dsh-plugin-browserskill/package.json
+++ b/packages/dsh-plugin-browserskill/package.json
@@ -47,7 +47,6 @@
     "client": {
       "platform": "web",
       "inject": [
-        "@deepseek-ai/dsh-client-runtime",
         "@deepseek-ai/dsh-client-ui-tool",
         "@deepseek-ai/dsh-client-ui-layout"
       ],
@@ -69,7 +68,6 @@
   "peerDependencies": {
     "@deepseek-ai/cordis": "^4.0.1",
     "@deepseek-ai/dsh-attachment": "^0.1.0-rc.6",
-    "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.6",
     "@deepseek-ai/dsh-client-ui-attachment": "^0.1.0-rc.6",
     "@deepseek-ai/dsh-client-ui-primitives": "^0.1.0-rc.6",
     "@deepseek-ai/dsh-client-ui-tool": "^0.1.0-rc.6",
@@ -80,9 +78,6 @@
   },
   "peerDependenciesMeta": {
     "@deepseek-ai/dsh-attachment": {
-      "optional": true
-    },
-    "@deepseek-ai/dsh-client-runtime": {
       "optional": true
     },
     "@deepseek-ai/dsh-client-ui-attachment": {

--- a/packages/dsh-plugin-browserskill/src/client/index.ts
+++ b/packages/dsh-plugin-browserskill/src/client/index.ts
@@ -7,6 +7,7 @@
  */
 
 import type { ImageAttachmentRef } from "@deepseek-ai/dsh-attachment";
+// Development-only types for the injected services; newer hosts no longer ship this package.
 import type { ClientContext, ISessions, SessionId } from "@deepseek-ai/dsh-client-runtime/client";
 // Type-only: pulls the 'shell.overlay' SlotMap merge into scope.
 import type {} from "@deepseek-ai/dsh-client-ui-layout/client";

--- a/packages/dsh-plugin-browserskill/tsdown.config.ts
+++ b/packages/dsh-plugin-browserskill/tsdown.config.ts
@@ -25,7 +25,6 @@ const CLIENT_EXTERNALS: readonly string[] = [
   "@deepseek-ai/dsh-client-ui-primitives",
   "@deepseek-ai/dsh-client-ui-attachment",
   "@deepseek-ai/dsh-client-schema-form",
-  "@deepseek-ai/dsh-client-runtime/client",
 ];
 
 /** Wire/type layers with no shared runtime identity: safe to inline. */


### PR DESCRIPTION
## Problem

Installing the DSH plugin on a newer host that no longer ships `@deepseek-ai/dsh-client-runtime` triggers a preflight warning because the plugin still declares it as a peer dependency.

The package is already marked optional. Its client imports are type-only, and neither the published client nor server bundle requires it at runtime.

Fixes #193.

## Changes

- Remove `dsh-client-runtime` from peer dependencies and its optional peer metadata.
- Remove the obsolete `dsh.client.inject` entry.
- Remove the runtime external allowance so future value imports cannot silently reintroduce this dependency.
- Keep the development dependency for existing type imports, with a comment explaining why.

This change does not upgrade the DSH SDK or alter browser tools or UI behavior.

## Validation

Verified on Windows:

- All 210 existing plugin tests passed.
- Plugin typecheck and build passed.
- Biome checks and frozen lockfile validation passed.
- Confirmed both generated bundles contain no reference to the removed runtime package.
- Loaded the generated client bundle and ran `apply()` with a resolver that rejects the removed package. Initialization and toolview/overlay registration succeeded.

The initialization check used real React with mocked host services and UI modules. The DSH Desktop preflight screen and full UI flow have not been tested because the matching Desktop installation was unavailable.