### PR TITLE
feat(vom): expose canvas visual refs in observations with cursor continuation | 在观察结果中呈现 Canvas 视觉入口并支持过多内容时翻页

### DIFF
--- a/apps/extension/src/session-manager/ref-store.ts
+++ b/apps/extension/src/session-manager/ref-store.ts
@@ -36,6 +36,10 @@ export class RefStore {
   private map = new Map<string, RefEntry>();
   private generation = 0;
 
+  get revision(): number {
+    return this.generation;
+  }
+
   size(): number {
     return this.map.size;
   }
@@ -87,6 +91,7 @@ export class RefStore {
   }
 
   clear(): void {
+    this.generation++;
     this.map.clear();
   }
 

--- a/apps/extension/src/tools/observation.ts
+++ b/apps/extension/src/tools/observation.ts
@@ -1143,7 +1143,8 @@ async function handleVomObservation(
         : {}),
     });
   } catch (err) {
-    clearObservationContinuation(ctx.refStore);
+    // Fresh observations clear their predecessor before capture. Continuation owns
+    // invalidation; cancellation must preserve its unpublished page for retry.
     if (isAbortError(err)) return cancelled(toolName);
     return {
       code: "cdp_failed",

--- a/apps/extension/src/tools/observation.ts
+++ b/apps/extension/src/tools/observation.ts
@@ -1,5 +1,13 @@
 import { parsePngDimensions } from "./png";
 import { captureVisualScreenshot } from "./visual-screenshot";
+import { deduplicateVisualCandidates } from "./vom/visual-dedup";
+import { discoverVisualCandidates } from "./vom/visual-discovery";
+import {
+  clearObservationContinuation,
+  type ObservationOutput,
+  prepareVisualObservation,
+  publishObservationPage,
+} from "./vom/visual-observation";
 
 export { parsePngDimensions } from "./png";
 
@@ -864,6 +872,7 @@ async function runHoverProbes(
 }
 
 export interface CaptureVomObservationOptions extends VomOptions {
+  includeVisualFacts?: boolean;
   conditionalSurfaceProbe?: boolean;
   hoverProbeBypassOverlay?: (tabId: number, enabled: boolean) => Promise<void>;
   signal?: AbortSignal;
@@ -874,11 +883,13 @@ export async function captureVomObservation(
   tabId: number,
   url: string | undefined,
   options: CaptureVomObservationOptions = {},
-): Promise<CaptureVomObservationResult> {
+): Promise<CaptureVomObservationResult & { visualOutput?: ObservationOutput }> {
   throwIfAborted(options.signal, "observation");
   await cdp.ensureAttachedToUrl?.(tabId, url);
   throwIfAborted(options.signal, "observation");
-  const facts = await captureObservationFacts<CdpAxNode>(cdp, tabId, options.signal, url);
+  const facts = await captureObservationFacts<CdpAxNode>(cdp, tabId, options.signal, url, {
+    includeVisualFacts: options.includeVisualFacts,
+  });
   const { captured, documents: normalizedDocuments } = semanticCapture(facts);
   throwIfAborted(options.signal, "observation");
   const semanticGraph = buildSemanticGraph({
@@ -897,11 +908,10 @@ export async function captureVomObservation(
     options,
   );
   throwIfAborted(options.signal, "observation");
-  const scene = projectSemanticGraph(
-    normalizeSemanticStructure(
-      resolveSemanticGraph(semanticGraph, { supplementalNames: hoverProbes.tooltipNames }),
-    ),
+  const structured = normalizeSemanticStructure(
+    resolveSemanticGraph(semanticGraph, { supplementalNames: hoverProbes.tooltipNames }),
   );
+  const scene = projectSemanticGraph(structured);
   const decoratedScene = attachCapturedSceneAnnotations(
     scene,
     normalizedDocuments,
@@ -934,6 +944,39 @@ export async function captureVomObservation(
     notices.push(
       "@warning document identity unverified: some retained documents could not be checked for changes during capture.",
     );
+  if (options.includeVisualFacts) {
+    const discovery = await deduplicateVisualCandidates(
+      await discoverVisualCandidates(facts, options.signal),
+      options.signal,
+    );
+    const identities = new Map(
+      facts.documents.flatMap((doc) =>
+        doc.identity ? [[doc.frame.frameId, doc.identity] as const] : [],
+      ),
+    );
+    const visualOutput = prepareVisualObservation(
+      decoratedScene,
+      structured,
+      discovery,
+      identities,
+      captured.rootFrameId ?? "root",
+      notices,
+      options,
+    );
+    return {
+      ...projectRecordSafeObservation({
+        rootFrameId: captured.rootFrameId ?? "root",
+        frameDocuments: normalizedDocuments,
+        rendered: { text: "", refs: [], truncated: false },
+        surfaceProbes: hoverProbes.surfaceProbes,
+        hoverProbe: {
+          performed: hoverProbes.performed,
+          revealedContent: hoverProbes.revealedContent,
+        },
+      }),
+      visualOutput,
+    };
+  }
   const captureNotice = notices.join("\n");
   const rendered = renderVom(decoratedScene, {
     maxDepth: options.maxDepth,
@@ -989,7 +1032,29 @@ async function handleVomObservation(
     deps.cdp.trackSessionTab?.(ctx.sessionId, target.tabId);
     const effectiveConditionalSurfaceProbe =
       deps.conditionalSurfaceProbe ?? conditionalSurfaceProbe;
+    const cursor = toolName === "observe" ? (params as ObserveParams).cursor : undefined;
+    if (cursor) {
+      if (
+        params.max_depth !== undefined ||
+        (params as ObserveParams).probe_hover ||
+        (params as ObserveParams).debug_surfaces
+      )
+        return {
+          code: "invalid_params",
+          message: "cursor cannot change depth or request hover/debug probes",
+        };
+      const page = await publishObservationPage(
+        ctx.refStore,
+        deps.cdp,
+        target.tabId,
+        { cursor, maxTokens: params.max_tokens },
+        signal,
+      );
+      return isRpcError(page) ? page : attachDialogs(deps.cdp, target.tabId, dialogCursor, page);
+    }
+    clearObservationContinuation(ctx.refStore);
     const observation = await captureVomObservation(deps.cdp, target.tabId, target.url, {
+      includeVisualFacts: toolName === "observe",
       maxDepth: params.max_depth,
       maxTokens: params.max_tokens,
       activeRegionPolicy: true,
@@ -998,6 +1063,40 @@ async function handleVomObservation(
       signal,
     });
     throwIfAborted(signal, toolName);
+    if (observation.visualOutput) {
+      const page = await publishObservationPage(
+        ctx.refStore,
+        deps.cdp,
+        target.tabId,
+        { output: observation.visualOutput },
+        signal,
+      );
+      if (isRpcError(page)) return page;
+      return attachDialogs(deps.cdp, target.tabId, dialogCursor, {
+        ...page,
+        ...(observation.hoverProbe?.performed
+          ? {
+              hover_probe: {
+                performed: true,
+                revealed_content: observation.hoverProbe.revealedContent,
+              },
+            }
+          : {}),
+        ...((params as ObserveParams).debug_surfaces
+          ? {
+              debug: {
+                surface_probes: (observation.surfaceProbes ?? []).map((probe) => ({
+                  trigger_backend_node_id: probe.triggerBackendNodeId,
+                  trigger_action: probe.triggerAction,
+                  sub_items: probe.subItems,
+                  ...(probe.triggerPoint ? { trigger_point: probe.triggerPoint } : {}),
+                  ...(probe.confidence ? { confidence: probe.confidence } : {}),
+                })),
+              },
+            }
+          : {}),
+      });
+    }
     const targetByFrameId = new Map(
       observation.frames.map((frame) => [frame.frameId, frame.target]),
     );
@@ -1044,6 +1143,7 @@ async function handleVomObservation(
         : {}),
     });
   } catch (err) {
+    clearObservationContinuation(ctx.refStore);
     if (isAbortError(err)) return cancelled(toolName);
     return {
       code: "cdp_failed",

--- a/apps/extension/src/tools/vom/__tests__/visual-observation.test.ts
+++ b/apps/extension/src/tools/vom/__tests__/visual-observation.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, it, vi } from "vitest";
 import { SessionManager } from "@/session-manager/manager";
 import { RefStore } from "@/session-manager/ref-store";
 import type { ObserveResult } from "@/transport/types";
+import { auditContext } from "../../audit-context";
 import { handleObserve, handleSnapshot } from "../../observation";
 import type { CdpRunner } from "../../shared";
 import type { DocumentIdentity } from "../facts";
@@ -164,6 +165,7 @@ describe("visual observation output", () => {
     let r = success(await publishObservationPage(f.store, f.cdp, 4, { output: f.output }));
     const seen = new Set<string>();
     let pages = 0;
+    let retriedFinalPage = false;
     while (true) {
       expect(
         r.text.split("\n").reduce((n, line) => n + Math.ceil(line.length / 4), 0),
@@ -177,9 +179,13 @@ describe("visual observation output", () => {
       const old = [...f.store.entries()].map(([ref]) => ref);
       r = success(await publishObservationPage(f.store, f.cdp, 4, { cursor }));
       for (const ref of old) expect(f.store.resolveEntry(ref)).toBeNull();
+      const revision = f.store.revision;
       expect(await publishObservationPage(f.store, f.cdp, 4, { cursor })).toEqual(r);
+      expect(f.store.revision).toBe(revision);
+      if (!r.next_cursor) retriedFinalPage = true;
       expect(++pages).toBeLessThan(35);
     }
+    expect(retriedFinalPage).toBe(true);
     expect(seen.size).toBe(35);
     expect(
       f.send.mock.calls.every((c) =>
@@ -845,4 +851,85 @@ it("can retry a cancelled final page with a smaller budget without losing buffer
     cursor = result.next_cursor;
   }
   expect(seen.size).toBe(20);
+});
+
+it("preserves DOM labels for audit on the first and continuation pages", async () => {
+  const f = fixture(0, 110);
+  f.scene.nodes.push(
+    ...Array.from({ length: 12 }, (_, i) => ({
+      ...node(i + 2, 1, "button", `Action ${i}`),
+      rect: { x: 0, y: i * 35, w: 100, h: 30 },
+    })),
+  );
+  f.output.render = prepareObservationRender(f.scene);
+  const manager = new SessionManager({
+    agentWindow: {
+      create: async () => 100,
+      remove: async () => {},
+      ensureActiveTab: async () => 4,
+    },
+  });
+  const ctx = await manager.start("audit-test");
+  ctx.agentCreatedTabs.add(4);
+  const originalChrome = globalThis.chrome;
+  vi.stubGlobal("chrome", {
+    tabs: { get: vi.fn(async () => ({ id: 4, url: "https://fixture.test/page" })) },
+  });
+  try {
+    let result = success(
+      await publishObservationPage(ctx.refStore, f.cdp, 4, { output: f.output }),
+    );
+    let pages = 0;
+    const labels: string[] = [];
+    while (true) {
+      for (const [ref, entry] of ctx.refStore.entries()) {
+        expect(entry.kind).toBe("dom");
+        if (entry.kind !== "dom") throw new Error("expected DOM ref");
+        expect(entry.name).toBe(`Action ${labels.length}`);
+        const audit = await auditContext(
+          {
+            id: "audit-click",
+            method: "tool.click",
+            params: {
+              session_id: ctx.sessionId,
+              tab_id: 4,
+              ref,
+              _audit_id: "operation-test",
+            },
+          },
+          manager,
+        );
+        expect(audit).toMatchObject({ target: entry.name, tab_id: 4 });
+        labels.push(entry.name!);
+      }
+      pages++;
+      if (!result.next_cursor) break;
+      result = success(
+        await publishObservationPage(ctx.refStore, f.cdp, 4, { cursor: result.next_cursor }),
+      );
+    }
+    expect(pages).toBeGreaterThan(1);
+    expect(labels).toHaveLength(12);
+    // A visual ref has no DOM audit label, even when its candidate has a label.
+    ctx.refStore.replace([
+      ["e1", { kind: "visual-region", candidate: { ...candidate(100), label: "Canvas" } }],
+    ]);
+    expect(
+      await auditContext(
+        {
+          id: "audit-visual",
+          method: "tool.click",
+          params: {
+            session_id: ctx.sessionId,
+            tab_id: 4,
+            ref: "e1",
+            _audit_id: "operation-test",
+          },
+        },
+        manager,
+      ),
+    ).not.toHaveProperty("target");
+  } finally {
+    vi.stubGlobal("chrome", originalChrome);
+  }
 });

--- a/apps/extension/src/tools/vom/__tests__/visual-observation.test.ts
+++ b/apps/extension/src/tools/vom/__tests__/visual-observation.test.ts
@@ -1,0 +1,541 @@
+import {
+  prepareObservationRender,
+  renderVom,
+  type VomNode,
+  type VomScene,
+} from "@browser-skill/vom";
+import { describe, expect, it, vi } from "vitest";
+import { SessionManager } from "@/session-manager/manager";
+import { RefStore } from "@/session-manager/ref-store";
+import type { ObserveResult } from "@/transport/types";
+import { handleObserve, handleSnapshot } from "../../observation";
+import type { CdpRunner } from "../../shared";
+import type { DocumentIdentity } from "../facts";
+import {
+  buildSemanticGraph,
+  normalizeSemanticStructure,
+  projectSemanticGraph,
+  resolveSemanticGraph,
+} from "../semantic-graph";
+import type { VisualCandidate } from "../visual-discovery";
+import {
+  attachVisualEntries,
+  type ObservationOutput,
+  prepareVisualObservation,
+  publishObservationPage,
+} from "../visual-observation";
+
+const identity: DocumentIdentity = {
+  attachmentId: "a",
+  target: { tabId: 4 },
+  frameId: "top",
+  documentElementBackendNodeId: 1,
+};
+const candidate = (id: number): VisualCandidate => ({
+  document: identity,
+  backendNodeId: id,
+  parentBackendNodeId: 1,
+  framePath: { document: identity },
+  region: {
+    status: "available",
+    borderBox: { x: 0, y: 0, width: 100, height: 100 },
+    crop: { x: 0, y: 0, width: 100, height: 100 },
+  },
+});
+const node = (id: number, parentId: number | null, role: string, name?: string): VomNode => ({
+  id,
+  parentId,
+  backendNodeId: id,
+  frameId: "top",
+  tag: role,
+  role,
+  name,
+  rect: { x: 0, y: 0, w: 100, h: 30 },
+  paintOrder: id,
+  position: "static",
+  pointerEvents: "auto",
+});
+function fixture(count = 20, maxTokens?: number) {
+  const candidates = Array.from({ length: count }, (_, i) => candidate(i + 100));
+  const scene: VomScene = {
+    viewport: { width: 1200, height: 800 },
+    nodes: [node(1, null, "rootwebarea")],
+    visuals: candidates.map((_, key) => ({ key, parentId: 1, frameId: "top" })),
+  };
+  const output: ObservationOutput = {
+    candidates,
+    identities: new Map([["top", identity]]),
+    rootIdentity: identity,
+    frames: new Map([["top", { target: identity.target }]]),
+    render: prepareObservationRender(scene),
+    notices: [],
+    maxTokens,
+  };
+  let changed = false;
+  const send = vi.fn(async (_tab: number, method: string) => {
+    if (method === "Page.createIsolatedWorld") return { executionContextId: 1 };
+    if (method === "Runtime.evaluate")
+      return {
+        result: {
+          deepSerializedValue: { type: "node", value: { backendNodeId: changed ? 999 : 1 } },
+        },
+      };
+    if (method === "Runtime.releaseObjectGroup") return {};
+    throw new Error(`unexpected ${method}`);
+  });
+  const cdp = { send, getAttachmentId: () => "a" } as unknown as CdpRunner;
+  return {
+    output,
+    scene,
+    store: new RefStore(),
+    cdp,
+    send,
+    change: () => {
+      changed = true;
+    },
+  };
+}
+const success = (r: Awaited<ReturnType<typeof publishObservationPage>>): ObserveResult => {
+  expect(r).not.toHaveProperty("code");
+  return r as ObserveResult;
+};
+
+describe("visual observation output", () => {
+  it("publishes all unnamed Canvas refs by default without live reads or screenshots", async () => {
+    const f = fixture(120);
+    const r = success(await publishObservationPage(f.store, f.cdp, 4, { output: f.output }));
+    expect(r.ref_count).toBe(120);
+    expect(r.next_cursor).toBeUndefined();
+    expect(r.text.match(/\[visual:screenshot\]/g)).toHaveLength(120);
+    expect(f.store.resolveEntry("e1")?.kind).toBe("visual-region");
+    expect(f.send).not.toHaveBeenCalled();
+  });
+  it("continues all candidates, replaces refs and retries the latest cursor without skipping", async () => {
+    const f = fixture(35, 100);
+    let r = success(await publishObservationPage(f.store, f.cdp, 4, { output: f.output }));
+    const seen = new Set<string>();
+    let pages = 0;
+    while (true) {
+      expect(
+        r.text.split("\n").reduce((n, line) => n + Math.ceil(line.length / 4), 0),
+      ).toBeLessThanOrEqual(100);
+      for (const [ref] of f.store.entries()) {
+        expect(seen.has(ref)).toBe(false);
+        seen.add(ref);
+      }
+      if (!r.next_cursor) break;
+      const cursor = r.next_cursor;
+      const old = [...f.store.entries()].map(([ref]) => ref);
+      r = success(await publishObservationPage(f.store, f.cdp, 4, { cursor }));
+      for (const ref of old) expect(f.store.resolveEntry(ref)).toBeNull();
+      expect(await publishObservationPage(f.store, f.cdp, 4, { cursor })).toEqual(r);
+      expect(++pages).toBeLessThan(35);
+    }
+    expect(seen.size).toBe(35);
+    expect(
+      f.send.mock.calls.every((c) =>
+        ["Page.createIsolatedWorld", "Runtime.evaluate", "Runtime.releaseObjectGroup"].includes(
+          c[1],
+        ),
+      ),
+    ).toBe(true);
+  });
+  it.each(["DOM", "replace", "clear", "tab"])("rejects a cursor after %s changes", async (kind) => {
+    const f = fixture(20, 100);
+    const first = success(await publishObservationPage(f.store, f.cdp, 4, { output: f.output }));
+    if (kind === "DOM") f.change();
+    if (kind === "replace") f.store.replace([]);
+    if (kind === "clear") f.store.clear();
+    expect(
+      await publishObservationPage(f.store, f.cdp, kind === "tab" ? 5 : 4, {
+        cursor: first.next_cursor,
+      }),
+    ).toHaveProperty("code");
+  });
+  it("does not consume an entry when a continuation budget is too small", async () => {
+    const f = fixture(20, 100);
+    const first = success(await publishObservationPage(f.store, f.cdp, 4, { output: f.output }));
+    const cursor = first.next_cursor!;
+    expect(
+      await publishObservationPage(f.store, f.cdp, 4, { cursor, maxTokens: 1 }),
+    ).toHaveProperty("code");
+    const next = success(
+      await publishObservationPage(f.store, f.cdp, 4, { cursor, maxTokens: 100 }),
+    );
+    expect(next.ref_count).toBeGreaterThan(0);
+  });
+  it("shrinks a long visual label, preserving its complete capability marker", async () => {
+    const f = fixture(1, 45);
+    f.scene.visuals![0].label = 'bad\n" ' + "x".repeat(1000);
+    f.output.render = prepareObservationRender(f.scene);
+    const r = success(await publishObservationPage(f.store, f.cdp, 4, { output: f.output }));
+    expect(r.text).toContain("@e1 canvas [visual:screenshot]");
+    expect(r.next_cursor).toBeUndefined();
+  });
+  it("keeps Canvas reachable below a depth limit", async () => {
+    const f = fixture(1);
+    f.scene.nodes.push(node(2, 1, "group", "deep"));
+    f.scene.visuals![0].parentId = 2;
+    f.output.render = prepareObservationRender(f.scene, { maxDepth: 1 });
+    const r = success(await publishObservationPage(f.store, f.cdp, 4, { output: f.output }));
+    expect(r.ref_count).toBe(1);
+    expect(r.truncated).toBe(true);
+  });
+  it("preserves the original semantic output when there are no Canvas entries", () => {
+    const scene: VomScene = {
+      viewport: { width: 1000, height: 800 },
+      nodes: [
+        node(1, null, "rootwebarea"),
+        node(2, 1, "button", "Save"),
+        node(3, 2, "statictext", "Save"),
+      ],
+    };
+    const original = renderVom(scene);
+    const prepared = prepareObservationRender(scene);
+    expect(
+      [
+        ...prepared.headers,
+        ...Array.from({ [Symbol.iterator]: () => prepared.rows }).map((r) => r.text),
+      ].join("\n"),
+    ).toBe(original.text);
+  });
+  it("joins through a dropped wrapper using source order without naming Canvas from nearby buttons", () => {
+    const docs: Parameters<typeof buildSemanticGraph>[0]["documents"] = [
+      {
+        frameId: "top",
+        target: { tabId: 4 },
+        contextScopeId: "top",
+        domNodes: [
+          {
+            backendNodeId: 1,
+            parentBackendNodeId: null,
+            tag: "main",
+            attrs: {},
+            rect: { x: 0, y: 0, w: 300, h: 300 },
+            paintOrder: 1,
+            position: "static",
+            pointerEvents: "auto",
+          },
+          {
+            backendNodeId: 2,
+            parentBackendNodeId: 1,
+            tag: "button",
+            attrs: { "aria-label": "Before" },
+            rect: { x: 0, y: 0, w: 100, h: 30 },
+            paintOrder: 2,
+            position: "static",
+            pointerEvents: "auto",
+          },
+          {
+            backendNodeId: 3,
+            parentBackendNodeId: 1,
+            tag: "div",
+            attrs: {},
+            rect: { x: 0, y: 30, w: 100, h: 100 },
+            paintOrder: 3,
+            position: "static",
+            pointerEvents: "auto",
+          },
+          {
+            backendNodeId: 4,
+            parentBackendNodeId: 3,
+            tag: "canvas",
+            attrs: {},
+            rect: { x: 0, y: 30, w: 100, h: 100 },
+            paintOrder: 4,
+            position: "static",
+            pointerEvents: "auto",
+          },
+          {
+            backendNodeId: 5,
+            parentBackendNodeId: 1,
+            tag: "button",
+            attrs: { "aria-label": "After" },
+            rect: { x: 0, y: 130, w: 100, h: 30 },
+            paintOrder: 5,
+            position: "static",
+            pointerEvents: "auto",
+          },
+        ],
+        axNodes: [],
+      },
+    ];
+    const graph = normalizeSemanticStructure(
+      resolveSemanticGraph(
+        buildSemanticGraph({
+          documents: docs,
+          rootFrameId: "top",
+          viewport: { width: 300, height: 300 },
+        }),
+      ),
+    );
+    const scene = attachVisualEntries(projectSemanticGraph(graph), graph, [candidate(4)]);
+    const prepared = prepareObservationRender(scene);
+    const text = Array.from({ [Symbol.iterator]: () => prepared.rows })
+      .map((r) => r.text)
+      .join("\n");
+    expect(text.indexOf('"Before"')).toBeLessThan(text.indexOf("[visual:screenshot]"));
+    expect(text.indexOf("[visual:screenshot]")).toBeLessThan(text.indexOf('"After"'));
+    expect(text).toMatch(/canvas \[visual:screenshot\]/);
+  });
+  it("keeps unplaced candidates in an explicit supplement", () => {
+    const graph = normalizeSemanticStructure(
+      resolveSemanticGraph(
+        buildSemanticGraph({
+          documents: [],
+          rootFrameId: "top",
+          viewport: { width: 300, height: 300 },
+        }),
+      ),
+    );
+    const prepared = prepareObservationRender(
+      attachVisualEntries({ viewport: { width: 300, height: 300 }, nodes: [] }, graph, [
+        candidate(10),
+      ]),
+    );
+    const text = Array.from({ [Symbol.iterator]: () => prepared.rows })
+      .map((r) => r.text)
+      .join("\n");
+    expect(text).toContain("Unplaced Canvas regions");
+    expect(text).toContain("[visual:screenshot]");
+  });
+  it("places child-frame Canvas under its iframe owner", () => {
+    const graph = normalizeSemanticStructure(
+      resolveSemanticGraph(
+        buildSemanticGraph({
+          rootFrameId: "top",
+          viewport: { width: 300, height: 300 },
+          documents: [
+            {
+              frameId: "top",
+              target: { tabId: 4 },
+              contextScopeId: "top",
+              axNodes: [],
+              domNodes: [
+                {
+                  backendNodeId: 1,
+                  parentBackendNodeId: null,
+                  tag: "main",
+                  attrs: {},
+                  rect: { x: 0, y: 0, w: 300, h: 300 },
+                  paintOrder: 1,
+                  position: "static",
+                  pointerEvents: "auto",
+                },
+                {
+                  backendNodeId: 2,
+                  parentBackendNodeId: 1,
+                  tag: "iframe",
+                  attrs: {},
+                  rect: { x: 0, y: 0, w: 200, h: 200 },
+                  paintOrder: 2,
+                  position: "static",
+                  pointerEvents: "auto",
+                },
+              ],
+            },
+            {
+              frameId: "child",
+              parentFrameId: "top",
+              ownerBackendNodeId: 2,
+              target: { tabId: 4, sessionId: "oopif" },
+              contextScopeId: "child",
+              axNodes: [],
+              domNodes: [
+                {
+                  backendNodeId: 11,
+                  parentBackendNodeId: null,
+                  tag: "canvas",
+                  attrs: {},
+                  rect: { x: 0, y: 0, w: 100, h: 100 },
+                  paintOrder: 1,
+                  position: "static",
+                  pointerEvents: "auto",
+                },
+              ],
+            },
+          ],
+        }),
+      ),
+    );
+    const c = { ...candidate(11), document: { ...identity, frameId: "child" } };
+    const scene = attachVisualEntries(projectSemanticGraph(graph), graph, [c]);
+    const owner = scene.nodes.find((n) => n.backendNodeId === 2)!;
+    expect(scene.visuals![0].parentId).toBe(owner.id);
+    expect(scene.visuals![0].fallbackContext).toBeUndefined();
+  });
+  it("does not register candidates missing screenshot paths", () => {
+    const graph = normalizeSemanticStructure(
+      resolveSemanticGraph(
+        buildSemanticGraph({
+          documents: [],
+          rootFrameId: "top",
+          viewport: { width: 300, height: 300 },
+        }),
+      ),
+    );
+    const c = { ...candidate(4), framePath: undefined };
+    const output = prepareVisualObservation(
+      { viewport: { width: 300, height: 300 }, nodes: [] },
+      graph,
+      { candidates: [c], issues: [], captureIssues: [], complete: true },
+      new Map(),
+      "top",
+      [],
+      {},
+    );
+    expect(output.candidates).toHaveLength(0);
+    expect(output.notices[0]).toContain("no verified screenshot path");
+  });
+});
+
+it("observe discovers and registers visual refs from its single production capture; snapshot stays semantic", async () => {
+  const strings = [
+    "#document",
+    "HTML",
+    "CANVAS",
+    "static",
+    "auto",
+    "visible",
+    "1",
+    "block",
+    "none",
+    "0px",
+    "http://fixture.test",
+  ];
+  const index = (s: string) => strings.indexOf(s);
+  const manager = new SessionManager({
+    agentWindow: {
+      create: async () => 100,
+      remove: async () => {},
+      ensureActiveTab: async () => 4,
+    },
+  });
+  const ctx = await manager.start("test");
+  const send = vi.fn(async (_tab: number, method: string, params: Record<string, unknown> = {}) => {
+    if (method === "Page.getLayoutMetrics")
+      return {
+        visualViewport: { clientWidth: 1000, clientHeight: 800 },
+        cssVisualViewport: { clientWidth: 1000, clientHeight: 800, scale: 1, zoom: 1 },
+        cssLayoutViewport: { clientWidth: 1000, clientHeight: 800, pageX: 0, pageY: 0 },
+      };
+    if (method === "DOMSnapshot.captureSnapshot") {
+      const styles = (params.computedStyles as string[]).map((key) =>
+        index(
+          (
+            {
+              position: "static",
+              "pointer-events": "auto",
+              cursor: "auto",
+              visibility: "visible",
+              opacity: "1",
+              display: "block",
+              "overflow-x": "visible",
+              "overflow-y": "visible",
+              zoom: "1",
+              clip: "auto",
+              "overflow-clip-margin": "0px",
+            } as Record<string, string>
+          )[key] ?? "none",
+        ),
+      );
+      return {
+        strings,
+        documents: [
+          {
+            frameId: "top",
+            documentURL: index("http://fixture.test"),
+            scrollOffsetX: 0,
+            scrollOffsetY: 0,
+            nodes: {
+              parentIndex: [-1, 0, 1],
+              nodeType: [9, 1, 1],
+              nodeName: [0, 1, 2],
+              backendNodeId: [10, 1, 100],
+              attributes: [[], [], []],
+            },
+            layout: {
+              nodeIndex: [1, 2],
+              styles: [styles, styles],
+              bounds: [
+                [0, 0, 1000, 800],
+                [20, 20, 100, 100],
+              ],
+              clientRects: [
+                [0, 0, 1000, 800],
+                [0, 0, 100, 100],
+              ],
+              paintOrders: [0, 1],
+            },
+          },
+        ],
+      };
+    }
+    if (method === "Accessibility.getFullAXTree")
+      return {
+        nodes: [
+          {
+            nodeId: "1",
+            backendDOMNodeId: 1,
+            role: { value: "RootWebArea" },
+            name: { value: "Fixture" },
+          },
+        ],
+      };
+    if (method === "Page.createIsolatedWorld") return { executionContextId: 1 };
+    if (method === "Runtime.evaluate")
+      return { result: { deepSerializedValue: { type: "node", value: { backendNodeId: 1 } } } };
+    if (method === "Runtime.releaseObjectGroup" || method.endsWith(".enable")) return {};
+    throw new Error(`unexpected ${method}`);
+  });
+  const cdp = {
+    send,
+    getAttachmentId: () => "a",
+    getFrameGraph: async () => ({
+      rootFrameId: "top",
+      frames: [{ frameId: "top", target: { tabId: 4 } }],
+    }),
+  } as unknown as CdpRunner;
+  const tab = { id: 4, windowId: 100, active: true, url: "http://fixture.test" } as chrome.tabs.Tab;
+  const deps = { cdp, tabsApi: { get: async () => tab, query: async () => [tab] } };
+  const observed = await handleObserve(manager, { session_id: "test" }, deps);
+  expect(observed).not.toHaveProperty("code");
+  expect((observed as ObserveResult).text).toContain("@e1 canvas [visual:screenshot]");
+  expect(ctx.refStore.resolveEntry("e1")?.kind).toBe("visual-region");
+  expect(send.mock.calls.filter((c) => c[1] === "DOMSnapshot.captureSnapshot")).toHaveLength(1);
+  expect(send.mock.calls.some((c) => c[1] === "Page.captureScreenshot")).toBe(false);
+  await handleSnapshot(manager, { session_id: "test" }, deps);
+  const captures = send.mock.calls.filter((c) => c[1] === "DOMSnapshot.captureSnapshot");
+  expect(captures[0][2]?.computedStyles).toHaveLength(18);
+  expect(captures[1][2]?.computedStyles).toHaveLength(5);
+  expect([...ctx.refStore.entries()].some(([, entry]) => entry.kind === "visual-region")).toBe(
+    false,
+  );
+});
+
+it.each([
+  "same",
+  "different",
+  "action",
+])("only suppresses redundant passive Canvas semantics: %s", (kind) => {
+  const semantic = node(
+    2,
+    1,
+    kind === "action" ? "button" : "canvas",
+    kind === "different" ? "Distinct semantics" : "Canvas title",
+  );
+  semantic.tag = "canvas";
+  const scene: VomScene = {
+    viewport: { width: 1000, height: 800 },
+    nodes: [node(1, null, "rootwebarea"), semantic],
+    visuals: [
+      { key: 0, sourceId: 2, beforeId: 2, parentId: 1, label: "Canvas title", frameId: "top" },
+    ],
+  };
+  const rows = Array.from({ [Symbol.iterator]: () => prepareObservationRender(scene).rows });
+  expect(rows.filter((r) => r.text.includes("Canvas title"))).toHaveLength(
+    kind === "action" ? 2 : 1,
+  );
+  expect(rows.some((r) => r.text.includes("Distinct semantics"))).toBe(kind === "different");
+  if (kind === "action") expect(rows.filter((r) => r.ref)).toHaveLength(2);
+});

--- a/apps/extension/src/tools/vom/__tests__/visual-observation.test.ts
+++ b/apps/extension/src/tools/vom/__tests__/visual-observation.test.ts
@@ -539,3 +539,261 @@ it.each([
   expect(rows.some((r) => r.text.includes("Distinct semantics"))).toBe(kind === "different");
   if (kind === "action") expect(rows.filter((r) => r.ref)).toHaveLength(2);
 });
+
+it.each([
+  "source",
+  "parent",
+  "frame",
+  "unplaced",
+])("does not resurrect modal background Canvas via %s", async (kind) => {
+  const f = fixture(1);
+  f.scene.rootFrameId = "top";
+  f.scene.nodes.push(node(2, 1, kind === "frame" ? "iframe" : "canvas"));
+  f.scene.nodes.push({
+    ...node(10, 1, "dialog", "Login"),
+    position: "fixed",
+    rect: { x: 0, y: 0, w: 800, h: 600 },
+  });
+  f.scene.visuals = [
+    {
+      key: 0,
+      frameId: kind === "frame" ? "child" : "top",
+      parentId: kind === "unplaced" ? null : 2,
+      ...(kind === "source" ? { sourceId: 2 } : {}),
+    },
+  ];
+  f.output.render = prepareObservationRender(f.scene);
+  const result = success(await publishObservationPage(f.store, f.cdp, 4, { output: f.output }));
+  expect(result.text).toContain("focus=L1");
+  expect(result.text).not.toContain("[visual:screenshot]");
+  expect(result.text).not.toContain("Unplaced Canvas");
+  expect([...f.store.entries()].some(([, entry]) => entry.kind === "visual-region")).toBe(false);
+  f.scene.nodes = f.scene.nodes.filter((n) => n.id !== 10);
+  expect(
+    Array.from({ [Symbol.iterator]: () => prepareObservationRender(f.scene).rows }).filter(
+      (r) => r.ref?.visualKey !== undefined,
+    ),
+  ).toHaveLength(1);
+});
+
+it("preserves modal Canvas with omitted semantics and admits proven foreground fallback", () => {
+  const scene: VomScene = {
+    rootFrameId: "top",
+    viewport: { width: 1000, height: 800 },
+    nodes: [
+      node(1, null, "rootwebarea"),
+      {
+        ...node(10, 1, "dialog", "Login"),
+        position: "fixed",
+        rect: { x: 0, y: 0, w: 800, h: 600 },
+      },
+    ],
+    visuals: [
+      { key: 0, parentId: 10, frameId: "top" },
+      {
+        key: 1,
+        parentId: null,
+        frameId: "top",
+        paintOrder: 11,
+        rect: { x: 10, y: 10, w: 40, h: 40 },
+      },
+    ],
+  };
+  const result = Array.from({ [Symbol.iterator]: () => prepareObservationRender(scene).rows });
+  expect(result.filter((r) => r.ref?.visualKey !== undefined).map((r) => r.ref!.visualKey)).toEqual(
+    [0, 1],
+  );
+});
+
+it.each([
+  true,
+  false,
+])("applies the existing active-region policy to Canvas (enabled=%s)", (enabled) => {
+  const scene: VomScene = {
+    rootFrameId: "top",
+    viewport: { width: 1000, height: 800 },
+    nodes: [
+      node(1, null, "rootwebarea"),
+      node(2, 1, "canvas"),
+      {
+        ...node(10, 1, "group", "Popover"),
+        position: "fixed",
+        rect: { x: 0, y: 0, w: 100, h: 100 },
+      },
+    ],
+    visuals: [
+      {
+        key: 0,
+        parentId: 1,
+        sourceId: 2,
+        frameId: "top",
+        rect: { x: 0, y: 0, w: 100, h: 30 },
+        paintOrder: 2,
+      },
+    ],
+  };
+  const rendered = Array.from({
+    [Symbol.iterator]: () => prepareObservationRender(scene, { activeRegionPolicy: enabled }).rows,
+  });
+  expect(rendered.filter((r) => r.ref?.visualKey !== undefined)).toHaveLength(enabled ? 0 : 1);
+});
+
+it.each([
+  "Runtime.evaluate",
+  "Runtime.releaseObjectGroup",
+])("retains a cancelled page through handleObserve during %s", async (method) => {
+  const f = fixture(35, 100);
+  const manager = new SessionManager({
+    agentWindow: {
+      create: async () => 100,
+      remove: async () => {},
+      ensureActiveTab: async () => 4,
+    },
+  });
+  const ctx = await manager.start("cancel-test");
+  const first = success(await publishObservationPage(ctx.refStore, f.cdp, 4, { output: f.output }));
+  const originalRefs = [...ctx.refStore.entries()];
+  const revision = ctx.refStore.revision;
+  const controller = new AbortController();
+  const original = f.send.getMockImplementation()!;
+  f.send.mockImplementation(async (tab, command) => {
+    const result = await original(tab, command);
+    if (command === method) controller.abort();
+    return result;
+  });
+  const tab = { id: 4, windowId: 100, url: "http://fixture.test" } as chrome.tabs.Tab;
+  const cancelled = await handleObserve(
+    manager,
+    { session_id: "cancel-test", cursor: first.next_cursor },
+    { cdp: f.cdp, tabsApi: { get: async () => tab, query: async () => [tab] } },
+    controller.signal,
+  );
+  expect(cancelled).toHaveProperty("code", "cancelled");
+  expect(ctx.refStore.revision).toBe(revision);
+  expect([...ctx.refStore.entries()]).toEqual(originalRefs);
+  f.send.mockImplementation(original);
+  const seen = new Set(originalRefs.map(([ref]) => ref));
+  let cursor = first.next_cursor;
+  while (cursor) {
+    const page = success(await publishObservationPage(ctx.refStore, f.cdp, 4, { cursor }));
+    expect(await publishObservationPage(ctx.refStore, f.cdp, 4, { cursor })).toEqual(page);
+    for (const [ref] of ctx.refStore.entries()) {
+      expect(seen.has(ref)).toBe(false);
+      seen.add(ref);
+    }
+    cursor = page.next_cursor;
+  }
+  expect(seen.size).toBe(35);
+});
+
+it("preserves a Canvas containing an active region rather than treating it as background", () => {
+  const scene: VomScene = {
+    rootFrameId: "top",
+    viewport: { width: 1000, height: 800 },
+    nodes: [
+      node(1, null, "rootwebarea"),
+      { ...node(2, 1, "canvas"), paintOrder: 5 },
+      {
+        ...node(10, 2, "group", "Popover"),
+        paintOrder: 5,
+        position: "fixed",
+        rect: { x: 0, y: 0, w: 100, h: 100 },
+      },
+    ],
+    visuals: [{ key: 0, parentId: 1, sourceId: 2, frameId: "top" }],
+  };
+  const result = prepareObservationRender(scene, { activeRegionPolicy: true });
+  const text = [
+    ...result.headers,
+    ...Array.from({ [Symbol.iterator]: () => result.rows }, (r) => r.text),
+  ].join("\n");
+  expect(text).toContain("[visual:screenshot]");
+  expect(text).toContain('group "Popover"');
+});
+
+it("an old cancelled validation cannot clear a newer observation", async () => {
+  const f = fixture(20, 100);
+  const first = success(await publishObservationPage(f.store, f.cdp, 4, { output: f.output }));
+  const controller = new AbortController();
+  const original = f.send.getMockImplementation()!;
+  let newer: ObserveResult | undefined;
+  f.send.mockImplementation(async (tab, method) => {
+    if (method === "Runtime.evaluate") {
+      newer = success(
+        await publishObservationPage(f.store, f.cdp, 4, { output: fixture(25, 100).output }),
+      );
+      controller.abort();
+    }
+    return original(tab, method);
+  });
+  await expect(
+    publishObservationPage(f.store, f.cdp, 4, { cursor: first.next_cursor }, controller.signal),
+  ).rejects.toThrow();
+  f.send.mockImplementation(original);
+  expect(
+    success(await publishObservationPage(f.store, f.cdp, 4, { cursor: newer!.next_cursor }))
+      .ref_count,
+  ).toBeGreaterThan(0);
+});
+
+it("keeps excluded Canvas out of every continuation page", async () => {
+  const f = fixture(36, 100);
+  f.scene.rootFrameId = "top";
+  f.scene.nodes.push({
+    ...node(10, 1, "dialog", "Login"),
+    position: "fixed",
+    rect: { x: 0, y: 0, w: 800, h: 600 },
+  });
+  f.scene.visuals!.forEach((v, i) => {
+    v.parentId = i === 0 ? 1 : 10;
+  });
+  f.output.render = prepareObservationRender(f.scene);
+  let result = success(await publishObservationPage(f.store, f.cdp, 4, { output: f.output }));
+  let count = 0;
+  while (true) {
+    for (const [, entry] of f.store.entries())
+      if (entry.kind === "visual-region") {
+        expect(entry.candidate.backendNodeId).not.toBe(100);
+        count++;
+      }
+    if (!result.next_cursor) break;
+    result = success(
+      await publishObservationPage(f.store, f.cdp, 4, { cursor: result.next_cursor }),
+    );
+  }
+  expect(count).toBe(35);
+});
+
+it("can retry a cancelled final page with a smaller budget without losing buffered rows", async () => {
+  const f = fixture(20, 100);
+  const first = success(await publishObservationPage(f.store, f.cdp, 4, { output: f.output }));
+  const seen = new Set([...f.store.entries()].map(([ref]) => ref));
+  const controller = new AbortController();
+  const original = f.send.getMockImplementation()!;
+  f.send.mockImplementation(async (tab, method) => {
+    if (method === "Runtime.evaluate") controller.abort();
+    return original(tab, method);
+  });
+  await expect(
+    publishObservationPage(
+      f.store,
+      f.cdp,
+      4,
+      { cursor: first.next_cursor, maxTokens: 10000 },
+      controller.signal,
+    ),
+  ).rejects.toThrow();
+  f.send.mockImplementation(original);
+  let cursor = first.next_cursor;
+  while (cursor) {
+    const result = success(
+      await publishObservationPage(f.store, f.cdp, 4, { cursor, maxTokens: 100 }),
+    );
+    for (const [ref] of f.store.entries()) {
+      expect(seen.has(ref)).toBe(false);
+      seen.add(ref);
+    }
+    cursor = result.next_cursor;
+  }
+  expect(seen.size).toBe(20);
+});

--- a/apps/extension/src/tools/vom/__tests__/visual-observation.test.ts
+++ b/apps/extension/src/tools/vom/__tests__/visual-observation.test.ts
@@ -17,6 +17,7 @@ import {
   projectSemanticGraph,
   resolveSemanticGraph,
 } from "../semantic-graph";
+import { deduplicateVisualCandidates } from "../visual-dedup";
 import type { VisualCandidate } from "../visual-discovery";
 import {
   attachVisualEntries,
@@ -108,6 +109,54 @@ describe("visual observation output", () => {
     expect(r.next_cursor).toBeUndefined();
     expect(r.text.match(/\[visual:screenshot\]/g)).toHaveLength(120);
     expect(f.store.resolveEntry("e1")?.kind).toBe("visual-region");
+    expect(f.send).not.toHaveBeenCalled();
+  });
+  it("publishes distinct refs for overlapping Canvas nodes after candidate deduplication", async () => {
+    const f = fixture(2);
+    const graph = normalizeSemanticStructure(
+      resolveSemanticGraph(
+        buildSemanticGraph({
+          rootFrameId: "top",
+          viewport: { width: 1200, height: 800 },
+          documents: [
+            {
+              frameId: "top",
+              target: identity.target,
+              contextScopeId: "top",
+              axNodes: [],
+              domNodes: [1, 100, 101].map((id) => ({
+                backendNodeId: id,
+                parentBackendNodeId: id === 1 ? null : 1,
+                tag: id === 1 ? "main" : "canvas",
+                attrs: {},
+                rect: { x: 0, y: 0, w: 100, h: 100 },
+                paintOrder: id,
+                position: "static",
+                pointerEvents: "auto",
+              })),
+            },
+          ],
+        }),
+      ),
+    );
+    const discovery = await deduplicateVisualCandidates({
+      candidates: [candidate(100), candidate(101), candidate(100)],
+      complete: true,
+      issues: [],
+      captureIssues: [],
+    });
+    f.output.candidates = discovery.candidates;
+    f.output.render = prepareObservationRender(
+      attachVisualEntries(projectSemanticGraph(graph), graph, discovery.candidates),
+    );
+    const result = success(await publishObservationPage(f.store, f.cdp, 4, { output: f.output }));
+    expect(result.ref_count).toBe(2);
+    expect(result.text.match(/\[visual:screenshot\]/g)).toHaveLength(2);
+    const refs = [...f.store.entries()];
+    expect(refs[0][0]).not.toBe(refs[1][0]);
+    expect(
+      refs.map(([, entry]) => entry.kind === "visual-region" && entry.candidate.backendNodeId),
+    ).toEqual([100, 101]);
     expect(f.send).not.toHaveBeenCalled();
   });
   it("continues all candidates, replaces refs and retries the latest cursor without skipping", async () => {

--- a/apps/extension/src/tools/vom/visual-observation.ts
+++ b/apps/extension/src/tools/vom/visual-observation.ts
@@ -95,6 +95,13 @@ export function attachVisualEntries(
           : {}),
         parentId,
         sourceId: own,
+        rect: {
+          x: c.region.crop.x,
+          y: c.region.crop.y,
+          w: c.region.crop.width,
+          h: c.region.crop.height,
+        },
+        paintOrder: source?.vom.paintOrder,
         beforeId: own ?? list[lo]?.id,
         label: c.label,
         frameId: c.document.frameId,
@@ -159,6 +166,7 @@ interface Page {
   refs: RenderedRef[];
   more: boolean;
   frameIds: Set<string>;
+  consumed: number;
 }
 interface Continuation {
   output: ObservationOutput;
@@ -186,6 +194,7 @@ function page(
   state: Continuation,
   budget: number | undefined,
   continued: boolean,
+  nextToken: string,
 ): Page | RpcError {
   const max = budget ?? Infinity;
   if (!(max >= 0) || Number.isNaN(max)) return failure("max_tokens must be nonnegative");
@@ -193,7 +202,7 @@ function page(
     ...state.output.render.headers,
     ...(continued ? ["@continued same observation; only refs in this response are current."] : []),
   ];
-  const footer = `@more observe --cursor ${state.token}; use this page's refs before continuing.`;
+  const footer = `@more observe --cursor ${nextToken}; use this page's refs before continuing.`;
   if (continued && state.buffer[0]?.context) headers.push(state.buffer[0].context);
   const fixed = [...headers, ...state.output.notices];
   let used = fixed.reduce((n, line) => n + cost(line), 0);
@@ -204,14 +213,14 @@ function page(
   let emitted = 0;
   while (true) {
     // One-row lookahead avoids reserving a continuation footer on the final row.
-    while (state.buffer.length < 2 && !state.exhausted) {
+    while (state.buffer.length < emitted + 2 && !state.exhausted) {
       const next = state.output.render.rows.next();
       if (next.done) state.exhausted = true;
       else state.buffer.push(next.value);
     }
-    const row = state.buffer[0];
+    const row = state.buffer[emitted];
     if (!row) break;
-    const reserve = state.buffer.length > 1 || !state.exhausted ? cost(footer) : 0;
+    const reserve = state.buffer.length > emitted + 1 || !state.exhausted ? cost(footer) : 0;
     let text = row.text;
     if (used + cost(text) + reserve > max && row.minimal) text = row.minimal;
     if (used + cost(text) + reserve > max) {
@@ -223,12 +232,11 @@ function page(
     lines.push(text);
     used += cost(text);
     emitted++;
-    state.buffer.shift();
   }
   lines.push(...state.output.notices);
-  const more = state.buffer.length > 0 || !state.exhausted;
+  const more = state.buffer.length > emitted || !state.exhausted;
   if (more) lines.push(footer);
-  return { text: lines.join("\n"), refs, more, frameIds };
+  return { text: lines.join("\n"), refs, more, frameIds, consumed: emitted };
 }
 
 export async function publishObservationPage(
@@ -264,13 +272,9 @@ export async function publishObservationPage(
     return failure("retry this cursor with the same budget, or use next_cursor");
   // Retry retains exactly the latest output; it cannot advance the iterator twice.
   const retry = input.cursor && state.last?.input === input.cursor ? state.last : undefined;
-  const previousToken = state.token;
-  if (input.cursor && !retry) state.token = crypto.randomUUID();
-  const rendered = retry ? undefined : page(state, budget, !!input.cursor);
-  if (rendered && "code" in rendered) {
-    state.token = previousToken;
-    return rendered;
-  }
+  const nextToken = crypto.randomUUID();
+  const rendered = retry ? undefined : page(state, budget, !!input.cursor, nextToken);
+  if (rendered && "code" in rendered) return rendered;
   const identities = new Map<string, DocumentIdentity>(retry?.identities);
   if (state.output.rootIdentity)
     identities.set(state.output.rootIdentity.frameId, state.output.rootIdentity);
@@ -289,12 +293,12 @@ export async function publishObservationPage(
   }
   if (input.cursor) {
     if (!state.output.rootIdentity || missingIdentity) {
-      continuations.delete(store);
+      if (continuations.get(store) === state) continuations.delete(store);
       return failure("observation identity unavailable; observe again");
     }
     for (const identity of identities.values()) {
       if ((await verifyDocumentIdentity(cdp, identity, signal)) !== "current") {
-        continuations.delete(store);
+        if (continuations.get(store) === state) continuations.delete(store);
         return failure("observation DOM changed; observe again");
       }
     }
@@ -320,7 +324,10 @@ export async function publishObservationPage(
       },
     ];
   });
+  // Publish only after validation; cancelled preparation leaves buffered rows and refs intact.
   store.replace(entries);
+  state.buffer.splice(0, rendered!.consumed);
+  state.token = nextToken;
   state.revision = store.revision;
   const result: ObserveResult = {
     text: rendered!.text,

--- a/apps/extension/src/tools/vom/visual-observation.ts
+++ b/apps/extension/src/tools/vom/visual-observation.ts
@@ -317,6 +317,7 @@ export async function publishObservationPage(
     return [
       ref.ref,
       {
+        ...(ref.name ? { name: ref.name } : {}),
         backendNodeId: ref.backendNodeId,
         tabId,
         frameId: ref.frameId,

--- a/apps/extension/src/tools/vom/visual-observation.ts
+++ b/apps/extension/src/tools/vom/visual-observation.ts
@@ -1,0 +1,347 @@
+import {
+  prepareObservationRender,
+  type RenderedRef,
+  type RenderRow,
+  type VomOptions,
+  type VomScene,
+} from "@browser-skill/vom";
+import type { CdpTarget } from "@/browser-driver/frame-graph";
+import type { RefInput, RefStore } from "@/session-manager/ref-store";
+import type { ObserveResult, RpcError } from "@/transport/types";
+import type { CdpRunner } from "../shared";
+import { throwIfAborted } from "./capture-abort";
+import { verifyDocumentIdentity } from "./document-identity";
+import type { DocumentIdentity } from "./facts";
+import { frameBackendKey, type StructuredSemanticGraph } from "./semantic-graph/types";
+import type { VisualCandidate, VisualDiscoveryResult } from "./visual-discovery";
+
+/** Attach by source structure, never by spatial proximity or a guessed label. */
+export function attachVisualEntries(
+  scene: VomScene,
+  graph: StructuredSemanticGraph,
+  candidates: readonly VisualCandidate[],
+): VomScene {
+  const retained = new Map(
+    scene.nodes
+      .filter((n) => n.backendNodeId !== undefined)
+      .map((n) => [frameBackendKey(n.frameId!, n.backendNodeId!), n.id]),
+  );
+  const byId = new Map(scene.nodes.map((n) => [n.id, n]));
+  const parents = new Map<string, number | null>();
+  function parentOf(id: string | undefined): number | null {
+    const path: string[] = [];
+    const seen = new Set<string>();
+    while (id && !parents.has(id)) {
+      const node = graph.nodes.get(id);
+      if (!node) break;
+      const kept =
+        node.backendNodeId === undefined
+          ? undefined
+          : retained.get(frameBackendKey(node.frameId, node.backendNodeId));
+      if (kept !== undefined) {
+        parents.set(id, kept);
+        break;
+      }
+      if (seen.has(id)) break;
+      seen.add(id);
+      path.push(id);
+      id = node.domParentId;
+    }
+    const parent = id ? (parents.get(id) ?? null) : null;
+    for (const key of path) parents.set(key, parent);
+    return parent;
+  }
+  const siblings = new Map<string, { id: number; order: number }[]>();
+  for (const node of scene.nodes) {
+    const sourceId =
+      node.backendNodeId === undefined
+        ? undefined
+        : graph.nodeByFrameBackend.get(frameBackendKey(node.frameId!, node.backendNodeId));
+    const source = sourceId ? graph.nodes.get(sourceId) : undefined;
+    if (!source) continue;
+    const key = `${node.frameId}:${node.parentId}`;
+    const list = siblings.get(key) ?? [];
+    list.push({ id: node.id, order: source.sourceOrder });
+    siblings.set(key, list);
+  }
+  for (const list of siblings.values()) list.sort((a, b) => a.order - b.order);
+  return {
+    ...scene,
+    visuals: candidates.map((c, key) => {
+      const sourceId = graph.nodeByFrameBackend.get(
+        frameBackendKey(c.document.frameId, c.backendNodeId),
+      );
+      const source = sourceId ? graph.nodes.get(sourceId) : undefined;
+      const own = retained.get(frameBackendKey(c.document.frameId, c.backendNodeId));
+      let parentId = own !== undefined ? byId.get(own)!.parentId : parentOf(source?.domParentId);
+      if (parentId === null) {
+        const owner = graph.frames.get(c.document.frameId)?.ownerNodeId;
+        if (owner) parentId = parentOf(owner);
+      }
+      const list = siblings.get(`${c.document.frameId}:${parentId}`) ?? [];
+      let lo = 0,
+        hi = list.length;
+      while (lo < hi) {
+        const mid = (lo + hi) >>> 1;
+        if (list[mid].order < (source?.sourceOrder ?? Infinity)) lo = mid + 1;
+        else hi = mid;
+      }
+      return {
+        key,
+        ...(parentId === null
+          ? {
+              fallbackContext: `Unplaced Canvas regions (frame ${(graph.frames.get(c.document.frameId)?.order ?? 0) + 1})`,
+            }
+          : {}),
+        parentId,
+        sourceId: own,
+        beforeId: own ?? list[lo]?.id,
+        label: c.label,
+        frameId: c.document.frameId,
+      };
+    }),
+  };
+}
+
+export interface ObservationOutput {
+  render: ReturnType<typeof prepareObservationRender>;
+  candidates: readonly VisualCandidate[];
+  identities: Map<string, DocumentIdentity>;
+  rootIdentity?: DocumentIdentity;
+  frames: Map<string, { target: CdpTarget; parentFrameId?: string }>;
+  notices: string[];
+  maxTokens?: number;
+}
+
+export function prepareVisualObservation(
+  scene: VomScene,
+  graph: StructuredSemanticGraph,
+  discovery: VisualDiscoveryResult,
+  identities: Map<string, DocumentIdentity>,
+  rootFrameId: string,
+  notices: string[],
+  options: VomOptions,
+): ObservationOutput {
+  const candidates = discovery.candidates.filter((c) => !!c.framePath);
+  const unavailable = discovery.candidates.length - candidates.length;
+  if (unavailable)
+    notices.push(`@warning ${unavailable} Canvas regions have no verified screenshot path.`);
+  const unsupported = discovery.issues.filter(
+    (issue) => issue.reason === "geometry-unsupported",
+  ).length;
+  const incomplete = discovery.issues.length - unsupported;
+  if (unsupported)
+    notices.push(
+      `@warning visual geometry unsupported (${unsupported} issues); no screenshot refs for those regions.`,
+    );
+  if (incomplete)
+    notices.push(
+      `@warning visual discovery incomplete (${incomplete} issues); some Canvas regions could not be verified.`,
+    );
+  return {
+    render: prepareObservationRender(attachVisualEntries(scene, graph, candidates), options),
+    candidates,
+    identities,
+    rootIdentity: identities.get(rootFrameId),
+    frames: new Map(
+      [...graph.frames].map(([id, frame]) => [
+        id,
+        { target: frame.target, parentFrameId: frame.parentFrameId },
+      ]),
+    ),
+    notices,
+    maxTokens: options.maxTokens,
+  };
+}
+
+interface Page {
+  text: string;
+  refs: RenderedRef[];
+  more: boolean;
+  frameIds: Set<string>;
+}
+interface Continuation {
+  output: ObservationOutput;
+  tabId: number;
+  revision: number;
+  token: string;
+  buffer: RenderRow[];
+  exhausted: boolean;
+  /** Only the latest response is retained for retrying its input cursor. */
+  last?: {
+    input: string;
+    budget?: number;
+    result: ObserveResult;
+    identities: Map<string, DocumentIdentity>;
+  };
+}
+const continuations = new WeakMap<RefStore, Continuation>();
+export function clearObservationContinuation(store: RefStore): void {
+  continuations.delete(store);
+}
+const cost = (line: string) => Math.ceil(line.length / 4);
+const failure = (message: string): RpcError => ({ code: "invalid_params", message });
+
+function page(
+  state: Continuation,
+  budget: number | undefined,
+  continued: boolean,
+): Page | RpcError {
+  const max = budget ?? Infinity;
+  if (!(max >= 0) || Number.isNaN(max)) return failure("max_tokens must be nonnegative");
+  const headers = [
+    ...state.output.render.headers,
+    ...(continued ? ["@continued same observation; only refs in this response are current."] : []),
+  ];
+  const footer = `@more observe --cursor ${state.token}; use this page's refs before continuing.`;
+  if (continued && state.buffer[0]?.context) headers.push(state.buffer[0].context);
+  const fixed = [...headers, ...state.output.notices];
+  let used = fixed.reduce((n, line) => n + cost(line), 0);
+  if (used > max) return failure("max_tokens is too small for observation headers and notices");
+  const lines = [...headers];
+  const refs: RenderedRef[] = [];
+  const frameIds = new Set<string>();
+  let emitted = 0;
+  while (true) {
+    // One-row lookahead avoids reserving a continuation footer on the final row.
+    while (state.buffer.length < 2 && !state.exhausted) {
+      const next = state.output.render.rows.next();
+      if (next.done) state.exhausted = true;
+      else state.buffer.push(next.value);
+    }
+    const row = state.buffer[0];
+    if (!row) break;
+    const reserve = state.buffer.length > 1 || !state.exhausted ? cost(footer) : 0;
+    let text = row.text;
+    if (used + cost(text) + reserve > max && row.minimal) text = row.minimal;
+    if (used + cost(text) + reserve > max) {
+      if (!emitted) return failure("max_tokens is too small to advance; increase the budget");
+      break;
+    }
+    if (row.ref) refs.push({ ...row.ref, line: lines.length });
+    if (row.frameId) frameIds.add(row.frameId);
+    lines.push(text);
+    used += cost(text);
+    emitted++;
+    state.buffer.shift();
+  }
+  lines.push(...state.output.notices);
+  const more = state.buffer.length > 0 || !state.exhausted;
+  if (more) lines.push(footer);
+  return { text: lines.join("\n"), refs, more, frameIds };
+}
+
+export async function publishObservationPage(
+  store: RefStore,
+  cdp: CdpRunner,
+  tabId: number,
+  input: { output?: ObservationOutput; cursor?: string; maxTokens?: number },
+  signal?: AbortSignal,
+): Promise<ObserveResult | RpcError> {
+  let state: Continuation;
+  if (input.output)
+    state = {
+      output: input.output,
+      tabId,
+      revision: store.revision,
+      token: crypto.randomUUID(),
+      exhausted: false,
+      buffer: [],
+    };
+  else {
+    const saved = continuations.get(store);
+    if (
+      !saved ||
+      saved.tabId !== tabId ||
+      saved.revision !== store.revision ||
+      (input.cursor !== saved.token && input.cursor !== saved.last?.input)
+    )
+      return failure("observation cursor expired; observe again");
+    state = saved;
+  }
+  const budget = input.maxTokens ?? state.output.maxTokens;
+  if (input.cursor && state.last?.input === input.cursor && state.last.budget !== budget)
+    return failure("retry this cursor with the same budget, or use next_cursor");
+  // Retry retains exactly the latest output; it cannot advance the iterator twice.
+  const retry = input.cursor && state.last?.input === input.cursor ? state.last : undefined;
+  const previousToken = state.token;
+  if (input.cursor && !retry) state.token = crypto.randomUUID();
+  const rendered = retry ? undefined : page(state, budget, !!input.cursor);
+  if (rendered && "code" in rendered) {
+    state.token = previousToken;
+    return rendered;
+  }
+  const identities = new Map<string, DocumentIdentity>(retry?.identities);
+  if (state.output.rootIdentity)
+    identities.set(state.output.rootIdentity.frameId, state.output.rootIdentity);
+  const refs = rendered?.refs ?? [];
+  const visited = new Set<string>();
+  let missingIdentity = false;
+  for (const frameId of rendered?.frameIds ?? []) {
+    let id: string | undefined = frameId;
+    while (id && !visited.has(id)) {
+      visited.add(id);
+      const identity = state.output.identities.get(id);
+      if (identity) identities.set(id, identity);
+      else missingIdentity = true;
+      id = state.output.frames.get(id)?.parentFrameId;
+    }
+  }
+  if (input.cursor) {
+    if (!state.output.rootIdentity || missingIdentity) {
+      continuations.delete(store);
+      return failure("observation identity unavailable; observe again");
+    }
+    for (const identity of identities.values()) {
+      if ((await verifyDocumentIdentity(cdp, identity, signal)) !== "current") {
+        continuations.delete(store);
+        return failure("observation DOM changed; observe again");
+      }
+    }
+  }
+  throwIfAborted(signal);
+  if (input.cursor && (continuations.get(store) !== state || store.revision !== state.revision))
+    return failure("observation cursor expired during validation; observe again");
+  if (retry) return retry.result;
+  const entries: [string, RefInput][] = refs.map((ref) => {
+    if (ref.visualKey !== undefined)
+      return [
+        ref.ref,
+        { kind: "visual-region", candidate: state.output.candidates[ref.visualKey] },
+      ];
+    const target = ref.frameId ? state.output.frames.get(ref.frameId)?.target : undefined;
+    return [
+      ref.ref,
+      {
+        backendNodeId: ref.backendNodeId,
+        tabId,
+        frameId: ref.frameId,
+        cdpSessionId: target?.sessionId,
+      },
+    ];
+  });
+  store.replace(entries);
+  state.revision = store.revision;
+  const result: ObserveResult = {
+    text: rendered!.text,
+    ref_count: refs.length,
+    tab_id: tabId,
+    truncated: rendered!.more || state.output.render.truncated(),
+    ...(rendered!.more ? { next_cursor: state.token } : {}),
+  };
+  if (input.cursor) state.last = { input: input.cursor, budget, result, identities };
+  if (!rendered!.more) {
+    // Keep only the latest response/identity proof for transport retry, not the full observation.
+    state.output = {
+      ...state.output,
+      candidates: [],
+      identities: new Map(),
+      frames: new Map(),
+      notices: [],
+      render: { headers: [], rows: [][Symbol.iterator](), truncated: () => false },
+    };
+  }
+  if (rendered!.more || input.cursor) continuations.set(store, state);
+  else continuations.delete(store);
+  return result;
+}

--- a/apps/extension/src/transport/types.ts
+++ b/apps/extension/src/transport/types.ts
@@ -344,11 +344,13 @@ export interface SnapshotResult {
 }
 
 export interface ObserveParams extends SnapshotParams {
+  cursor?: string;
   debug_surfaces?: boolean;
   probe_hover?: boolean;
 }
 
 export interface ObserveResult extends SnapshotResult {
+  next_cursor?: string;
   hover_probe?: {
     performed: boolean;
     revealed_content: boolean;

--- a/crates/bsk-cli/skill/SKILL.md
+++ b/crates/bsk-cli/skill/SKILL.md
@@ -116,6 +116,26 @@ Escalate page reading only as needed:
 Do not start with raw HTML or screenshots merely to discover ordinary controls. When interaction is
 needed, obtain a fresh observation before acting on screenshot or HTML findings.
 
+## Canvas and observation continuation
+
+`observe` may place `@eN canvas [visual:screenshot]` near related page controls. Names are
+optional: do not infer a table title or controls inside Canvas from adjacent labels. Visual refs
+support `screenshot --ref`, not click/fill/hover or HTML extraction. First observe returns text,
+not an image. Use the surrounding semantics to decide whether a Canvas screenshot is needed.
+If you cannot receive and understand images in this session, tell the user the Canvas contents
+cannot be interpreted and ask them to switch to an image-capable model; continue with available
+semantic information. BrowserSkill does not detect the model's capabilities.
+
+There is no default token cap. With an explicit `--max-tokens` limit, an observation may return
+`next_cursor` and an `@more` instruction. Use current refs before calling
+`bsk observe --cursor <token> --session <id>`: each response replaces the ref map, so refs from
+previous pages must not be reused. A response can contain many Canvas entries. Follow cursors
+when relevant content remains, rather than repeatedly reading the same prefix.
+Continuation reads the same captured observation; it does not refresh or hover the page. Do not
+combine it with depth changes or hover probing. A new observe/snapshot replaces the continuation;
+if the page identity changed, observe again. Screenshot execution checks current target identity
+and geometry, but permits Canvas repainting and does not freeze pixels.
+
 ## Respect the Agent Window boundary
 
 Normal page writes affect only Agent Window tabs. To operate a user tab, first list it with

--- a/crates/bsk-cli/src/cli/error.rs
+++ b/crates/bsk-cli/src/cli/error.rs
@@ -451,7 +451,7 @@ mod tests {
     }
 
     #[test]
-    fn not_found_ref_uses_snapshot_hint_in_json() {
+    fn not_found_ref_uses_observe_hint_in_json() {
         let cli = CliError::from_rpc(RpcError {
             code: ErrorCode::NotFound,
             message: "ref @e99 unknown for tab 7".into(),
@@ -467,7 +467,7 @@ mod tests {
                 .get("hint")
                 .and_then(|v| v.as_str())
                 .unwrap()
-                .contains("bsk snapshot")
+                .contains("bsk observe")
         );
         assert!(
             !parsed

--- a/crates/bsk-cli/src/cli/observe.rs
+++ b/crates/bsk-cli/src/cli/observe.rs
@@ -14,6 +14,9 @@ use crate::cli::error::{CliError, Format};
 
 #[derive(Debug, Clone, Args)]
 pub struct ObserveArgs {
+    /// Continue the same observation. Use current refs before continuing.
+    #[arg(long, conflicts_with_all = ["max_depth", "probe_hover", "debug_surfaces"])]
+    pub cursor: Option<String>,
     /// Session id (must be active).
     #[arg(long)]
     pub session: String,
@@ -48,6 +51,7 @@ pub fn dispatch(args: ObserveArgs, format: Format) -> Result<(), CliError> {
 
 fn run(sock: PathBuf, args: ObserveArgs, format: Format) -> Result<(), CliError> {
     let params = ObserveParams {
+        cursor: args.cursor,
         session_id: args.session.clone(),
         tab_id: args.tab_id,
         max_depth: args.max_depth,
@@ -68,7 +72,7 @@ fn run(sock: PathBuf, args: ObserveArgs, format: Format) -> Result<(), CliError>
             } else {
                 println!("{}", reply.text);
             }
-            if reply.truncated {
+            if reply.truncated && reply.next_cursor.is_none() {
                 eprintln!(
                     "warning: observation truncated (refs={}, tab={}). Increase --max-depth / --max-tokens if needed.",
                     reply.ref_count, reply.tab_id
@@ -88,4 +92,61 @@ fn call(sock: PathBuf, params: ObserveParams) -> Result<ObserveResult, CliError>
         Some(params),
         TOOL_IPC_TIMEOUT,
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ObserveArgs;
+    use clap::Parser;
+
+    #[derive(Parser)]
+    struct Command {
+        #[command(flatten)]
+        observe: ObserveArgs,
+    }
+
+    #[test]
+    fn cursor_accepts_a_page_budget() {
+        let parsed = Command::try_parse_from([
+            "observe",
+            "--session",
+            "s1",
+            "--cursor",
+            "page-two",
+            "--max-tokens",
+            "100",
+        ])
+        .unwrap();
+        assert_eq!(parsed.observe.cursor.as_deref(), Some("page-two"));
+        assert_eq!(parsed.observe.max_tokens, Some(100));
+    }
+
+    #[test]
+    fn cursor_cannot_change_capture_options() {
+        for option in ["--probe-hover", "--debug-surfaces"] {
+            assert!(
+                Command::try_parse_from([
+                    "observe",
+                    "--session",
+                    "s1",
+                    "--cursor",
+                    "page-two",
+                    option,
+                ])
+                .is_err()
+            );
+        }
+        assert!(
+            Command::try_parse_from([
+                "observe",
+                "--session",
+                "s1",
+                "--cursor",
+                "page-two",
+                "--max-depth",
+                "2",
+            ])
+            .is_err()
+        );
+    }
 }

--- a/crates/bsk-cli/src/cli/render_error.rs
+++ b/crates/bsk-cli/src/cli/render_error.rs
@@ -270,8 +270,8 @@ pub fn info_for_error(code: ErrorCode, data: Option<&serde_json::Value>) -> Rend
             exit_code: base.exit_code,
         },
         (ErrorCode::NotFound, reason::REF_NOT_FOUND) => RenderInfo {
-            summary: "snapshot ref was not found for this tab",
-            hint: Some("rerun `bsk snapshot` for the current tab and use one of the returned refs"),
+            summary: "observation ref was not found for this tab",
+            hint: Some("rerun `bsk observe` for the current tab and use one of the returned refs"),
             exit_code: base.exit_code,
         },
         (ErrorCode::NotFound, reason::SELECTOR_NOT_FOUND) => RenderInfo {
@@ -709,8 +709,8 @@ mod tests {
     fn ref_not_found_overrides_not_found_copy() {
         let data = serde_json::json!({ "reason": reason::REF_NOT_FOUND });
         let info = info_for_error(ErrorCode::NotFound, Some(&data));
-        assert_eq!(info.summary, "snapshot ref was not found for this tab");
-        assert!(info.hint.unwrap().contains("bsk snapshot"));
+        assert_eq!(info.summary, "observation ref was not found for this tab");
+        assert!(info.hint.unwrap().contains("bsk observe"));
     }
 
     #[test]

--- a/crates/bsk-cli/src/skill_install/storage.rs
+++ b/crates/bsk-cli/src/skill_install/storage.rs
@@ -10,9 +10,16 @@ use tempfile::NamedTempFile;
 
 /// All readers that may replace a skill hold this lock until their writes finish.
 /// Keep the lock file in place: deleting it could let two processes lock different
-/// files at the same path. Closing the handle releases the OS lock.
+/// files at the same path. Explicitly unlock on drop: a concurrently spawned
+/// child may still hold an inherited handle until exec, delaying close-only release.
 pub(super) struct SkillLock {
     _file: File,
+}
+
+impl Drop for SkillLock {
+    fn drop(&mut self) {
+        let _ = FileExt::unlock(&self._file);
+    }
 }
 
 impl SkillLock {
@@ -152,5 +159,19 @@ mod tests {
         drop(lock);
         assert!(dir.path().join(".bsk.lock").exists());
         assert!(SkillLock::try_acquire(dir.path()).unwrap().is_some());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn dropping_guard_releases_lock_with_a_duplicate_handle_alive() {
+        let dir = tempfile::tempdir().unwrap();
+        let lock = SkillLock::acquire(dir.path()).unwrap();
+        // dup shares the open file description, as an inherited fd does between
+        // fork and exec in a concurrently spawned child process.
+        let duplicate = lock._file.try_clone().unwrap();
+        assert!(SkillLock::try_acquire(dir.path()).unwrap().is_none());
+        drop(lock);
+        assert!(SkillLock::try_acquire(dir.path()).unwrap().is_some());
+        drop(duplicate);
     }
 }

--- a/crates/bsk-cli/tests/tools_ipc.rs
+++ b/crates/bsk-cli/tests/tools_ipc.rs
@@ -473,6 +473,7 @@ async fn observe_returns_semantic_text_and_ref_count() {
         let _: ObserveParams = serde_json::from_value(req.params.clone().unwrap()).unwrap();
         ResponseBody::Ok(
             serde_json::to_value(ObserveResult {
+                next_cursor: None,
                 text: "@vom 1\n  @e1 button \"Products\" [hover: Shoes]\n".into(),
                 ref_count: 1,
                 tab_id: 13,
@@ -490,6 +491,7 @@ async fn observe_returns_semantic_text_and_ref_count() {
         &sock,
         Method::ToolObserve,
         ObserveParams {
+            cursor: None,
             session_id,
             tab_id: None,
             max_depth: None,

--- a/crates/bsk-protocol/schema/tool_observe_params.json
+++ b/crates/bsk-protocol/schema/tool_observe_params.json
@@ -7,6 +7,13 @@
     "session_id"
   ],
   "properties": {
+    "cursor": {
+      "description": "Continue a retained observation; does not recapture the page.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "debug_surfaces": {
       "description": "Include implementation diagnostics for conditional surface probes.",
       "default": false,

--- a/crates/bsk-protocol/schema/tool_observe_result.json
+++ b/crates/bsk-protocol/schema/tool_observe_result.json
@@ -35,6 +35,13 @@
         }
       ]
     },
+    "next_cursor": {
+      "description": "Continue omitted content from this same observation.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "ref_count": {
       "description": "Number of `@e<N>` refs registered for this session by this observation. Equivalent to the size of the new ref-store map.",
       "type": "integer",

--- a/crates/bsk-protocol/src/tools/observation.rs
+++ b/crates/bsk-protocol/src/tools/observation.rs
@@ -63,6 +63,9 @@ pub struct SnapshotResult {
 /// page state.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 pub struct ObserveParams {
+    /// Continue a retained observation; does not recapture the page.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cursor: Option<String>,
     pub session_id: String,
     /// Optional target tab. Defaults to the Agent Window's currently
     /// active tab.
@@ -126,6 +129,9 @@ pub struct HoverProbeReport {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 pub struct ObserveResult {
+    /// Continue omitted content from this same observation.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub next_cursor: Option<String>,
     /// Semantic VOM observation text. Refs are rendered as `@e<N>` so
     /// the agent can copy them into subsequent interaction tools.
     pub text: String,
@@ -328,6 +334,7 @@ mod tests {
     #[test]
     fn observe_result_round_trips_with_ref_count() {
         let r = ObserveResult {
+            next_cursor: None,
             text: "@vom 1\n  @e1 button \"submit\"\n".into(),
             ref_count: 1,
             tab_id: 42,
@@ -343,6 +350,25 @@ mod tests {
     }
 
     #[test]
+    fn observe_cursor_round_trips_without_changing_snapshot() {
+        let params: ObserveParams = serde_json::from_value(json!({
+            "session_id": "s1", "cursor": "next-page", "max_tokens": 100
+        }))
+        .unwrap();
+        assert_eq!(params.cursor.as_deref(), Some("next-page"));
+        assert_eq!(serde_json::to_value(params).unwrap()["cursor"], "next-page");
+        let result: ObserveResult = serde_json::from_value(json!({
+            "text": "@more", "ref_count": 0, "tab_id": 4,
+            "truncated": true, "next_cursor": "next-page"
+        }))
+        .unwrap();
+        assert_eq!(
+            serde_json::to_value(result).unwrap()["next_cursor"],
+            "next-page"
+        );
+    }
+
+    #[test]
     fn observe_params_default_to_no_hover_probing() {
         let params: ObserveParams =
             serde_json::from_value(serde_json::json!({ "session_id": "s1" })).unwrap();
@@ -352,6 +378,7 @@ mod tests {
     #[test]
     fn observe_result_round_trips_with_hover_probe_report() {
         let r = ObserveResult {
+            next_cursor: None,
             text: "@vom 1\n".into(),
             ref_count: 0,
             tab_id: 42,

--- a/packages/dsh-plugin-browserskill/skill/SKILL.md
+++ b/packages/dsh-plugin-browserskill/skill/SKILL.md
@@ -112,3 +112,16 @@ Continue from returned sequence cursors instead of rereading the same buffer.
 
 Arbitrary page-script evaluation and interaction recording are intentionally unsupported. Do not
 invent tools or route around those limits.
+
+## Canvas and continued observations
+
+`@eN canvas [visual:screenshot]` supports only `browser_inspect` action=screenshot with that
+ref. Names are optional; do not invent Canvas contents from nearby controls. First observe
+returns text. If you cannot understand images, tell the user to switch to an image-capable
+model and continue with available semantics; BrowserSkill does not detect model capabilities.
+
+No token cap applies by default. With explicit maxTokens, follow nextCursor using
+browser_inspect action=observe and cursor. Use current refs first: each response replaces
+previous refs and may contain many Canvas entries. Continuation reads the same observation,
+without recapture; do not change depth. New observe/snapshot or DOM identity changes invalidate
+it. Use fresh observe for updated content.

--- a/packages/dsh-plugin-browserskill/src/browser-tools.ts
+++ b/packages/dsh-plugin-browserskill/src/browser-tools.ts
@@ -156,6 +156,10 @@ const BROWSER_TOOL_SPECS: BrowserToolSpec[] = [
       tabId: TAB_ID_PARAM,
       maxDepth: { type: "integer", description: "Tree depth cap for observe/snapshot." },
       maxTokens: { type: "integer", description: "Token cap for observe/snapshot." },
+      cursor: {
+        type: "string",
+        description: "Observe continuation cursor; use current refs before continuing.",
+      },
       ref: { type: "string", description: "Fresh ref for scoped html or cropped screenshot." },
       maxBytes: { type: "integer", description: "HTML byte cap." },
       since: { type: "integer", description: "Console/network sequence cursor." },

--- a/packages/dsh-plugin-browserskill/src/client/BrowserInspectToolView.tsx
+++ b/packages/dsh-plugin-browserskill/src/client/BrowserInspectToolView.tsx
@@ -84,6 +84,7 @@ interface InspectArgs {
   tabId?: unknown;
   maxDepth?: unknown;
   maxTokens?: unknown;
+  cursor?: unknown;
   ref?: unknown;
   maxBytes?: unknown;
   since?: unknown;
@@ -105,6 +106,8 @@ function commandOf(argsRaw: string, callId: string): { command: string; title: s
     parts.push(
       typeof args.session === "string" && args.session !== "" ? args.session : "(current)",
     );
+    if (action === "observe" && typeof args.cursor === "string")
+      parts.push("--cursor", args.cursor);
     if (action === "observe" || action === "snapshot") {
       appendNumber(parts, "--max-depth", args.maxDepth);
       appendNumber(parts, "--max-tokens", args.maxTokens);

--- a/packages/dsh-plugin-browserskill/src/tools.ts
+++ b/packages/dsh-plugin-browserskill/src/tools.ts
@@ -496,6 +496,14 @@ function defineBrowserOperations(deps: ToolDeps, register: DefinitionRegistrar):
         description,
         parameters: {
           session: SESSION_PARAM,
+          ...(kind === "observe"
+            ? {
+                cursor: {
+                  type: "string" as const,
+                  description: "Continue omitted content; previous page refs expire.",
+                },
+              }
+            : {}),
           maxDepth: { type: "integer", description: "Cap on tree depth before truncating." },
           maxTokens: {
             type: "integer",
@@ -512,6 +520,7 @@ function defineBrowserOperations(deps: ToolDeps, register: DefinitionRegistrar):
               text: { type: "string", required: true },
               refCount: { type: "integer", required: true },
               truncated: { type: "boolean", required: true },
+              nextCursor: { type: "string" },
             },
           },
           render: (_args, value) => [
@@ -519,7 +528,10 @@ function defineBrowserOperations(deps: ToolDeps, register: DefinitionRegistrar):
               type: "text",
               text:
                 value.text.length > 0
-                  ? value.text + (value.truncated ? "\n(truncated — re-run with looser caps)" : "")
+                  ? value.text +
+                    (value.truncated && !value.nextCursor
+                      ? "\n(truncated — re-run with looser caps)"
+                      : "")
                   : "(empty observation — page may still be loading)",
             },
           ],
@@ -528,6 +540,8 @@ function defineBrowserOperations(deps: ToolDeps, register: DefinitionRegistrar):
         async execute(args, exec) {
           const sessionId = registry.resolve(args.session, name);
           const cmdArgs = [kind, "--session", sessionId];
+          if (kind === "observe" && args.cursor !== undefined)
+            cmdArgs.push("--cursor", String(args.cursor));
           if (args.maxDepth !== undefined) cmdArgs.push("--max-depth", String(args.maxDepth));
           if (args.maxTokens !== undefined) cmdArgs.push("--max-tokens", String(args.maxTokens));
           const reply = (await runBsk(deps, exec, cmdArgs, kind, sessionId)) as {
@@ -535,6 +549,7 @@ function defineBrowserOperations(deps: ToolDeps, register: DefinitionRegistrar):
             ref_count: number;
             tab_id: number;
             truncated?: boolean;
+            next_cursor?: string;
           };
           return {
             session: sessionId,
@@ -542,6 +557,7 @@ function defineBrowserOperations(deps: ToolDeps, register: DefinitionRegistrar):
             text: reply.text,
             refCount: reply.ref_count,
             truncated: reply.truncated ?? false,
+            ...(reply.next_cursor ? { nextCursor: reply.next_cursor } : {}),
           };
         },
         presentCall: (args) => ({

--- a/packages/dsh-plugin-browserskill/tests/skill.test.ts
+++ b/packages/dsh-plugin-browserskill/tests/skill.test.ts
@@ -50,7 +50,9 @@ describe("registerBskSkill", () => {
     // Keep the lazily injected instructions inside a bounded prompt budget,
     // while the lower bound catches accidental truncation of the guidance.
     expect(content.length).toBeGreaterThan(3_000);
-    expect(content.length).toBeLessThan(6_000);
+    expect(content.length).toBeLessThan(7_000);
+    expect(content).toContain("[visual:screenshot]");
+    expect(content).toContain("nextCursor");
     expect(skill.source).toBe("bundled");
     // Source frontmatter is registration metadata and must not leak into the body.
     expect(content.startsWith("---")).toBe(false);

--- a/packages/dsh-plugin-browserskill/tests/tools.test.ts
+++ b/packages/dsh-plugin-browserskill/tests/tools.test.ts
@@ -1478,3 +1478,24 @@ describe("wheel action", () => {
     expect(calls).toHaveLength(1);
   });
 });
+
+it("inspect.observe forwards continuation cursors and exposes the next cursor", async () => {
+  const { tools, calls } = setup({
+    "session start": { session_id: "s1", agent_window_id: 100 },
+    observe: { ...SNAPSHOT_REPLY, truncated: true, next_cursor: "page-three" },
+  });
+  await startSession(tools);
+  const value = await tools
+    .get("inspect.observe")
+    ?.execute({ cursor: "page-two", maxTokens: 100 }, makeExec());
+  expect(calls.at(-1)?.args).toEqual([
+    "observe",
+    "--session",
+    "s1",
+    "--cursor",
+    "page-two",
+    "--max-tokens",
+    "100",
+  ]);
+  expect(value).toMatchObject({ nextCursor: "page-three", truncated: true });
+});

--- a/packages/vom/src/index.ts
+++ b/packages/vom/src/index.ts
@@ -2,6 +2,8 @@ export {
   applyVomInteractionRecovery,
   isVomReferenceNode,
   isVomStructuralRole,
+  prepareObservationRender,
+  type RenderRow,
   renderVom,
 } from "./render";
 export type {
@@ -12,6 +14,7 @@ export type {
   Rect,
   RenderedRef,
   Viewport,
+  VisualEntry,
   VomNode,
   VomOptions,
   VomRef,

--- a/packages/vom/src/render.ts
+++ b/packages/vom/src/render.ts
@@ -1109,7 +1109,11 @@ function collectDescendants(nodes: VomNode[], roots: Set<number>): Set<number> {
   return included;
 }
 
-function applyActiveRegionPolicy(nodes: VomNode[], scene: VomScene): VomNode[] {
+function applyActiveRegionPolicy(
+  nodes: VomNode[],
+  scene: VomScene,
+  visualSources?: ReadonlyMap<number, VomNode>,
+): VomNode[] {
   const parentMap = buildParentMap(nodes);
   const nodesById = new Map(nodes.map((node) => [node.id, node]));
   const lineageCache = new Map<number, Map<string | undefined, VomNode>>();
@@ -1127,10 +1131,10 @@ function applyActiveRegionPolicy(nodes: VomNode[], scene: VomScene): VomNode[] {
 
   const blockedRoots = new Set<number>();
   for (const target of nodes) {
-    if (!isVomReferenceNode(target)) continue;
+    if (target.visualKey === undefined && !isVomReferenceNode(target)) continue;
     const blocked = candidates.some((candidate) =>
       isBlockedByRegion(
-        target,
+        visualSources?.get(target.id) ?? target,
         candidate.node,
         parentMap,
         nodesById,
@@ -1208,20 +1212,65 @@ export function prepareObservationRender(
 } {
   const recovered = applyVomInteractionRecovery(scene.nodes);
   const layer = detectBlockingLayer(recovered, scene.viewport, scene.rootFrameId);
-  const included = layer ? collectDescendants(recovered, layer.members) : undefined;
-  const visible = included
-    ? recovered.filter((n) => included.has(n.id))
+  const recoveredById = new Map(recovered.map((n) => [n.id, n]));
+  let nextId = recovered.reduce((max, n) => Math.max(max, n.id), 0) + 1;
+  // Scope targets participate in existing filtering, never in blocker detection.
+  // Keep the exact source as parent so an excluded source cannot reappear via fallback.
+  const visualTargets: VomNode[] = (scene.visuals ?? []).map((v) => ({
+    id: nextId++,
+    parentId: v.sourceId ?? v.parentId,
+    frameId: v.frameId,
+    visualKey: v.key,
+    tag: "canvas",
+    rect: v.rect ?? (v.sourceId === undefined ? null : recoveredById.get(v.sourceId)?.rect) ?? null,
+    paintOrder:
+      v.paintOrder ??
+      (v.sourceId === undefined ? undefined : recoveredById.get(v.sourceId)?.paintOrder) ??
+      0,
+    position: "static",
+    pointerEvents: "none",
+    referenceable: false,
+  }));
+  const visualSources = new Map<number, VomNode>();
+  for (let i = 0; i < visualTargets.length; i++) {
+    const sourceId = scene.visuals![i].sourceId;
+    const source = sourceId === undefined ? undefined : recoveredById.get(sourceId);
+    if (source) visualSources.set(visualTargets[i].id, { ...source, rect: visualTargets[i].rect });
+  }
+  const scopeNodes = [...recovered, ...visualTargets];
+  const members = layer ? new Set(layer.members) : undefined;
+  if (members && layer) {
+    const blocker = recoveredById.get(layer.rootId)!;
+    for (let i = 0; i < visualTargets.length; i++) {
+      const target = visualTargets[i];
+      const v = scene.visuals![i];
+      if (
+        v.sourceId === undefined &&
+        v.paintOrder !== undefined &&
+        target.frameId === blocker.frameId &&
+        target.paintOrder >= blocker.paintOrder
+      )
+        members.add(target.id);
+    }
+  }
+  const included = members ? collectDescendants(scopeNodes, members) : undefined;
+  const scoped = included
+    ? scopeNodes.filter((n) => included.has(n.id))
     : options.activeRegionPolicy
-      ? applyActiveRegionPolicy(recovered, scene)
-      : recovered;
+      ? applyActiveRegionPolicy(scopeNodes, scene, visualSources)
+      : scopeNodes;
+  const allowedVisuals = new Set(
+    scoped.filter((n) => n.visualKey !== undefined).map((n) => n.visualKey),
+  );
+  const visible = scoped.filter((n) => n.visualKey === undefined);
   const byId = new Map(visible.map((n) => [n.id, n]));
   const ids = new Set(byId.keys());
-  let nextId = visible.reduce((max, n) => Math.max(max, n.id), 0) + 1;
   const before = new Map<number, VomNode[]>();
   const tail: VomNode[] = [];
   const fallbackGroups = new Map<string, number>();
   const representedSources = new Set<number>();
   for (const v of scene.visuals ?? []) {
+    if (!allowedVisuals.has(v.key)) continue;
     const source = v.sourceId === undefined ? undefined : byId.get(v.sourceId);
     // Only suppress an exact passive Canvas description already carried by the visual line.
     // Action refs and distinct semantic content remain separate.

--- a/packages/vom/src/render.ts
+++ b/packages/vom/src/render.ts
@@ -777,6 +777,7 @@ function shouldSkipRedundantChildren(node: VomNode, state: RenderState): boolean
 }
 
 interface RenderState {
+  visualAncestors: Set<number>;
   lines: string[];
   refs: RenderedRef[];
   nextRef: number;
@@ -785,7 +786,6 @@ interface RenderState {
   maxTokens: number;
   redactValues: boolean;
   truncated: boolean;
-  stopped: boolean;
   children: Map<number | null, VomNode[]>;
   parentMap: Map<number, number | null>;
   nodesById: Map<number, VomNode>;
@@ -795,33 +795,13 @@ interface RenderState {
   scopeMap: Map<number, ActiveScopeBlock>;
 }
 
-function emitActiveScopeBlock(scope: ActiveScopeBlock, depth: number, state: RenderState): void {
-  if (state.stopped || scope.lines.length === 0) return;
-  const indent = "  ".repeat(depth);
-  const header = `${indent}[§ active: ${scope.label}]`;
-  const headerTokens = estimateTokens(header);
-  if (state.tokens + headerTokens > state.maxTokens) {
-    state.truncated = true;
-    state.stopped = true;
-    return;
-  }
-  state.lines.push(header);
-  state.tokens += headerTokens;
-
-  for (const text of scope.lines.slice(0, MAX_SCOPE_LINES)) {
-    if (state.stopped) return;
-    const clean = cleaned(text);
-    if (!clean) continue;
-    const line = `${indent}  ${clean}`;
-    const nextTokens = state.tokens + estimateTokens(line);
-    if (nextTokens > state.maxTokens) {
-      state.truncated = true;
-      state.stopped = true;
-      return;
-    }
-    state.lines.push(line);
-    state.tokens = nextTokens;
-  }
+export interface RenderRow {
+  context?: string;
+  frameId?: string;
+  text: string;
+  ref?: RenderedRef;
+  /** Minimal complete visual entry when a long label cannot fit. */
+  minimal?: string;
 }
 
 function pushRenderChildren(
@@ -834,69 +814,97 @@ function pushRenderChildren(
   }
 }
 
-function renderTree(children: Map<number | null, VomNode[]>, state: RenderState): void {
+function* renderTreeRows(
+  children: Map<number | null, VomNode[]>,
+  state: RenderState,
+  observation = false,
+  representedSources?: ReadonlySet<number>,
+): Generator<RenderRow> {
   const stack: Array<{ node: VomNode; depth: number }> = [];
   pushRenderChildren(stack, children.get(null) ?? [], 1);
 
-  while (stack.length > 0 && !state.stopped) {
+  while (stack.length > 0) {
     const { node, depth } = stack.pop() as { node: VomNode; depth: number };
 
-    if (!shouldRender(node)) {
+    if (representedSources?.has(node.id) || (node.visualKey === undefined && !shouldRender(node))) {
       pushRenderChildren(stack, children.get(node.id) ?? [], depth);
       continue;
     }
 
-    if (depth > state.maxDepth) {
+    if (depth > state.maxDepth && node.visualKey === undefined) {
       state.truncated = true;
+      if (observation && state.visualAncestors.has(node.id))
+        pushRenderChildren(stack, children.get(node.id) ?? [], depth);
       continue;
     }
 
-    const ref = isVomReferenceNode(node) ? `e${state.nextRef}` : undefined;
-    const context = ref ? handleContext(node, state) : [];
+    const visual = node.visualKey !== undefined;
+    const ref = visual || isVomReferenceNode(node) ? `e${state.nextRef++}` : undefined;
+    const context = ref && !visual ? handleContext(node, state) : [];
     const surface = state.surfaceMap.get(node.id);
-    const line = renderNodeLine(node, depth, ref, context, surface, state.redactValues);
-    const nextTokens = state.tokens + estimateTokens(line);
-    if (nextTokens > state.maxTokens) {
-      state.truncated = true;
-      state.stopped = true;
-      break;
-    }
-
-    state.lines.push(line);
-    state.tokens = nextTokens;
-    if (ref) {
-      const name = cleaned(node.name);
-      state.refs.push({
-        ref,
-        backendNodeId: node.backendNodeId ?? node.id,
-        ...(node.frameId ? { frameId: node.frameId } : {}),
-        ...(node.role ? { role: node.role } : {}),
-        ...(name ? { name } : {}),
-        ...(context.length > 0 ? { ctx: context.join(" > ") } : {}),
-        line: state.lines.length - 1,
-      });
-      state.nextRef += 1;
-    }
-
+    const indent = "  ".repeat(Math.min(depth, state.maxDepth, 32));
+    const minimal = visual ? `${indent}@${ref} canvas [visual:screenshot]` : undefined;
+    const label = cleaned(node.name);
+    const text = visual
+      ? label
+        ? `${indent}@${ref} canvas ${JSON.stringify(Array.from(label).slice(0, 160).join(""))} [visual:screenshot]`
+        : minimal!
+      : renderNodeLine(node, depth, ref, context, surface, state.redactValues);
+    const parent = node.parentId === null ? undefined : state.nodesById.get(node.parentId);
+    const parentLabel = parent ? cleaned(parent.name) : undefined;
+    yield {
+      ...(parent
+        ? {
+            context: `@context ${parent.role ?? parent.tag}${parentLabel ? ` ${JSON.stringify(Array.from(parentLabel).slice(0, 80).join(""))}` : ""}`,
+          }
+        : {}),
+      frameId: node.frameId,
+      text,
+      ...(minimal ? { minimal } : {}),
+      ...(ref
+        ? {
+            ref: {
+              ref,
+              backendNodeId: node.backendNodeId ?? node.id,
+              ...(visual ? { visualKey: node.visualKey } : {}),
+              ...(node.frameId ? { frameId: node.frameId } : {}),
+              ...(node.role ? { role: node.role } : {}),
+              ...(label ? { name: label } : {}),
+              ...(context.length > 0 ? { ctx: context.join(" > ") } : {}),
+              line: 0,
+            },
+          }
+        : {}),
+    };
     const scope = state.scopeMap.get(node.id);
-    if (scope) emitActiveScopeBlock(scope, depth + 1, state);
+    if (scope?.lines.length) {
+      yield { text: `${"  ".repeat(depth + 1)}[§ active: ${scope.label}]` };
+      for (const text of scope.lines.slice(0, MAX_SCOPE_LINES)) {
+        const clean = cleaned(text);
+        if (clean) yield { text: `${"  ".repeat(depth + 2)}${clean}` };
+      }
+    }
 
-    if ((ref && shouldSkipRedundantRefChildren(node)) || shouldSkipRedundantChildren(node, state)) {
+    if (
+      (!observation || !state.visualAncestors.has(node.id)) &&
+      ((ref && shouldSkipRedundantRefChildren(node)) || shouldSkipRedundantChildren(node, state))
+    ) {
       continue;
     }
     pushRenderChildren(stack, children.get(node.id) ?? [], depth + 1);
   }
 }
 
-function renderNodes(
+function createRenderState(
   nodes: VomNode[],
   options: VomOptions,
   initialLines: string[],
-  surfaces: CondSurface[] = [],
-  activeScopeBlocks: ActiveScopeBlock[] = [],
+  surfaces: CondSurface[],
+  activeScopeBlocks: ActiveScopeBlock[],
 ): RenderState {
   const children = buildChildren(nodes);
   const state: RenderState = {
+    visualAncestors: new Set(),
     lines: [...initialLines],
     refs: [],
     nextRef: 1,
@@ -905,7 +913,6 @@ function renderNodes(
     maxTokens: options.maxTokens ?? DEFAULT_MAX_TOKENS,
     redactValues: options.redactValues ?? false,
     truncated: false,
-    stopped: false,
     children,
     parentMap: buildParentMap(nodes),
     nodesById: new Map(nodes.map((node) => [node.id, node])),
@@ -915,7 +922,36 @@ function renderNodes(
     scopeMap: new Map(activeScopeBlocks.map((scope) => [scope.triggerId, scope])),
   };
 
-  renderTree(children, state);
+  for (const node of nodes) {
+    if (node.visualKey === undefined) continue;
+    let id = node.parentId;
+    while (id !== null && !state.visualAncestors.has(id)) {
+      state.visualAncestors.add(id);
+      id = state.parentMap.get(id) ?? null;
+    }
+  }
+  return state;
+}
+
+function renderNodes(
+  nodes: VomNode[],
+  options: VomOptions,
+  initialLines: string[],
+  surfaces: CondSurface[] = [],
+  activeScopeBlocks: ActiveScopeBlock[] = [],
+): RenderState {
+  const state = createRenderState(nodes, options, initialLines, surfaces, activeScopeBlocks);
+  const children = state.children;
+  for (const row of renderTreeRows(children, state)) {
+    const cost = estimateTokens(row.text);
+    if (state.tokens + cost > state.maxTokens) {
+      state.truncated = true;
+      break;
+    }
+    if (row.ref) state.refs.push({ ...row.ref, line: state.lines.length });
+    state.lines.push(row.text);
+    state.tokens += cost;
+  }
 
   return state;
 }
@@ -1159,4 +1195,115 @@ export function renderVom(scene: VomScene, options: VomOptions = {}): VomResult 
     refs: state.refs,
     truncated: state.truncated,
   };
+}
+
+/** Prepare semantics once; the iterator retains traversal position, never raw capture facts. */
+export function prepareObservationRender(
+  scene: VomScene,
+  options: VomOptions = {},
+): {
+  headers: string[];
+  rows: Iterator<RenderRow>;
+  truncated: () => boolean;
+} {
+  const recovered = applyVomInteractionRecovery(scene.nodes);
+  const layer = detectBlockingLayer(recovered, scene.viewport, scene.rootFrameId);
+  const included = layer ? collectDescendants(recovered, layer.members) : undefined;
+  const visible = included
+    ? recovered.filter((n) => included.has(n.id))
+    : options.activeRegionPolicy
+      ? applyActiveRegionPolicy(recovered, scene)
+      : recovered;
+  const byId = new Map(visible.map((n) => [n.id, n]));
+  const ids = new Set(byId.keys());
+  let nextId = visible.reduce((max, n) => Math.max(max, n.id), 0) + 1;
+  const before = new Map<number, VomNode[]>();
+  const tail: VomNode[] = [];
+  const fallbackGroups = new Map<string, number>();
+  const representedSources = new Set<number>();
+  for (const v of scene.visuals ?? []) {
+    const source = v.sourceId === undefined ? undefined : byId.get(v.sourceId);
+    // Only suppress an exact passive Canvas description already carried by the visual line.
+    // Action refs and distinct semantic content remain separate.
+    if (
+      source &&
+      normalizedTag(source) === "canvas" &&
+      normalizedRole(source) === "canvas" &&
+      !isVomReferenceNode(source) &&
+      !source.value &&
+      !source.text &&
+      (!cleaned(source.name) || cleaned(source.name) === cleaned(v.label))
+    ) {
+      representedSources.add(source.id);
+    }
+
+    const node: VomNode = {
+      id: nextId++,
+      parentId: v.parentId !== null && ids.has(v.parentId) ? v.parentId : null,
+      tag: "canvas",
+      role: "canvas",
+      name: v.label,
+      frameId: v.frameId,
+      visualKey: v.key,
+      rect: null,
+      paintOrder: 0,
+      position: "static",
+      pointerEvents: "none",
+      referenceable: false,
+    };
+    if (node.parentId === null) {
+      const label = v.fallbackContext ?? "Unplaced Canvas regions";
+      let groupId = fallbackGroups.get(label);
+      if (groupId === undefined) {
+        groupId = nextId++;
+        fallbackGroups.set(label, groupId);
+        tail.push({
+          id: groupId,
+          parentId: null,
+          tag: "section",
+          role: "group",
+          name: label,
+          rect: null,
+          paintOrder: 0,
+          position: "static",
+          pointerEvents: "none",
+          referenceable: false,
+        });
+      }
+      node.parentId = groupId;
+    }
+    if (
+      v.beforeId !== undefined &&
+      ids.has(v.beforeId) &&
+      byId.get(v.beforeId)?.parentId === node.parentId
+    ) {
+      const list = before.get(v.beforeId) ?? [];
+      list.push(node);
+      before.set(v.beforeId, list);
+    } else tail.push(node);
+  }
+  const nodes = visible.flatMap((n) => [...(before.get(n.id) ?? []), n]).concat(tail);
+  const headers = [
+    "@vom 1",
+    `@view ${scene.viewport.width}x${scene.viewport.height}`,
+    `@layers ${layer ? 2 : 1} focus=L1`,
+    layer ? `L1 ${layer.kind} cover=${Math.round(layer.coverage * 100)}%` : "L1 page",
+  ];
+  const state = createRenderState(
+    nodes,
+    options,
+    [],
+    scene.surfaces ?? [],
+    scene.activeScopeBlocks ?? [],
+  );
+  function* rows(): Generator<RenderRow> {
+    yield* renderTreeRows(state.children, state, true, representedSources);
+    if (layer)
+      yield {
+        text: renderPageOcclusionLine(
+          countRenderable(recovered.filter((n) => !included!.has(n.id))),
+        ),
+      };
+  }
+  return { headers, rows: rows(), truncated: () => state.truncated };
 }

--- a/packages/vom/src/types.ts
+++ b/packages/vom/src/types.ts
@@ -19,6 +19,8 @@ export type LayerKind = "page" | "modal" | "mask";
  * before constructing these nodes.
  */
 export interface VomNode {
+  /** Internal render-only visual entry; never a DOM action target. */
+  visualKey?: number;
   id: number;
   parentId: number | null;
   backendNodeId?: number;
@@ -54,7 +56,19 @@ export interface VomNode {
   insideNative?: boolean;
 }
 
+export interface VisualEntry {
+  /** Exact retained Canvas node, distinct from the next sibling insertion point. */
+  sourceId?: number;
+  fallbackContext?: string;
+  key: number;
+  parentId: number | null;
+  beforeId?: number;
+  label?: string;
+  frameId: string;
+}
+
 export interface VomScene {
+  visuals?: VisualEntry[];
   viewport: Viewport;
   nodes: VomNode[];
   /** Root document whose paint order defines page-level blocking layers. */
@@ -97,6 +111,7 @@ export interface VomRef {
 }
 
 export interface RenderedRef extends VomRef {
+  visualKey?: number;
   role?: string;
   name?: string;
   ctx?: string;

--- a/packages/vom/src/types.ts
+++ b/packages/vom/src/types.ts
@@ -57,6 +57,9 @@ export interface VomNode {
 }
 
 export interface VisualEntry {
+  /** Existing capture geometry/order used only by observation scope filtering. */
+  rect?: Rect;
+  paintOrder?: number;
   /** Exact retained Canvas node, distinct from the next sibling insertion point. */
   sourceId?: number;
   fallbackContext?: string;

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -116,6 +116,26 @@ Escalate page reading only as needed:
 Do not start with raw HTML or screenshots merely to discover ordinary controls. When interaction is
 needed, obtain a fresh observation before acting on screenshot or HTML findings.
 
+## Canvas and observation continuation
+
+`observe` may place `@eN canvas [visual:screenshot]` near related page controls. Names are
+optional: do not infer a table title or controls inside Canvas from adjacent labels. Visual refs
+support `screenshot --ref`, not click/fill/hover or HTML extraction. First observe returns text,
+not an image. Use the surrounding semantics to decide whether a Canvas screenshot is needed.
+If you cannot receive and understand images in this session, tell the user the Canvas contents
+cannot be interpreted and ask them to switch to an image-capable model; continue with available
+semantic information. BrowserSkill does not detect the model's capabilities.
+
+There is no default token cap. With an explicit `--max-tokens` limit, an observation may return
+`next_cursor` and an `@more` instruction. Use current refs before calling
+`bsk observe --cursor <token> --session <id>`: each response replaces the ref map, so refs from
+previous pages must not be reused. A response can contain many Canvas entries. Follow cursors
+when relevant content remains, rather than repeatedly reading the same prefix.
+Continuation reads the same captured observation; it does not refresh or hover the page. Do not
+combine it with depth changes or hover probing. A new observe/snapshot replaces the continuation;
+if the page identity changed, observe again. Screenshot execution checks current target identity
+and geometry, but permits Canvas repainting and does not freeze pixels.
+
 ## Respect the Agent Window boundary
 
 Normal page writes affect only Agent Window tabs. To operate a user tab, first list it with


### PR DESCRIPTION
## 背景

前序 PR 已提供 Canvas 候选发现、视觉 ref 和按目标截图能力。本 PR 将这些能力接入 observe，让 agent 能发现页面中的 Canvas，并按需获取截图。

## 主要改动

- 在 Canvas 对应的 DOM 位置附近输出 `@eN canvas [visual:screenshot]`，保留相邻控件上下文；名称可选，不推断 Canvas 内部内容。
- 首次观察仅返回语义信息和视觉入口；agent 需要查看内容时，通过对应 ref 请求截图。
- 默认不设置输出预算；显式指定 max_tokens 时，通过 next_cursor 续读同一次观察，避免只返回前缀而遗漏后续内容。
- 每次响应只保留当前页的 ref；校验续读所属的页面身份，防止复用失效结果。
- 同步 CLI、插件及 skill 指引，说明视觉 ref 的用途、续读方式，以及由 agent 判断当前会话是否具备图像理解能力。

## 范围

复用同一次采集生成语义和视觉条目；续读不重新采集页面。不改变 snapshot 的语义观察行为，不引入 OCR 或 Canvas 内部交互能力。

## 验证

- 扩展测试：1267 通过，32 跳过；相关 VOM、插件及 CLI 测试通过。
- 真实浏览器验证：24 个 Canvas 默认完整输出，有限预算下续读无遗漏或重复，游标重试及旧 ref 失效行为正确。
- iWiki 表格 Canvas、主页面及跨进程 iframe 的按 ref 截图通过，保留原生圆角效果。