### PR TITLE
feat(vom): support screenshot-bound point interactions on canvas regions | 支持基于截图坐标的 canvas 点选操作

### DIFF
--- a/apps/extension/src/tools/__tests__/visual-screenshot.test.ts
+++ b/apps/extension/src/tools/__tests__/visual-screenshot.test.ts
@@ -6,6 +6,7 @@ import { handleScreenshot } from "../observation";
 import type { CdpRunner } from "../shared";
 import { consumeVisualCapture, issueVisualCapture } from "../visual-capture";
 import { captureVisualScreenshot, visualScreenshotScale } from "../visual-screenshot";
+import { resolveVisualRegionNow, verifyVisualHit } from "../visual-target";
 import type { VisualCandidate, VisualFramePath } from "../vom/visual-discovery";
 
 const styles = {
@@ -678,4 +679,82 @@ it.each([
   ).toHaveProperty("code", "invalid_params");
   expect(f.input).toHaveLength(0);
   expect(await handleClick(f.manager, f.params, f.deps)).not.toHaveProperty("code");
+});
+
+describe("visual hit shadow boundaries", () => {
+  it.each([
+    "plain",
+    "open",
+    "closed",
+    "nested",
+    "slotted",
+    "iframe",
+  ])("executes the hit script for %s targets and rejects occlusion in every scope", async (kind) => {
+    const container = document.createElement("div");
+    document.body.append(container);
+    const target = document.createElement(kind === "iframe" ? "iframe" : "canvas");
+    const scopes: { root: Document | ShadowRoot; node: Element }[] = [];
+    let parent: Element | ShadowRoot = container;
+    const modes: ShadowRootMode[] =
+      kind === "nested"
+        ? ["closed", "open", "closed"]
+        : kind === "plain"
+          ? []
+          : [kind === "open" ? "open" : "closed"];
+    let scope: Document | ShadowRoot = document;
+    for (const mode of modes) {
+      const host = document.createElement("div");
+      parent.append(host);
+      if (kind === "slotted") {
+        host.attachShadow({ mode }).append(document.createElement("slot"));
+        parent = host;
+        break;
+      }
+      scopes.push({ root: scope, node: host });
+      scope = host.attachShadow({ mode });
+      if (mode === "closed") expect(host.shadowRoot).toBeNull();
+      parent = scope;
+    }
+    parent.append(target);
+    scopes.push({ root: scope, node: target });
+    // happy-dom has no layout hit testing. Stub only the browser hit results;
+    // execute the actual CDP script against real DOM roots, including closed ones.
+    const hits = scopes.map(({ root, node }) => {
+      const original = Object.getOwnPropertyDescriptor(root, "elementFromPoint");
+      const hit = vi.fn((): Element | null => node);
+      Object.defineProperty(root, "elementFromPoint", { configurable: true, value: hit });
+      return { root, original, hit, node };
+    });
+    try {
+      const f = fixture();
+      const state = await resolveVisualRegionNow(f.cdp, f.candidate);
+      if ("code" in state) throw new Error(state.message);
+      const original = f.send.getMockImplementation()!;
+      f.send.mockImplementation(async (cdpTarget, method, params = {}) => {
+        if (
+          method === "Runtime.callFunctionOn" &&
+          String(params.functionDeclaration).includes("elementFromPoint")
+        ) {
+          const run = new Function(`return (${params.functionDeclaration});`)();
+          return { result: { value: run.call(target, 20, 30) } };
+        }
+        return original(cdpTarget, method, params);
+      });
+      expect(await verifyVisualHit(f.cdp, state, { x: 20, y: 30 })).toBe(true);
+      for (const { hit, node } of hits) {
+        hit.mockReturnValue(document.createElement("div"));
+        expect(await verifyVisualHit(f.cdp, state, { x: 20, y: 30 })).toBe(false);
+        hit.mockReturnValue(node);
+      }
+      target.remove();
+      expect(await verifyVisualHit(f.cdp, state, { x: 20, y: 30 })).toBe(false);
+      expect(f.cdp.getFrameGraph).not.toHaveBeenCalled();
+    } finally {
+      for (const { root, original } of hits) {
+        if (original) Object.defineProperty(root, "elementFromPoint", original);
+        else Reflect.deleteProperty(root, "elementFromPoint");
+      }
+      container.remove();
+    }
+  });
 });

--- a/apps/extension/src/tools/__tests__/visual-screenshot.test.ts
+++ b/apps/extension/src/tools/__tests__/visual-screenshot.test.ts
@@ -758,3 +758,86 @@ describe("visual hit shadow boundaries", () => {
     }
   });
 });
+
+it.each([
+  ["upper", "upper", true],
+  ["lower", "upper", false],
+  ["lower", "lower", true],
+  ["upper", "lower", false],
+] as const)("keeps overlapping target identity: requested=%s hit=%s", async (requested, hit, allowed) => {
+  const f = await pointFixture();
+  const lower = document.createElement("canvas");
+  const upper = document.createElement("canvas");
+  document.body.append(lower, upper);
+  const hitDescriptor = Object.getOwnPropertyDescriptor(document, "elementFromPoint");
+  // Model the browser's hit result: upper receives events, or passes them to lower.
+  Object.defineProperty(document, "elementFromPoint", {
+    configurable: true,
+    value: () => (hit === "upper" ? upper : lower),
+  });
+  const original = f.send.getMockImplementation()!;
+  f.send.mockImplementation(async (target, method, params = {}) => {
+    if (
+      method === "Runtime.callFunctionOn" &&
+      String(params.functionDeclaration).includes("elementFromPoint")
+    ) {
+      const run = new Function(`return (${params.functionDeclaration});`)();
+      const node = params.objectId === "4" ? upper : lower;
+      const coordinates = (params.arguments as { value: number }[]).map((arg) => arg.value);
+      return { result: { value: run.call(node, ...coordinates) } };
+    }
+    if (
+      method === "Runtime.callFunctionOn" &&
+      params.objectId === "4" &&
+      String(params.functionDeclaration).includes("styleNames")
+    ) {
+      const rows = [{ ...f.topRows[0], node: { backend: 4 } }, ...f.topRows.slice(1)];
+      return { result: { deepSerializedValue: encode({ top: true, dpr: 1, rows }) } };
+    }
+    return original(target, method, params);
+  });
+  try {
+    f.ctx.refStore.replace([
+      ["e1", { kind: "visual-region", candidate: f.candidate }],
+      ["e2", { kind: "visual-region", candidate: { ...f.candidate, backendNodeId: 4 } }],
+    ]);
+    const ref = requested === "upper" ? "e2" : "e1";
+    const shot = await handleScreenshot(
+      f.manager,
+      { session_id: "point", ref },
+      {
+        cdp: f.cdp,
+        tabsApi: f.deps.tabsApi,
+        captureApi: { ...f.deps.tabsApi, captureVisibleTab: vi.fn() },
+        sendToTab: vi.fn(async () => ({})),
+      },
+    );
+    expect(shot).toHaveProperty("capture_id");
+    const result = await handleClick(
+      f.manager,
+      {
+        ...f.params,
+        ref,
+        capture_id: (shot as { capture_id: string }).capture_id,
+      },
+      f.deps,
+    );
+    if (allowed) {
+      expect(result).toMatchObject({ x: 60, y: 40 });
+      expect(f.input.map((event) => event.type)).toEqual([
+        "mouseMoved",
+        "mousePressed",
+        "mouseReleased",
+      ]);
+    } else {
+      expect(result).toHaveProperty("data.reason", "visual_capture_stale");
+      expect(f.input).toHaveLength(0);
+    }
+    expect(f.cdp.getFrameGraph).not.toHaveBeenCalled();
+  } finally {
+    if (hitDescriptor) Object.defineProperty(document, "elementFromPoint", hitDescriptor);
+    else Reflect.deleteProperty(document, "elementFromPoint");
+    lower.remove();
+    upper.remove();
+  }
+});

--- a/apps/extension/src/tools/__tests__/visual-screenshot.test.ts
+++ b/apps/extension/src/tools/__tests__/visual-screenshot.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
 import type { CdpTarget } from "@/browser-driver/frame-graph";
 import { SessionManager } from "@/session-manager/manager";
+import { handleClick } from "../interaction";
 import { handleScreenshot } from "../observation";
 import type { CdpRunner } from "../shared";
+import { consumeVisualCapture, issueVisualCapture } from "../visual-capture";
 import { captureVisualScreenshot, visualScreenshotScale } from "../visual-screenshot";
 import type { VisualCandidate, VisualFramePath } from "../vom/visual-discovery";
 
@@ -100,7 +102,11 @@ function fixture(child = false, oopif = false) {
   };
   const controller = new AbortController();
   const send = vi.fn(
-    async (target: CdpTarget, method: string, params: Record<string, unknown> = {}) => {
+    async (
+      target: CdpTarget,
+      method: string,
+      params: Record<string, unknown> = {},
+    ): Promise<Record<string, unknown>> => {
       if (method === "DOM.getFrameOwner") return { backendNodeId: control.wrongOwner ? 999 : 2 };
       if (method === "Page.createIsolatedWorld")
         return { executionContextId: params.frameId === "child" ? 11 : 1 };
@@ -382,7 +388,7 @@ describe("visual screenshot", () => {
     );
     expect(f.send.mock.calls.filter((c) => c[1] === "Page.captureScreenshot")).toHaveLength(1);
   });
-  it("accepts post-capture layout and style updates without rereading geometry", async () => {
+  it("keeps the image viewable when post-capture mapping reads fail", async () => {
     const f = fixture();
     f.control.onShot = () => {
       f.topRows[0].box.x += 100;
@@ -392,11 +398,12 @@ describe("visual screenshot", () => {
     expect(await captureVisualScreenshot(f.cdp, f.candidate)).toMatchObject({
       width: 100,
       height: 40,
+      capture_unavailable: expect.any(String),
     });
     const after = f.send.mock.calls.slice(
       f.send.mock.calls.findIndex((c) => c[1] === "Page.captureScreenshot") + 1,
     );
-    expect(after.filter((c) => c[1] === "DOM.resolveNode")).toHaveLength(1);
+    expect(after.filter((c) => c[1] === "DOM.resolveNode")).toHaveLength(2);
     expect(
       after.some(
         (c) =>
@@ -404,7 +411,7 @@ describe("visual screenshot", () => {
           c[1] === "DOM.getBoxModel" ||
           String(c[2]?.functionDeclaration).includes("styleNames"),
       ),
-    ).toBe(false);
+    ).toBe(true);
   });
   it("remeasures geometry before a pixel-budget retry", async () => {
     const f = fixture();
@@ -457,4 +464,218 @@ describe("visual screenshot", () => {
     expect(result).toMatchObject({ width: 100, height: 40, format: "png" });
     expect(sendToTab).toHaveBeenCalledTimes(2);
   });
+});
+
+async function pointFixture(child = false, oopif = false) {
+  const f = fixture(child, oopif);
+  const manager = new SessionManager({
+    agentWindow: {
+      create: async () => 100,
+      remove: async () => {},
+      ensureActiveTab: async () => 4,
+    },
+  });
+  const ctx = await manager.start("point");
+  ctx.refStore.replace([["e1", { kind: "visual-region", candidate: f.candidate }]]);
+  const tab = { id: 4, windowId: 100, active: true } as chrome.tabs.Tab;
+  const tabsApi = { get: async () => tab, query: async () => [tab] };
+  const bypassOverlay = vi.fn(async (_tab: number, _enabled: boolean) => {});
+  const original = f.send.getMockImplementation()!;
+  const input: Record<string, unknown>[] = [];
+  const hitPoints: number[][] = [];
+  const control = { hit: true, onMove: () => {}, failPress: false };
+  f.send.mockImplementation(async (target, method, params = {}) => {
+    if (
+      method === "Runtime.callFunctionOn" &&
+      String(params.functionDeclaration).includes("elementFromPoint")
+    ) {
+      hitPoints.push((params.arguments as { value: number }[]).map((a) => a.value));
+      return { result: { value: control.hit } };
+    }
+    if (method === "Input.dispatchMouseEvent") {
+      input.push(params);
+      if (params.type === "mouseMoved") control.onMove();
+      if (params.type === "mousePressed" && control.failPress) throw new Error("transport lost");
+      return {};
+    }
+    return original(target, method, params);
+  });
+  const shot = await handleScreenshot(
+    manager,
+    { session_id: "point", ref: "e1" },
+    {
+      cdp: f.cdp,
+      tabsApi,
+      captureApi: { ...tabsApi, captureVisibleTab: vi.fn() },
+      sendToTab: vi.fn(async () => ({})),
+    },
+  );
+  expect(shot).toHaveProperty("capture_id");
+  const params = {
+    session_id: "point",
+    ref: "e1",
+    capture_id: (shot as { capture_id: string }).capture_id,
+    image_x: child ? 100 : 50,
+    image_y: child ? 40 : 20,
+  };
+  return {
+    ...f,
+    manager,
+    ctx,
+    params,
+    input,
+    hitPoints,
+    pointControl: control,
+    deps: { cdp: f.cdp, tabsApi, bypassOverlay },
+    shot,
+  };
+}
+
+it.each([
+  [false, false],
+  [true, false],
+  [true, true],
+])("clicks only the captured Canvas through the frame path child=%s oopif=%s", async (child, oopif) => {
+  const f = await pointFixture(child, oopif);
+  const result = await handleClick(f.manager, f.params, f.deps);
+  expect(result).toMatchObject({ x: child ? 220 : 60, y: child ? 280 : 40 });
+  expect(f.hitPoints.at(-1)).toEqual([60, 40]);
+  expect(f.input.map((e) => e.type)).toEqual(["mouseMoved", "mousePressed", "mouseReleased"]);
+  expect(f.cdp.getFrameGraph).not.toHaveBeenCalled();
+  const count = f.input.length;
+  expect(await handleClick(f.manager, f.params, f.deps)).toHaveProperty(
+    "data.reason",
+    "visual_capture_stale",
+  );
+  expect(f.input).toHaveLength(count);
+  expect(f.deps.bypassOverlay.mock.calls).toEqual([
+    [4, true],
+    [4, false],
+  ]);
+});
+
+it.each([
+  "replace",
+  "geometry",
+  "occluded",
+  "expired",
+  "wrong-ref",
+  "wrong-session",
+])("rejects unusable captures before moving: %s", async (kind) => {
+  const f = await pointFixture();
+  if (kind === "replace")
+    f.ctx.refStore.replace([["e1", { kind: "visual-region", candidate: f.candidate }]]);
+  if (kind === "geometry") f.topRows[0].box.x += 10;
+  if (kind === "occluded") f.pointControl.hit = false;
+  if (kind === "wrong-ref") f.params.ref = "e2";
+  if (kind === "wrong-session") f.params.session_id = "other";
+  const now = Date.now();
+  const clock =
+    kind === "expired" ? vi.spyOn(Date, "now").mockReturnValue(now + 120001) : undefined;
+  try {
+    expect(await handleClick(f.manager, f.params, f.deps)).toHaveProperty("code");
+    expect(f.input).toHaveLength(0);
+  } finally {
+    clock?.mockRestore();
+  }
+});
+
+it.each([
+  "geometry",
+  "occluded",
+  "cancel",
+  "press-failed",
+])("does not silently replay after %s during click", async (kind) => {
+  const f = await pointFixture();
+  const controller = new AbortController();
+  f.pointControl.onMove = () => {
+    if (kind === "geometry") f.topRows[0].box.x += 10;
+    if (kind === "occluded") f.pointControl.hit = false;
+    if (kind === "cancel") controller.abort();
+  };
+  f.pointControl.failPress = kind === "press-failed";
+  const result = await handleClick(f.manager, f.params, { ...f.deps, signal: controller.signal });
+  expect(result).toHaveProperty("data.effect_state", kind === "press-failed" ? "unknown" : "none");
+  expect(f.input.map((e) => e.type)).toEqual(
+    kind === "press-failed" ? ["mouseMoved", "mousePressed", "mouseReleased"] : ["mouseMoved"],
+  );
+  expect(await handleClick(f.manager, f.params, f.deps)).toHaveProperty(
+    "data.reason",
+    "visual_capture_stale",
+  );
+});
+
+it("dispatches two complete clicks with modifiers for a double-click", async () => {
+  const f = await pointFixture();
+  expect(
+    await handleClick(f.manager, { ...f.params, click_count: 2, modifiers: ["shift"] }, f.deps),
+  ).not.toHaveProperty("code");
+  expect(f.input.map((e) => [e.type, e.clickCount])).toEqual([
+    ["mouseMoved", undefined],
+    ["mousePressed", 1],
+    ["mouseReleased", 1],
+    ["mousePressed", 2],
+    ["mouseReleased", 2],
+  ]);
+  expect(f.input.every((e) => e.modifiers === 8)).toBe(true);
+});
+
+it("returns a viewable image without a click capture when the mapping changes during capture", async () => {
+  const f = fixture();
+  f.control.onShot = () => {
+    f.topRows[0].box.x += 1;
+  };
+  const shot = await captureVisualScreenshot(f.cdp, f.candidate);
+  expect(shot).toMatchObject({ width: 100, height: 40, capture_unavailable: expect.any(String) });
+  expect(shot).not.toHaveProperty("mapping");
+});
+
+it("bounds capture storage and invalidates superseded images without retaining pixels", async () => {
+  const f = await pointFixture();
+  const shot = await captureVisualScreenshot(f.cdp, f.candidate);
+  if ("code" in shot || !shot.mapping) throw new Error("expected mapping");
+  f.ctx.refStore.replace(
+    Array.from(
+      { length: 33 },
+      (_, i) => [`e${i + 1}`, { kind: "visual-region" as const, candidate: f.candidate }] as const,
+    ),
+  );
+  const ids: string[] = [];
+  for (let i = 1; i <= 33; i++) {
+    const entry = f.ctx.refStore.resolveEntry(`e${i}`)!;
+    if (entry.kind !== "visual-region") throw new Error("expected visual");
+    ids.push(issueVisualCapture(f.ctx.refStore, `e${i}`, entry, shot.mapping, 100, 40)!);
+  }
+  const request = (ref: string, id: string) =>
+    consumeVisualCapture(f.ctx.refStore, 4, {
+      session_id: "point",
+      ref,
+      capture_id: id,
+      image_x: 50,
+      image_y: 20,
+    });
+  expect(request("e1", ids[0])).toHaveProperty("code");
+  expect(request("e2", ids[1])).toHaveProperty("point", { x: 60, y: 40 });
+  const entry = f.ctx.refStore.resolveEntry("e33")!;
+  if (entry.kind !== "visual-region") throw new Error("expected visual");
+  const newest = issueVisualCapture(f.ctx.refStore, "e33", entry, shot.mapping, 100, 40)!;
+  expect(request("e33", ids[32])).toHaveProperty("code");
+  expect(request("e33", newest)).toHaveProperty("point");
+  f.ctx.refStore.clear();
+  expect(issueVisualCapture(f.ctx.refStore, "e33", entry, shot.mapping, 100, 40)).toBeUndefined();
+});
+
+it.each([
+  [-1, 0],
+  [100, 0],
+  [0, 40],
+  [NaN, 0],
+  [0, Infinity],
+])("rejects invalid PNG point %s,%s without consuming its capture", async (x, y) => {
+  const f = await pointFixture();
+  expect(
+    await handleClick(f.manager, { ...f.params, image_x: x, image_y: y }, f.deps),
+  ).toHaveProperty("code", "invalid_params");
+  expect(f.input).toHaveLength(0);
+  expect(await handleClick(f.manager, f.params, f.deps)).not.toHaveProperty("code");
 });

--- a/apps/extension/src/tools/interaction.ts
+++ b/apps/extension/src/tools/interaction.ts
@@ -1,3 +1,6 @@
+import { consumeVisualCapture, isVisualPointRequest } from "./visual-capture";
+import { resolveVisualRegionNow, sameVisualMapping, verifyVisualHit } from "./visual-target";
+import { isAbortError } from "./vom/capture-abort";
 // DOM interaction tools — click, hover, focus/blur, fill, press, and select.
 //
 // All interaction tools:
@@ -460,6 +463,7 @@ export async function handleClick(
   if (isRpcError(target)) return target;
   const denied = enforceAgentWindow(ctx, target, "click");
   if (denied) return denied;
+  if (isVisualPointRequest(params)) return clickVisualPoint(ctx, target, params, deps);
   const resolved = await resolveActionTarget(deps.cdp, ctx, target, params, "click");
   if (isRpcError(resolved)) return resolved;
   return clickResolvedTarget(ctx, resolved, params, deps);
@@ -496,13 +500,10 @@ export async function clickResolvedTarget(
     return { code: "cancelled", message: "click aborted" };
   }
 
-  const button: MouseButton = params.button ?? "left";
   const clickCount = params.click_count ?? 1;
   if (clickCount < 1) {
     return { code: "invalid_params", message: "click_count must be greater than zero" };
   }
-  const modifiers = modifiersBitfield(params.modifiers);
-
   const overlayBlocking = await checkOverlayAtPoint(deps.cdp, target.tabId, centre.x, centre.y);
   let automationBypassEnabled = false;
   if (overlayBlocking && deps.bypassOverlay) {
@@ -515,52 +516,8 @@ export async function clickResolvedTarget(
   }
 
   try {
-    // Move first so hover state activates, then press → release.
-    await deps.cdp.send(target.tabId, "Input.dispatchMouseEvent", {
-      type: "mouseMoved",
-      x: centre.x,
-      y: centre.y,
-      modifiers,
-    });
-    if (throwIfAborted(deps.signal)) {
-      return { code: "cancelled", message: "click aborted" };
-    }
-    await deps.cdp.send(target.tabId, "Input.dispatchMouseEvent", {
-      type: "mousePressed",
-      x: centre.x,
-      y: centre.y,
-      button,
-      clickCount,
-      modifiers,
-    });
-    if (throwIfAborted(deps.signal)) {
-      try {
-        await deps.cdp.send(target.tabId, "Input.dispatchMouseEvent", {
-          type: "mouseReleased",
-          x: centre.x,
-          y: centre.y,
-          button,
-          clickCount,
-          modifiers,
-        });
-      } catch (err) {
-        console.debug("[bsk interaction] best-effort mouseReleased after abort failed", err);
-      }
-      return { code: "cancelled", message: "click aborted" };
-    }
-    await deps.cdp.send(target.tabId, "Input.dispatchMouseEvent", {
-      type: "mouseReleased",
-      x: centre.x,
-      y: centre.y,
-      button,
-      clickCount,
-      modifiers,
-    });
-  } catch (err) {
-    return {
-      code: "cdp_failed",
-      message: err instanceof Error ? err.message : String(err),
-    };
+    const error = await dispatchClickAtPoint(target.tabId, centre, params, deps);
+    if (error) return error;
   } finally {
     if (automationBypassEnabled && deps.bypassOverlay && !deps.keepOverlayBypassAfterHover) {
       try {
@@ -578,6 +535,153 @@ export async function clickResolvedTarget(
     x: centre.x,
     y: centre.y,
   });
+}
+
+/** Shared mouse lifecycle; visual clicks additionally verify after move and emit full double clicks. */
+async function dispatchClickAtPoint(
+  tabId: number,
+  point: { x: number; y: number },
+  params: Pick<ClickParams, "button" | "click_count" | "modifiers">,
+  deps: InteractionDeps,
+  beforePress?: () => Promise<RpcError | null>,
+): Promise<RpcError | null> {
+  const button = params.button ?? "left",
+    modifiers = modifiersBitfield(params.modifiers);
+  let releaseNeeded = false,
+    attempted = false,
+    moved = false,
+    count = params.click_count ?? 1;
+  const release = () =>
+    deps.cdp.send(tabId, "Input.dispatchMouseEvent", {
+      type: "mouseReleased",
+      ...point,
+      button,
+      clickCount: count,
+      modifiers,
+    });
+  const failure = (error: RpcError): RpcError =>
+    beforePress
+      ? {
+          ...error,
+          data: {
+            ...error.data,
+            effect_state: attempted ? "unknown" : "none",
+            pointer_moved: moved,
+          },
+        }
+      : error;
+  try {
+    if (deps.signal?.aborted) return failure({ code: "cancelled", message: "click aborted" });
+    moved = true;
+    await deps.cdp.send(tabId, "Input.dispatchMouseEvent", {
+      type: "mouseMoved",
+      ...point,
+      modifiers,
+    });
+    if (beforePress) {
+      const error = await beforePress();
+      if (error) return failure(error);
+    }
+    const counts = beforePress
+      ? Array.from({ length: params.click_count ?? 1 }, (_, i) => i + 1)
+      : [count];
+    for (count of counts) {
+      if (beforePress && count > 1) {
+        const error = await beforePress();
+        if (error) return failure(error);
+      }
+      if (deps.signal?.aborted) return failure({ code: "cancelled", message: "click aborted" });
+      attempted = true;
+      releaseNeeded = true;
+      await deps.cdp.send(tabId, "Input.dispatchMouseEvent", {
+        type: "mousePressed",
+        ...point,
+        button,
+        clickCount: count,
+        modifiers,
+      });
+      await release();
+      releaseNeeded = false;
+    }
+    if (deps.signal?.aborted) return failure({ code: "cancelled", message: "click aborted" });
+    return null;
+  } catch (error) {
+    return failure({
+      code: deps.signal?.aborted || isAbortError(error) ? "cancelled" : "cdp_failed",
+      message: error instanceof Error ? error.message : String(error),
+    });
+  } finally {
+    if (releaseNeeded) await release().catch(() => {});
+  }
+}
+
+async function clickVisualPoint(
+  ctx: SessionContext,
+  target: ResolvedTargetTab,
+  params: ClickParams,
+  deps: InteractionDeps,
+): Promise<ClickResult | RpcError> {
+  const consumed = consumeVisualCapture(ctx.refStore, target.tabId, params);
+  if (isRpcError(consumed)) return consumed;
+  const { capture, point } = consumed;
+  const dialogCursor = markDialogCursor(deps.cdp, target.tabId);
+  const changed = () =>
+    rpcError(
+      "not_found",
+      "visual_capture_stale",
+      "visual target, mapping or hit target changed; observe and screenshot again",
+    );
+  const validate = async (): Promise<RpcError | null> => {
+    if (
+      ctx.refStore.resolveEntry(capture.ref) !== capture.entry ||
+      ctx.refStore.revision !== capture.generation
+    )
+      return changed();
+    const current = await resolveVisualRegionNow(deps.cdp, capture.entry.candidate, deps.signal);
+    if (isRpcError(current)) return current;
+    if (
+      !sameVisualMapping(capture.mapping, current) ||
+      !(await verifyVisualHit(deps.cdp, current, point, deps.signal))
+    )
+      return changed();
+    if (
+      ctx.refStore.resolveEntry(capture.ref) !== capture.entry ||
+      ctx.refStore.revision !== capture.generation ||
+      current.mappings.some(
+        (m) => deps.cdp.getAttachmentId?.(target.tabId) !== m.document.attachmentId,
+      )
+    )
+      return changed();
+    return null;
+  };
+  let bypass = false;
+  try {
+    deps.cdp.trackSessionTab?.(ctx.sessionId, target.tabId);
+    if (deps.bypassOverlay) {
+      await deps.bypassOverlay(target.tabId, true);
+      bypass = true;
+    }
+    const invalid = await validate();
+    if (invalid) return { ...invalid, data: { ...invalid.data, effect_state: "none" } };
+    const error = await dispatchClickAtPoint(target.tabId, point, params, deps, async () => {
+      await wait(32, deps.signal); // Scheduling opportunity, not a claim of page stability.
+      return validate();
+    });
+    if (error) return error;
+    return attachDialogs(deps.cdp, target.tabId, dialogCursor, {
+      tab_id: target.tabId,
+      used_ref: capture.ref,
+      ...point,
+    });
+  } catch (error) {
+    return {
+      code: deps.signal?.aborted || isAbortError(error) ? "cancelled" : "cdp_failed",
+      message: error instanceof Error ? error.message : String(error),
+      data: { effect_state: "none" },
+    };
+  } finally {
+    if (bypass) await deps.bypassOverlay!(target.tabId, false).catch(() => {});
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/extension/src/tools/observation.ts
+++ b/apps/extension/src/tools/observation.ts
@@ -1,4 +1,5 @@
 import { parsePngDimensions } from "./png";
+import { clearVisualCapture, issueVisualCapture } from "./visual-capture";
 import { captureVisualScreenshot } from "./visual-screenshot";
 import { deduplicateVisualCandidates } from "./vom/visual-dedup";
 import { discoverVisualCandidates } from "./vom/visual-discovery";
@@ -291,6 +292,7 @@ export async function handleScreenshot(
     }
     const entry = lookupRefTarget(ctx, ref, target.tabId);
     if (entry?.kind === "visual-region") {
+      clearVisualCapture(ctx.refStore, ref);
       deps.cdp.trackSessionTab?.(ctx.sessionId, target.tabId);
       const captured = await withExtensionOverlayHidden(
         target.tabId,
@@ -298,7 +300,22 @@ export async function handleScreenshot(
         deps.sendToTab,
       );
       if (isRpcError(captured)) return captured;
-      return withShotDialogs({ ...captured, format: "png", tab_id: target.tabId });
+      const { mapping, ...image } = captured;
+      const captureId = mapping
+        ? issueVisualCapture(ctx.refStore, ref, entry, mapping, image.width, image.height)
+        : undefined;
+      return withShotDialogs({
+        ...image,
+        format: "png",
+        tab_id: target.tabId,
+        ...(captureId
+          ? { capture_id: captureId }
+          : {
+              capture_unavailable:
+                image.capture_unavailable ??
+                "observation replaced during capture; observe and screenshot again",
+            }),
+      });
     }
     const node = resolveSnapshotRef(ctx, ref, target.tabId);
     if (isRpcError(node)) return node;

--- a/apps/extension/src/tools/visual-capture.ts
+++ b/apps/extension/src/tools/visual-capture.ts
@@ -1,0 +1,112 @@
+import { normaliseRef, type RefStore, type VisualRefInput } from "@/session-manager/ref-store";
+import type { ClickParams, RpcError } from "@/transport/types";
+import { rpcError } from "./errors";
+import type { VisualTargetState } from "./visual-target";
+
+const TTL_MS = 120_000;
+const MAX_CAPTURES = 32;
+interface Capture {
+  id: string;
+  ref: string;
+  generation: number;
+  entry: VisualRefInput;
+  mapping: VisualTargetState;
+  width: number;
+  height: number;
+  expiresAt: number;
+}
+const stores = new WeakMap<RefStore, Map<string, Capture>>();
+function captures(store: RefStore): Map<string, Capture> {
+  let result = stores.get(store);
+  if (!result) stores.set(store, (result = new Map()));
+  for (const [ref, capture] of result)
+    if (capture.expiresAt <= Date.now() || capture.generation !== store.revision)
+      result.delete(ref);
+  return result;
+}
+export function clearVisualCapture(store: RefStore, ref: string): void {
+  captures(store).delete(normaliseRef(ref));
+}
+export function issueVisualCapture(
+  store: RefStore,
+  ref: string,
+  entry: VisualRefInput & { generation: number },
+  mapping: VisualTargetState,
+  width: number,
+  height: number,
+): string | undefined {
+  ref = normaliseRef(ref);
+  if (store.resolveEntry(ref) !== entry || entry.generation !== store.revision) return undefined;
+  const items = captures(store);
+  items.delete(ref);
+  if (items.size >= MAX_CAPTURES) items.delete(items.keys().next().value!);
+  const id = crypto.randomUUID();
+  items.set(ref, {
+    id,
+    ref,
+    entry,
+    generation: store.revision,
+    mapping,
+    width,
+    height,
+    expiresAt: Date.now() + TTL_MS,
+  });
+  return id;
+}
+export function isVisualPointRequest(params: ClickParams): boolean {
+  return (
+    params.capture_id !== undefined || params.image_x !== undefined || params.image_y !== undefined
+  );
+}
+export function consumeVisualCapture(
+  store: RefStore,
+  tabId: number,
+  params: ClickParams,
+): { capture: Capture; point: { x: number; y: number } } | RpcError {
+  if (
+    !params.ref ||
+    params.selector ||
+    typeof params.capture_id !== "string" ||
+    !params.capture_id ||
+    !Number.isFinite(params.image_x) ||
+    !Number.isFinite(params.image_y) ||
+    ![1, 2].includes(params.click_count ?? 1)
+  )
+    return rpcError(
+      "invalid_params",
+      "visual_capture_invalid",
+      "Canvas point clicks require a visual ref, capture_id, finite image_x/image_y and click_count 1 or 2",
+    );
+  const ref = normaliseRef(params.ref);
+  const entry = store.resolveEntry(ref);
+  const items = captures(store);
+  const capture = items.get(ref);
+  if (
+    !capture ||
+    capture.id !== params.capture_id ||
+    entry !== capture.entry ||
+    entry.kind !== "visual-region" ||
+    entry.candidate.document.target.tabId !== tabId
+  )
+    return rpcError(
+      "not_found",
+      "visual_capture_stale",
+      "capture expired, consumed or does not match the current visual ref; observe and screenshot again",
+    );
+  const x = params.image_x!,
+    y = params.image_y!;
+  if (x < 0 || y < 0 || x >= capture.width || y >= capture.height)
+    return rpcError(
+      "invalid_params",
+      "visual_coordinate_invalid",
+      "image coordinates must be inside the original PNG dimensions",
+    );
+  items.delete(ref); // Before the first await or input: never dispatch twice with this image.
+  return {
+    capture,
+    point: {
+      x: capture.mapping.crop.x + (x / capture.width) * capture.mapping.crop.width,
+      y: capture.mapping.crop.y + (y / capture.height) * capture.mapping.crop.height,
+    },
+  };
+}

--- a/apps/extension/src/tools/visual-screenshot.ts
+++ b/apps/extension/src/tools/visual-screenshot.ts
@@ -1,77 +1,16 @@
-import type { CdpFrame } from "@/browser-driver/frame-graph";
 import type { RpcError } from "@/transport/types";
 import { rpcError } from "./errors";
-import {
-  type GeometryProjection,
-  projectRectToViewport,
-  type Size,
-  type ViewportRect,
-} from "./geometry";
-import { type CssViewport, screenshotPageRect } from "./geometry/coordinate-types";
-import { cssViewport, GeometryContext } from "./geometry/frame-context";
+import { screenshotPageRect } from "./geometry/coordinate-types";
 import { parsePngDimensions } from "./png";
-import { type CdpRunner, sendToCdpTarget } from "./shared";
-import { isAbortError, throwIfAborted } from "./vom/capture-abort";
-import { resolveVerifiedNode } from "./vom/document-identity";
-import type { DocumentIdentity } from "./vom/facts";
-import { VISUAL_STYLES } from "./vom/snapshot";
-import type { VisualCandidate, VisualFramePath } from "./vom/visual-discovery";
+import type { CdpRunner } from "./shared";
 import {
-  EMPTY_VISUAL_CONTEXT,
-  extendVisualContext,
-  projectVisualBox,
-  resolveVisualRegion,
-  type VisualClipSource,
-  type VisualContext,
-  visualProjectionIssue,
-} from "./vom/visual-region";
-
-interface LiveRow {
-  node: number;
-  tag: string;
-  box: ViewportRect;
-  client: ViewportRect;
-  contentSize: Size;
-  styles: Record<string, string>;
-}
-interface LiveFrame {
-  top: boolean;
-  dpr: number;
-  rows: LiveRow[]; // Anchor first, root last.
-}
-
-// Read only one current ancestry, including shadow hosts, in the verified isolated world.
-const READ_ANCESTRY = `function(styleNames) {
-  if (!this.isConnected || this.ownerDocument !== document) return null;
-  const rows = [];
-  for (let node = this; node; node = node.parentElement || node.getRootNode().host) {
-    if (!(node instanceof Element)) return null;
-    const s = getComputedStyle(node), r = node.getBoundingClientRect();
-    rows.push({ node, tag: node.localName,
-      box: { x:r.x, y:r.y, width:r.width, height:r.height },
-      client: { x:r.x+node.clientLeft, y:r.y+node.clientTop, width:node.clientWidth, height:node.clientHeight },
-      contentSize: { width:node.clientWidth-parseFloat(s.paddingLeft)-parseFloat(s.paddingRight), height:node.clientHeight-parseFloat(s.paddingTop)-parseFloat(s.paddingBottom) },
-      styles: Object.fromEntries(styleNames.map(key => [key,s.getPropertyValue(key)])) });
-  }
-  return { top: window === window.top, dpr: devicePixelRatio, rows };
-}`;
-
-interface DeepValue {
-  type: string;
-  value?: unknown;
-}
-/** This read returns JSON primitives plus DOM nodes (backend IDs), never remote object handles. */
-function decode(value: DeepValue): unknown {
-  if (value.type === "node") return (value.value as { backendNodeId?: number })?.backendNodeId;
-  if (value.type === "array") return (value.value as DeepValue[]).map(decode);
-  if (value.type === "object")
-    return Object.fromEntries(
-      (value.value as [string, DeepValue][]).map(([key, item]) => [key, decode(item)]),
-    );
-  if (value.type === "null") return null;
-  if (["string", "number", "boolean"].includes(value.type)) return value.value;
-  throw new Error("unexpected live ancestry serialization");
-}
+  resolveVisualRegionNow,
+  sameVisualMapping,
+  type VisualTargetState,
+  verifyCapturedTarget,
+} from "./visual-target";
+import { isAbortError, throwIfAborted } from "./vom/capture-abort";
+import type { VisualCandidate } from "./vom/visual-discovery";
 
 function stale(message: string): RpcError {
   return rpcError(
@@ -80,44 +19,6 @@ function stale(message: string): RpcError {
     `${message}; observe again before requesting a screenshot`,
   );
 }
-
-function sameIdentity(a: DocumentIdentity, b: DocumentIdentity): boolean {
-  return (
-    a.attachmentId === b.attachmentId &&
-    a.frameId === b.frameId &&
-    a.target.tabId === b.target.tabId &&
-    a.target.sessionId === b.target.sessionId &&
-    a.documentElementBackendNodeId === b.documentElementBackendNodeId
-  );
-}
-
-function closeRect(a: ViewportRect, b: ViewportRect): boolean {
-  return [
-    a.x - b.x,
-    a.y - b.y,
-    a.x + a.width - b.x - b.width,
-    a.y + a.height - b.y - b.height,
-  ].every((delta) => Number.isFinite(delta) && Math.abs(delta) <= 0.25);
-}
-
-function sameClips(a?: VisualClipSource, b?: VisualClipSource): boolean {
-  while (a && b) {
-    if (
-      !sameIdentity(a.document, b.document) ||
-      a.backendNodeId !== b.backendNodeId ||
-      a.x !== b.x ||
-      a.y !== b.y ||
-      a.overflowX !== b.overflowX ||
-      a.overflowY !== b.overflowY ||
-      !closeRect(a.box, b.box)
-    )
-      return false;
-    a = a.parent;
-    b = b.parent;
-  }
-  return !a && !b;
-}
-
 /** Scale affects raster size only, never the selected CSS region. */
 export function visualScreenshotScale(width: number, height: number, pixelsPerCss: number): number {
   if (![width, height, pixelsPerCss].every((n) => Number.isFinite(n) && n > 0))
@@ -129,256 +30,21 @@ export function visualScreenshotScale(width: number, height: number, pixelsPerCs
   );
 }
 
-async function readFrame(
-  cdp: CdpRunner,
-  document: DocumentIdentity,
-  anchor: number,
-  signal?: AbortSignal,
-): Promise<LiveFrame | RpcError> {
-  const verified = await resolveVerifiedNode(cdp, document, anchor, signal);
-  if (verified.status !== "current") return stale(`visual DOM identity ${verified.status}`);
-  try {
-    throwIfAborted(signal);
-    const reply = await sendToCdpTarget<{
-      result?: { deepSerializedValue?: DeepValue };
-      exceptionDetails?: unknown;
-    }>(cdp, document.target, "Runtime.callFunctionOn", {
-      objectId: verified.objectId,
-      objectGroup: verified.objectGroup,
-      functionDeclaration: READ_ANCESTRY,
-      arguments: [{ value: VISUAL_STYLES }],
-      serializationOptions: {
-        serialization: "deep",
-        additionalParameters: { maxNodeDepth: 0, includeShadowTree: "none" },
-      },
-    });
-    throwIfAborted(signal);
-    if (reply.exceptionDetails || !reply.result?.deepSerializedValue)
-      return stale("visual ancestry unavailable");
-    const result = decode(reply.result.deepSerializedValue) as LiveFrame | null;
-    if (
-      !result?.rows?.length ||
-      result.rows[0].node !== anchor ||
-      result.rows.at(-1)?.node !== document.documentElementBackendNodeId ||
-      !result.rows.every((row) => Number.isSafeInteger(row.node) && row.node > 0)
-    )
-      return stale("visual ancestry incomplete");
-    if (cdp.getAttachmentId?.(document.target.tabId) !== document.attachmentId)
-      return stale("visual attachment changed");
-    return result;
-  } finally {
-    await sendToCdpTarget(cdp, document.target, "Runtime.releaseObjectGroup", {
-      objectGroup: verified.objectGroup,
-    }).catch(() => {});
-    throwIfAborted(signal);
-  }
-}
-
-/** All live reads for one screenshot use this one measurement context. */
-async function resolveVisualRegionNow(
-  cdp: CdpRunner,
-  candidate: VisualCandidate,
-  signal?: AbortSignal,
-): Promise<{ crop: ViewportRect; viewport: CssViewport; dpr: number } | RpcError> {
-  throwIfAborted(signal);
-  if (!candidate.framePath || !sameIdentity(candidate.document, candidate.framePath.document))
-    return stale("visual frame path unavailable");
-  const path: { frame: VisualFramePath; anchor: number }[] = [];
-  const seen = new Set<string>();
-  let frame: VisualFramePath | undefined = candidate.framePath;
-  let anchor = candidate.backendNodeId;
-  while (frame) {
-    if (
-      seen.has(frame.document.frameId) ||
-      frame.document.target.tabId !== candidate.document.target.tabId ||
-      cdp.getAttachmentId?.(frame.document.target.tabId) !== frame.document.attachmentId
-    )
-      return stale("invalid visual frame path");
-    seen.add(frame.document.frameId);
-    path.push({ frame, anchor });
-    anchor = frame.parent?.ownerBackendNodeId ?? 0;
-    frame = frame.parent?.frame;
-  }
-  path.reverse();
-  const frames: CdpFrame[] = path.map(({ frame }) => ({
-    frameId: frame.document.frameId,
-    target: frame.document.target,
-    ...(frame.parent
-      ? {
-          parentFrameId: frame.parent.frame.document.frameId,
-          ownerBackendNodeId: frame.parent.ownerBackendNodeId,
-        }
-      : {}),
-  }));
-  // Validate each recorded edge instead of asking the driver to fill all page owners.
-  for (const { frame } of path) {
-    if (!frame.parent) continue;
-    throwIfAborted(signal);
-    const owner = await sendToCdpTarget<{ backendNodeId?: number }>(
-      cdp,
-      frame.parent.frame.document.target,
-      "DOM.getFrameOwner",
-      { frameId: frame.document.frameId },
-    );
-    if (owner.backendNodeId !== frame.parent.ownerBackendNodeId)
-      return stale("visual frame owner changed");
-  }
-  const geometry = new GeometryContext(
-    cdp,
-    candidate.document.target.tabId,
-    { rootFrameId: frames[0].frameId, frames },
-    signal,
-  );
-  let context: VisualContext = EMPTY_VISUAL_CONTEXT;
-  let parentRead: LiveFrame | undefined;
-  let finalRegion: VisualCandidate["region"] | undefined;
-  let topDpr = 0;
-  for (let i = 0; i < path.length; i++) {
-    const { frame, anchor } = path[i];
-    const live = await readFrame(cdp, frame.document, anchor, signal);
-    if ("code" in live) return live;
-    if (live.top !== (i === 0)) return stale("visual root frame changed");
-    if (i === 0) topDpr = live.dpr;
-    const metrics = await geometry.layoutMetrics(frame.document.target);
-    const viewport = cssViewport(metrics);
-    const projections: GeometryProjection[] = [];
-    if (frame.parent) {
-      const parent = frame.parent.frame.document;
-      const size = parentRead!.rows[0].contentSize;
-      if (![size.width, size.height].every((n) => Number.isFinite(n) && n > 0))
-        return stale("iframe content size unavailable");
-      const parentViewport = await geometry.viewport(parent.target);
-      if (!parentViewport) return stale("parent viewport unavailable");
-      const local = await geometry.snapshotProjection(
-        { target: parent.target, frameId: frame.document.frameId },
-        frame.parent.ownerBackendNodeId,
-        [],
-        parentViewport,
-        size,
-      );
-      const outer = await geometry.targetProjection(parent.frameId);
-      if (local.status !== "available" || !outer)
-        return stale("visual frame projection unavailable");
-      projections.push(local.projection.geometry, outer);
-    } else projections.push({ sourceClips: [], edges: [], topViewport: viewport });
-    const issue = visualProjectionIssue({
-      projections,
-      coordinates: { layoutUnitsPerCssPixel: 1, scrollCss: { x: 0, y: 0 } },
-      pageScale: metrics.cssVisualViewport?.scale ?? metrics.visualViewport?.scale,
-    });
-    if (issue) return stale(issue);
-    for (let j = live.rows.length - 1; j >= 0; j--) {
-      const row = live.rows[j];
-      const isAnchor = j === 0;
-      const node = {
-        document: frame.document,
-        backendNodeId: row.node,
-        styles: row.styles,
-        clientBox: projectVisualBox(row.client, projections),
-      };
-      context = extendVisualContext(
-        context,
-        node,
-        !isAnchor && row.tag !== "iframe" && row.tag !== "frame",
-      );
-    }
-    if (i < path.length - 1) {
-      const owner = live.rows[0];
-      context = {
-        ...context,
-        hidden:
-          context.hidden ||
-          owner.styles.visibility === "hidden" ||
-          owner.styles.visibility === "collapse",
-        transformed: false,
-        localClip: false,
-        unpositionedClip: false,
-      };
-    } else {
-      const row = live.rows[0];
-      if (row.tag !== "canvas") return stale("visual anchor is no longer Canvas");
-      let visible: ViewportRect | null = row.box;
-      for (const projection of projections)
-        visible = visible
-          ? projectRectToViewport(
-              { x: visible.x, y: visible.y, w: visible.width, h: visible.height },
-              projection,
-            )
-          : null;
-      const region = resolveVisualRegion({
-        borderBox: projectVisualBox(row.box, projections),
-        frameVisibleBox: visible,
-        context,
-        visibility: row.styles.visibility,
-      });
-      if (region.status !== "available")
-        return stale(
-          `visual region ${region.status}${region.status === "unavailable" ? `: ${region.reason}` : ""}`,
-        );
-      finalRegion = region;
-    }
-    parentRead = live;
-  }
-  if (
-    !finalRegion ||
-    !closeRect(candidate.region.borderBox, finalRegion.borderBox) ||
-    !closeRect(candidate.region.crop, finalRegion.crop) ||
-    !sameClips(candidate.region.clips, finalRegion.clips)
-  )
-    return stale("visual region changed");
-  const viewport = cssViewport(await geometry.layoutMetrics(frames[0].target));
-  return { crop: finalRegion.crop, viewport, dpr: topDpr };
-}
-
-/** Check identity only: repainting and post-capture layout changes are allowed. */
-async function verifyCapturedTarget(
-  cdp: CdpRunner,
-  candidate: VisualCandidate,
-  signal?: AbortSignal,
-): Promise<RpcError | null> {
-  try {
-    let frame = candidate.framePath;
-    let anchor = candidate.backendNodeId;
-    // The path was validated before capture; never rebuild it from the current page.
-    while (frame) {
-      const verified = await resolveVerifiedNode(cdp, frame.document, anchor, signal);
-      if (verified.status !== "current") return stale(`visual DOM identity ${verified.status}`);
-      await sendToCdpTarget(cdp, frame.document.target, "Runtime.releaseObjectGroup", {
-        objectGroup: verified.objectGroup,
-      }).catch(() => {});
-      throwIfAborted(signal);
-      if (frame.parent) {
-        const owner = await sendToCdpTarget<{ backendNodeId?: number }>(
-          cdp,
-          frame.parent.frame.document.target,
-          "DOM.getFrameOwner",
-          { frameId: frame.document.frameId },
-        );
-        throwIfAborted(signal);
-        if (owner.backendNodeId !== frame.parent.ownerBackendNodeId)
-          return stale("visual frame owner changed");
-        anchor = frame.parent.ownerBackendNodeId;
-      }
-      frame = frame.parent?.frame;
-    }
-    throwIfAborted(signal);
-    return cdp.getAttachmentId?.(candidate.document.target.tabId) ===
-      candidate.document.attachmentId
-      ? null
-      : stale("visual attachment changed");
-  } catch (error) {
-    throwIfAborted(signal);
-    if (isAbortError(error)) throw error;
-    return stale("visual identity unavailable after capture");
-  }
-}
-
 /** One target only. No frame discovery, scrolling, AX, or snapshot recapture. */
 export async function captureVisualScreenshot(
   cdp: CdpRunner,
   candidate: VisualCandidate,
   signal?: AbortSignal,
-): Promise<{ image_base64: string; width: number; height: number } | RpcError> {
+): Promise<
+  | {
+      image_base64: string;
+      width: number;
+      height: number;
+      mapping?: VisualTargetState;
+      capture_unavailable?: string;
+    }
+  | RpcError
+> {
   try {
     let region = await resolveVisualRegionNow(cdp, candidate, signal);
     if ("code" in region) return region;
@@ -410,8 +76,21 @@ export async function captureVisualScreenshot(
         cdp.getAttachmentId?.(candidate.document.target.tabId) !== candidate.document.attachmentId
       )
         return stale("visual attachment changed");
-      const identityError = await verifyCapturedTarget(cdp, candidate, signal);
-      if (identityError) return identityError;
+      let after: VisualTargetState | RpcError;
+      try {
+        after = await resolveVisualRegionNow(cdp, candidate, signal, true);
+      } catch (error) {
+        throwIfAborted(signal);
+        if (isAbortError(error)) throw error;
+        after = stale("post-capture mapping unavailable");
+      }
+      if ("code" in after) {
+        // Preserve PR7 viewing behavior when geometry became unsupported, but never
+        // return an image whose identity could not be confirmed.
+        const identityError = await verifyCapturedTarget(cdp, candidate, signal);
+        if (identityError) return identityError;
+      }
+      const mapping = !("code" in after) && sameVisualMapping(region, after) ? region : undefined;
       const dims = shot.data ? parsePngDimensions(shot.data) : null;
       if (!dims)
         return rpcError(
@@ -420,7 +99,17 @@ export async function captureVisualScreenshot(
           "visual screenshot returned invalid PNG dimensions",
         );
       const correction = visualScreenshotScale(dims.width, dims.height, 1);
-      if (correction === 1) return { image_base64: shot.data!, ...dims };
+      if (correction === 1)
+        return {
+          image_base64: shot.data!,
+          ...dims,
+          ...(mapping
+            ? { mapping }
+            : {
+                capture_unavailable:
+                  "visual mapping changed during capture; observe and screenshot again",
+              }),
+        };
       scale *= correction * 0.99;
     }
     return rpcError(

--- a/apps/extension/src/tools/visual-target.ts
+++ b/apps/extension/src/tools/visual-target.ts
@@ -1,0 +1,473 @@
+import type { CdpFrame } from "@/browser-driver/frame-graph";
+import type { RpcError } from "@/transport/types";
+import { rpcError } from "./errors";
+import {
+  type GeometryProjection,
+  projectRectToViewport,
+  type Size,
+  type ViewportRect,
+} from "./geometry";
+import { type CssViewport } from "./geometry/coordinate-types";
+import { cssViewport, GeometryContext } from "./geometry/frame-context";
+import { type CdpRunner, sendToCdpTarget } from "./shared";
+import { isAbortError, throwIfAborted } from "./vom/capture-abort";
+import { resolveVerifiedNode } from "./vom/document-identity";
+import type { DocumentIdentity } from "./vom/facts";
+import { VISUAL_STYLES } from "./vom/snapshot";
+import type { VisualCandidate, VisualFramePath } from "./vom/visual-discovery";
+import {
+  EMPTY_VISUAL_CONTEXT,
+  extendVisualContext,
+  projectVisualBox,
+  resolveVisualRegion,
+  type VisualClipSource,
+  type VisualContext,
+  visualProjectionIssue,
+} from "./vom/visual-region";
+
+interface LiveRow {
+  node: number;
+  tag: string;
+  box: ViewportRect;
+  client: ViewportRect;
+  contentSize: Size;
+  styles: Record<string, string>;
+}
+interface LiveFrame {
+  top: boolean;
+  dpr: number;
+  scrollX?: number;
+  scrollY?: number;
+  width?: number;
+  height?: number;
+  rows: LiveRow[]; // Anchor first, root last.
+}
+
+// Read only one current ancestry, including shadow hosts, in the verified isolated world.
+const READ_ANCESTRY = `function(styleNames) {
+  if (!this.isConnected || this.ownerDocument !== document) return null;
+  const rows = [];
+  for (let node = this; node; node = node.parentElement || node.getRootNode().host) {
+    if (!(node instanceof Element)) return null;
+    const s = getComputedStyle(node), r = node.getBoundingClientRect();
+    rows.push({ node, tag: node.localName,
+      box: { x:r.x, y:r.y, width:r.width, height:r.height },
+      client: { x:r.x+node.clientLeft, y:r.y+node.clientTop, width:node.clientWidth, height:node.clientHeight },
+      contentSize: { width:node.clientWidth-parseFloat(s.paddingLeft)-parseFloat(s.paddingRight), height:node.clientHeight-parseFloat(s.paddingTop)-parseFloat(s.paddingBottom) },
+      styles: Object.fromEntries(styleNames.map(key => [key,s.getPropertyValue(key)])) });
+  }
+  return { top: window === window.top, dpr: devicePixelRatio, scrollX, scrollY, width: innerWidth, height: innerHeight, rows };
+}`;
+
+interface DeepValue {
+  type: string;
+  value?: unknown;
+}
+/** This read returns JSON primitives plus DOM nodes (backend IDs), never remote object handles. */
+function decode(value: DeepValue): unknown {
+  if (value.type === "node") return (value.value as { backendNodeId?: number })?.backendNodeId;
+  if (value.type === "array") return (value.value as DeepValue[]).map(decode);
+  if (value.type === "object")
+    return Object.fromEntries(
+      (value.value as [string, DeepValue][]).map(([key, item]) => [key, decode(item)]),
+    );
+  if (value.type === "null") return null;
+  if (["string", "number", "boolean"].includes(value.type)) return value.value;
+  throw new Error("unexpected live ancestry serialization");
+}
+
+function stale(message: string): RpcError {
+  return rpcError(
+    "not_found",
+    "visual_target_changed",
+    `${message}; observe again before requesting a screenshot`,
+  );
+}
+
+export function sameIdentity(a: DocumentIdentity, b: DocumentIdentity): boolean {
+  return (
+    a.attachmentId === b.attachmentId &&
+    a.frameId === b.frameId &&
+    a.target.tabId === b.target.tabId &&
+    a.target.sessionId === b.target.sessionId &&
+    a.documentElementBackendNodeId === b.documentElementBackendNodeId
+  );
+}
+
+function closeRect(a: ViewportRect, b: ViewportRect): boolean {
+  return [
+    a.x - b.x,
+    a.y - b.y,
+    a.x + a.width - b.x - b.width,
+    a.y + a.height - b.y - b.height,
+  ].every((delta) => Number.isFinite(delta) && Math.abs(delta) <= 0.25);
+}
+
+function sameClips(a?: VisualClipSource, b?: VisualClipSource): boolean {
+  while (a && b) {
+    if (
+      !sameIdentity(a.document, b.document) ||
+      a.backendNodeId !== b.backendNodeId ||
+      a.x !== b.x ||
+      a.y !== b.y ||
+      a.overflowX !== b.overflowX ||
+      a.overflowY !== b.overflowY ||
+      !closeRect(a.box, b.box)
+    )
+      return false;
+    a = a.parent;
+    b = b.parent;
+  }
+  return !a && !b;
+}
+
+async function readFrame(
+  cdp: CdpRunner,
+  document: DocumentIdentity,
+  anchor: number,
+  signal?: AbortSignal,
+): Promise<LiveFrame | RpcError> {
+  const verified = await resolveVerifiedNode(cdp, document, anchor, signal);
+  if (verified.status !== "current") return stale(`visual DOM identity ${verified.status}`);
+  try {
+    throwIfAborted(signal);
+    const reply = await sendToCdpTarget<{
+      result?: { deepSerializedValue?: DeepValue };
+      exceptionDetails?: unknown;
+    }>(cdp, document.target, "Runtime.callFunctionOn", {
+      objectId: verified.objectId,
+      objectGroup: verified.objectGroup,
+      functionDeclaration: READ_ANCESTRY,
+      arguments: [{ value: VISUAL_STYLES }],
+      serializationOptions: {
+        serialization: "deep",
+        additionalParameters: { maxNodeDepth: 0, includeShadowTree: "none" },
+      },
+    });
+    throwIfAborted(signal);
+    if (reply.exceptionDetails || !reply.result?.deepSerializedValue)
+      return stale("visual ancestry unavailable");
+    const result = decode(reply.result.deepSerializedValue) as LiveFrame | null;
+    if (
+      !result?.rows?.length ||
+      result.rows[0].node !== anchor ||
+      result.rows.at(-1)?.node !== document.documentElementBackendNodeId ||
+      !result.rows.every((row) => Number.isSafeInteger(row.node) && row.node > 0)
+    )
+      return stale("visual ancestry incomplete");
+    if (cdp.getAttachmentId?.(document.target.tabId) !== document.attachmentId)
+      return stale("visual attachment changed");
+    return result;
+  } finally {
+    await sendToCdpTarget(cdp, document.target, "Runtime.releaseObjectGroup", {
+      objectGroup: verified.objectGroup,
+    }).catch(() => {});
+    throwIfAborted(signal);
+  }
+}
+
+/** All live reads for one screenshot use this one measurement context. */
+export async function resolveVisualRegionNow(
+  cdp: CdpRunner,
+  candidate: VisualCandidate,
+  signal?: AbortSignal,
+  allowGeometryChange = false,
+): Promise<VisualTargetState | RpcError> {
+  throwIfAborted(signal);
+  if (!candidate.framePath || !sameIdentity(candidate.document, candidate.framePath.document))
+    return stale("visual frame path unavailable");
+  const path: { frame: VisualFramePath; anchor: number }[] = [];
+  const seen = new Set<string>();
+  let frame: VisualFramePath | undefined = candidate.framePath;
+  let anchor = candidate.backendNodeId;
+  while (frame) {
+    if (
+      seen.has(frame.document.frameId) ||
+      frame.document.target.tabId !== candidate.document.target.tabId ||
+      cdp.getAttachmentId?.(frame.document.target.tabId) !== frame.document.attachmentId
+    )
+      return stale("invalid visual frame path");
+    seen.add(frame.document.frameId);
+    path.push({ frame, anchor });
+    anchor = frame.parent?.ownerBackendNodeId ?? 0;
+    frame = frame.parent?.frame;
+  }
+  path.reverse();
+  const frames: CdpFrame[] = path.map(({ frame }) => ({
+    frameId: frame.document.frameId,
+    target: frame.document.target,
+    ...(frame.parent
+      ? {
+          parentFrameId: frame.parent.frame.document.frameId,
+          ownerBackendNodeId: frame.parent.ownerBackendNodeId,
+        }
+      : {}),
+  }));
+  // Validate each recorded edge instead of asking the driver to fill all page owners.
+  for (const { frame } of path) {
+    if (!frame.parent) continue;
+    throwIfAborted(signal);
+    const owner = await sendToCdpTarget<{ backendNodeId?: number }>(
+      cdp,
+      frame.parent.frame.document.target,
+      "DOM.getFrameOwner",
+      { frameId: frame.document.frameId },
+    );
+    if (owner.backendNodeId !== frame.parent.ownerBackendNodeId)
+      return stale("visual frame owner changed");
+  }
+  const geometry = new GeometryContext(
+    cdp,
+    candidate.document.target.tabId,
+    { rootFrameId: frames[0].frameId, frames },
+    signal,
+  );
+  let context: VisualContext = EMPTY_VISUAL_CONTEXT;
+  let parentRead: LiveFrame | undefined;
+  let finalRegion: VisualCandidate["region"] | undefined;
+  let topDpr = 0;
+  const mappings: VisualTargetState["mappings"] = [];
+  for (let i = 0; i < path.length; i++) {
+    const { frame, anchor } = path[i];
+    const live = await readFrame(cdp, frame.document, anchor, signal);
+    if ("code" in live) return live;
+    if (live.top !== (i === 0)) return stale("visual root frame changed");
+    if (i === 0) topDpr = live.dpr;
+    const metrics = await geometry.layoutMetrics(frame.document.target);
+    const viewport = cssViewport(metrics);
+    const projections: GeometryProjection[] = [];
+    if (frame.parent) {
+      const parent = frame.parent.frame.document;
+      const size = parentRead!.rows[0].contentSize;
+      if (![size.width, size.height].every((n) => Number.isFinite(n) && n > 0))
+        return stale("iframe content size unavailable");
+      const parentViewport = await geometry.viewport(parent.target);
+      if (!parentViewport) return stale("parent viewport unavailable");
+      const local = await geometry.snapshotProjection(
+        { target: parent.target, frameId: frame.document.frameId },
+        frame.parent.ownerBackendNodeId,
+        [],
+        parentViewport,
+        size,
+      );
+      const outer = await geometry.targetProjection(parent.frameId);
+      if (local.status !== "available" || !outer)
+        return stale("visual frame projection unavailable");
+      projections.push(local.projection.geometry, outer);
+    } else projections.push({ sourceClips: [], edges: [], topViewport: viewport });
+    const issue = visualProjectionIssue({
+      projections,
+      coordinates: { layoutUnitsPerCssPixel: 1, scrollCss: { x: 0, y: 0 } },
+      pageScale: metrics.cssVisualViewport?.scale ?? metrics.visualViewport?.scale,
+    });
+    if (issue) return stale(issue);
+    const unit = projectVisualBox({ x: 0, y: 0, width: 1, height: 1 }, projections);
+    if (!unit || !(unit.width > 0 && unit.height > 0)) return stale("visual mapping unavailable");
+    mappings.push({
+      document: frame.document,
+      anchor,
+      unit,
+      viewport: {
+        ...viewport,
+        scrollX: live.scrollX ?? viewport.scrollX,
+        scrollY: live.scrollY ?? viewport.scrollY,
+        width: live.width ?? viewport.width,
+        height: live.height ?? viewport.height,
+      },
+    });
+    for (let j = live.rows.length - 1; j >= 0; j--) {
+      const row = live.rows[j];
+      const isAnchor = j === 0;
+      const node = {
+        document: frame.document,
+        backendNodeId: row.node,
+        styles: row.styles,
+        clientBox: projectVisualBox(row.client, projections),
+      };
+      context = extendVisualContext(
+        context,
+        node,
+        !isAnchor && row.tag !== "iframe" && row.tag !== "frame",
+      );
+    }
+    if (i < path.length - 1) {
+      const owner = live.rows[0];
+      context = {
+        ...context,
+        hidden:
+          context.hidden ||
+          owner.styles.visibility === "hidden" ||
+          owner.styles.visibility === "collapse",
+        transformed: false,
+        localClip: false,
+        unpositionedClip: false,
+      };
+    } else {
+      const row = live.rows[0];
+      if (row.tag !== "canvas") return stale("visual anchor is no longer Canvas");
+      let visible: ViewportRect | null = row.box;
+      for (const projection of projections)
+        visible = visible
+          ? projectRectToViewport(
+              { x: visible.x, y: visible.y, w: visible.width, h: visible.height },
+              projection,
+            )
+          : null;
+      const region = resolveVisualRegion({
+        borderBox: projectVisualBox(row.box, projections),
+        frameVisibleBox: visible,
+        context,
+        visibility: row.styles.visibility,
+      });
+      if (region.status !== "available")
+        return stale(
+          `visual region ${region.status}${region.status === "unavailable" ? `: ${region.reason}` : ""}`,
+        );
+      finalRegion = region;
+    }
+    parentRead = live;
+  }
+  if (
+    !finalRegion ||
+    (!allowGeometryChange &&
+      (!closeRect(candidate.region.borderBox, finalRegion.borderBox) ||
+        !closeRect(candidate.region.crop, finalRegion.crop) ||
+        !sameClips(candidate.region.clips, finalRegion.clips)))
+  )
+    return stale("visual region changed");
+  const viewport = cssViewport(await geometry.layoutMetrics(frames[0].target));
+  return { crop: finalRegion.crop, region: finalRegion, viewport, dpr: topDpr, mappings };
+}
+
+/** Check identity only: repainting and post-capture layout changes are allowed. */
+export async function verifyCapturedTarget(
+  cdp: CdpRunner,
+  candidate: VisualCandidate,
+  signal?: AbortSignal,
+): Promise<RpcError | null> {
+  try {
+    let frame = candidate.framePath;
+    let anchor = candidate.backendNodeId;
+    // The path was validated before capture; never rebuild it from the current page.
+    while (frame) {
+      const verified = await resolveVerifiedNode(cdp, frame.document, anchor, signal);
+      if (verified.status !== "current") return stale(`visual DOM identity ${verified.status}`);
+      await sendToCdpTarget(cdp, frame.document.target, "Runtime.releaseObjectGroup", {
+        objectGroup: verified.objectGroup,
+      }).catch(() => {});
+      throwIfAborted(signal);
+      if (frame.parent) {
+        const owner = await sendToCdpTarget<{ backendNodeId?: number }>(
+          cdp,
+          frame.parent.frame.document.target,
+          "DOM.getFrameOwner",
+          { frameId: frame.document.frameId },
+        );
+        throwIfAborted(signal);
+        if (owner.backendNodeId !== frame.parent.ownerBackendNodeId)
+          return stale("visual frame owner changed");
+        anchor = frame.parent.ownerBackendNodeId;
+      }
+      frame = frame.parent?.frame;
+    }
+    throwIfAborted(signal);
+    return cdp.getAttachmentId?.(candidate.document.target.tabId) ===
+      candidate.document.attachmentId
+      ? null
+      : stale("visual attachment changed");
+  } catch (error) {
+    throwIfAborted(signal);
+    if (isAbortError(error)) throw error;
+    return stale("visual identity unavailable after capture");
+  }
+}
+
+export interface VisualTargetState {
+  crop: ViewportRect;
+  region: VisualCandidate["region"];
+  viewport: CssViewport;
+  dpr: number;
+  mappings: {
+    document: DocumentIdentity;
+    anchor: number;
+    unit: ViewportRect;
+    viewport: CssViewport;
+  }[];
+}
+function sameViewport(a: CssViewport, b: CssViewport): boolean {
+  return (
+    a.width === b.width &&
+    a.height === b.height &&
+    a.scrollX === b.scrollX &&
+    a.scrollY === b.scrollY &&
+    a.cssToDip === b.cssToDip
+  );
+}
+export function sameVisualMapping(a: VisualTargetState, b: VisualTargetState): boolean {
+  return (
+    a.dpr === b.dpr &&
+    sameViewport(a.viewport, b.viewport) &&
+    closeRect(a.crop, b.crop) &&
+    closeRect(a.region.borderBox, b.region.borderBox) &&
+    sameClips(a.region.clips, b.region.clips) &&
+    a.mappings.length === b.mappings.length &&
+    a.mappings.every((m, i) => {
+      const n = b.mappings[i];
+      return (
+        m.anchor === n.anchor &&
+        sameIdentity(m.document, n.document) &&
+        closeRect(m.unit, n.unit) &&
+        Math.abs(m.unit.width - n.unit.width) < 1e-6 &&
+        Math.abs(m.unit.height - n.unit.height) < 1e-6 &&
+        sameViewport(m.viewport, n.viewport)
+      );
+    })
+  );
+}
+/** Browser hit testing follows each verified frame, including open shadow roots. */
+export async function verifyVisualHit(
+  cdp: CdpRunner,
+  state: VisualTargetState,
+  point: { x: number; y: number },
+  signal?: AbortSignal,
+): Promise<boolean> {
+  for (const mapping of state.mappings) {
+    throwIfAborted(signal);
+    const { unit, document, anchor } = mapping;
+    if (!(unit.width > 0 && unit.height > 0)) return false;
+    const verified = await resolveVerifiedNode(cdp, document, anchor, signal);
+    if (verified.status !== "current") return false;
+    try {
+      const result = await sendToCdpTarget<{
+        result?: { value?: boolean };
+        exceptionDetails?: unknown;
+      }>(cdp, document.target, "Runtime.callFunctionOn", {
+        objectId: verified.objectId,
+        objectGroup: verified.objectGroup,
+        functionDeclaration: `function(x,y) {
+          if (!this.isConnected || this.ownerDocument !== document) return false;
+          for(let n=this;n;n=n.parentElement || n.getRootNode().host) if(n.inert) return false;
+          let hit=document.elementFromPoint(x,y);
+          while(hit && hit.shadowRoot) {
+            const inner=hit.shadowRoot.elementFromPoint(x,y);
+            if(!inner || inner===hit) break;
+            hit=inner;
+          }
+          return hit===this;
+        }`,
+        arguments: [
+          { value: (point.x - unit.x) / unit.width },
+          { value: (point.y - unit.y) / unit.height },
+        ],
+        returnByValue: true,
+      });
+      if (result.exceptionDetails || result.result?.value !== true) return false;
+    } finally {
+      await sendToCdpTarget(cdp, document.target, "Runtime.releaseObjectGroup", {
+        objectGroup: verified.objectGroup,
+      }).catch(() => {});
+      throwIfAborted(signal);
+    }
+  }
+  return true;
+}

--- a/apps/extension/src/tools/visual-target.ts
+++ b/apps/extension/src/tools/visual-target.ts
@@ -424,7 +424,7 @@ export function sameVisualMapping(a: VisualTargetState, b: VisualTargetState): b
     })
   );
 }
-/** Browser hit testing follows each verified frame, including open shadow roots. */
+/** Browser hit testing follows each verified frame, including open and closed shadow roots. */
 export async function verifyVisualHit(
   cdp: CdpRunner,
   state: VisualTargetState,
@@ -447,13 +447,17 @@ export async function verifyVisualHit(
         functionDeclaration: `function(x,y) {
           if (!this.isConnected || this.ownerDocument !== document) return false;
           for(let n=this;n;n=n.parentElement || n.getRootNode().host) if(n.inert) return false;
-          let hit=document.elementFromPoint(x,y);
-          while(hit && hit.shadowRoot) {
-            const inner=hit.shadowRoot.elementFromPoint(x,y);
-            if(!inner || inner===hit) break;
-            hit=inner;
+          // Resolve roots from the verified target; closed hosts expose no shadowRoot.
+          const path=[];
+          for(let node=this;node;) {
+            const root=node.getRootNode();
+            path.push({root,node});
+            if(root===document) break;
+            if(!root.host) return false;
+            node=root.host;
           }
-          return hit===this;
+          // Check every outer scope as well, so internal hits cannot bypass an overlay.
+          return path.reverse().every(({root,node}) => root.elementFromPoint(x,y)===node);
         }`,
         arguments: [
           { value: (point.x - unit.x) / unit.width },

--- a/apps/extension/src/transport/types.ts
+++ b/apps/extension/src/transport/types.ts
@@ -25,6 +25,9 @@ export type RpcErrorReason =
   | "element_not_visible"
   | "ref_not_found"
   | "ref_kind_unsupported"
+  | "visual_capture_stale"
+  | "visual_capture_invalid"
+  | "visual_coordinate_invalid"
   | "visual_target_changed"
   | "visual_pixel_budget_exceeded"
   | "selector_not_found"
@@ -320,6 +323,8 @@ export interface ScreenshotParams {
 }
 
 export interface ScreenshotResult {
+  capture_id?: string;
+  capture_unavailable?: string;
   image_base64: string;
   width: number;
   height: number;
@@ -440,6 +445,9 @@ export type MouseButton = "left" | "middle" | "right";
 export type KeyModifier = "alt" | "ctrl" | "meta" | "shift";
 
 export interface ClickParams {
+  capture_id?: string;
+  image_x?: number;
+  image_y?: number;
   session_id: string;
   ref?: string;
   selector?: string;

--- a/crates/bsk-cli/skill/SKILL.md
+++ b/crates/bsk-cli/skill/SKILL.md
@@ -120,7 +120,8 @@ needed, obtain a fresh observation before acting on screenshot or HTML findings.
 
 `observe` may place `@eN canvas [visual:screenshot]` near related page controls. Names are
 optional: do not infer a table title or controls inside Canvas from adjacent labels. Visual refs
-support `screenshot --ref`, not click/fill/hover or HTML extraction. First observe returns text,
+support `screenshot --ref`; point clicks additionally require its `capture_id` and image coordinates.
+They do not support fill/hover or HTML extraction. First observe returns text,
 not an image. Use the surrounding semantics to decide whether a Canvas screenshot is needed.
 If you cannot receive and understand images in this session, tell the user the Canvas contents
 cannot be interpreted and ask them to switch to an image-capable model; continue with available
@@ -135,6 +136,17 @@ Continuation reads the same captured observation; it does not refresh or hover t
 combine it with depth changes or hover probing. A new observe/snapshot replaces the continuation;
 if the page identity changed, observe again. Screenshot execution checks current target identity
 and geometry, but permits Canvas repainting and does not freeze pixels.
+
+A Canvas screenshot can return `capture_id`. To click a point you identified in that image, use
+`bsk click eN --capture <id> --image-x <x> --image-y <y> --session <id>`.
+Use original PNG pixels (returned width/height), not resized display or viewport coordinates.
+Captures are single-use, expire after two minutes, and are invalidated by a newer screenshot of
+that ref or observation/continuation. With `capture_unavailable`, view the image but observe and
+screenshot again before clicking. Click counts 1/2, buttons and modifiers are supported.
+After clicking, observe or screenshot to verify the result; use DOM refs for revealed controls.
+A completed click does not prove business success. Canvas repainting is allowed; changed identity,
+geometry or hit target is rejected. If `effect_state=unknown`, inspect before retrying with a new
+capture. Do not infer cell-editing, IME, drag or hover support from point-click capability.
 
 ## Respect the Agent Window boundary
 

--- a/crates/bsk-cli/src/cli/interaction.rs
+++ b/crates/bsk-cli/src/cli/interaction.rs
@@ -103,6 +103,15 @@ pub(crate) fn split_target(
 
 #[derive(Debug, Clone, Args)]
 pub struct ClickArgs {
+    /// Bind a Canvas point click to the image returned by screenshot --ref.
+    #[arg(long = "capture", requires_all = ["image_x", "image_y"], conflicts_with = "selector")]
+    pub capture_id: Option<String>,
+    /// X coordinate in the original screenshot PNG, not viewport CSS pixels.
+    #[arg(long, requires = "capture_id")]
+    pub image_x: Option<f64>,
+    /// Y coordinate in the original screenshot PNG.
+    #[arg(long, requires = "capture_id")]
+    pub image_y: Option<f64>,
     /// Snapshot ref (`@e3`, `e3`) or CSS selector. Optional when `--ref`/`--selector` is used.
     pub target: Option<String>,
 
@@ -150,6 +159,9 @@ pub fn dispatch_click(args: ClickArgs, format: Format) -> Result<(), CliError> {
     let modifiers = parse_modifiers(&args.modifiers)
         .map_err(|e| CliError::Local(anyhow::anyhow!("--modifiers: {e}")))?;
     let params = ClickParams {
+        capture_id: args.capture_id.clone(),
+        image_x: args.image_x,
+        image_y: args.image_y,
         session_id: args.session.clone(),
         ref_,
         selector,

--- a/crates/bsk-cli/src/cli/render_error.rs
+++ b/crates/bsk-cli/src/cli/render_error.rs
@@ -250,6 +250,22 @@ pub fn info_for_error(code: ErrorCode, data: Option<&serde_json::Value>) -> Rend
             ),
             exit_code: base.exit_code,
         },
+        (ErrorCode::NotFound, "visual_capture_stale") => RenderInfo {
+            summary: "Canvas screenshot capture is no longer usable",
+            hint: Some(
+                "run `bsk observe`, screenshot the current Canvas ref, and use its new capture_id",
+            ),
+            exit_code: base.exit_code,
+        },
+        (ErrorCode::InvalidParams, "visual_capture_invalid" | "visual_coordinate_invalid") => {
+            RenderInfo {
+                summary: "invalid screenshot-bound Canvas click",
+                hint: Some(
+                    "provide a visual ref, --capture, --image-x and --image-y in the original PNG dimensions",
+                ),
+                exit_code: base.exit_code,
+            }
+        }
         (ErrorCode::NotFound, reason::VISUAL_TARGET_CHANGED) => RenderInfo {
             summary: "visual target needs a fresh observation",
             hint: Some(

--- a/crates/bsk-cli/src/cli/screenshot.rs
+++ b/crates/bsk-cli/src/cli/screenshot.rs
@@ -60,7 +60,7 @@ fn run(sock: PathBuf, args: ScreenshotArgs, format: Format) -> Result<(), CliErr
         .map_err(CliError::Local)?;
     match format {
         Format::Json => {
-            let json = serde_json::json!({
+            let mut json = serde_json::json!({
                 "tab_id": reply.tab_id,
                 "width": reply.width,
                 "height": reply.height,
@@ -68,6 +68,12 @@ fn run(sock: PathBuf, args: ScreenshotArgs, format: Format) -> Result<(), CliErr
                 "path": out_path.to_string_lossy(),
                 "byte_size": bytes.len(),
             });
+            if let Some(id) = &reply.capture_id {
+                json["capture_id"] = serde_json::json!(id);
+            }
+            if let Some(reason) = &reply.capture_unavailable {
+                json["capture_unavailable"] = serde_json::json!(reason);
+            }
             println!(
                 "{}",
                 serde_json::to_string_pretty(&json)
@@ -76,6 +82,15 @@ fn run(sock: PathBuf, args: ScreenshotArgs, format: Format) -> Result<(), CliErr
         }
         Format::Human => {
             println!("{}", out_path.display());
+            if let Some(id) = &reply.capture_id {
+                println!(
+                    "capture: {id} ({}x{} original PNG pixels; single use)",
+                    reply.width, reply.height
+                );
+            }
+            if let Some(reason) = &reply.capture_unavailable {
+                println!("capture unavailable: {reason}");
+            }
             print_dialog_summaries(&reply.dialogs);
         }
     }

--- a/crates/bsk-cli/tests/cli_parse.rs
+++ b/crates/bsk-cli/tests/cli_parse.rs
@@ -715,3 +715,35 @@ fn rejects_invalid_wheel_numbers_and_timeouts() {
         assert!(Cli::try_parse_from(argv).is_err());
     }
 }
+
+#[test]
+fn canvas_click_requires_complete_capture_coordinates() {
+    let cli = parse(&[
+        "bsk",
+        "click",
+        "e1",
+        "--session",
+        "test",
+        "--capture",
+        "image",
+        "--image-x",
+        "12.5",
+        "--image-y",
+        "20",
+    ]);
+    let Command::Click(args) = cli.command else {
+        panic!("expected click")
+    };
+    assert_eq!(args.capture_id.as_deref(), Some("image"));
+    assert_eq!(args.image_x, Some(12.5));
+    assert_eq!(args.image_y, Some(20.0));
+    for extra in [
+        vec!["--capture", "image"],
+        vec!["--image-x", "12"],
+        vec!["--capture", "image", "--image-x", "12"],
+    ] {
+        let mut argv = vec!["bsk", "click", "e1", "--session", "test"];
+        argv.extend(extra);
+        assert!(Cli::try_parse_from(argv).is_err());
+    }
+}

--- a/crates/bsk-cli/tests/tools_ipc.rs
+++ b/crates/bsk-cli/tests/tools_ipc.rs
@@ -233,6 +233,8 @@ async fn screenshot_returns_image_base64_with_dimensions() {
         let _: ScreenshotParams = serde_json::from_value(req.params.clone().unwrap()).unwrap();
         ResponseBody::Ok(
             serde_json::to_value(ScreenshotResult {
+                capture_id: None,
+                capture_unavailable: None,
                 image_base64: "iVBORw0KGgo=".into(),
                 width: 800,
                 height: 600,
@@ -281,6 +283,8 @@ async fn screenshot_forwards_ref_to_extension() {
         assert_eq!(params.ref_.as_deref(), Some("@e5"));
         ResponseBody::Ok(
             serde_json::to_value(ScreenshotResult {
+                capture_id: Some("capture-test".into()),
+                capture_unavailable: None,
                 image_base64: "iVBORw0KGgo=".into(),
                 width: 100,
                 height: 60,
@@ -304,6 +308,7 @@ async fn screenshot_forwards_ref_to_extension() {
     )
     .await
     .expect("screenshot with ref ok");
+    assert_eq!(result.capture_id.as_deref(), Some("capture-test"));
     assert_eq!(result.width, 100);
     assert_eq!(result.height, 60);
     handle.shutdown().await;

--- a/crates/bsk-cli/tests/tools_m7_ipc.rs
+++ b/crates/bsk-cli/tests/tools_m7_ipc.rs
@@ -343,6 +343,9 @@ async fn click_round_trips_ref_and_modifiers() {
         }
         let p: ClickParams = serde_json::from_value(params).unwrap();
         assert_eq!(p.ref_.as_deref(), Some("@e3"));
+        assert_eq!(p.capture_id.as_deref(), Some("capture-test"));
+        assert_eq!(p.image_x, Some(12.5));
+        assert_eq!(p.image_y, Some(34.0));
         assert_eq!(p.button, Some(MouseButton::Right));
         assert_eq!(
             p.modifiers,
@@ -366,6 +369,9 @@ async fn click_round_trips_ref_and_modifiers() {
         &sock,
         Method::ToolClick,
         ClickParams {
+            capture_id: Some("capture-test".into()),
+            image_x: Some(12.5),
+            image_y: Some(34.0),
             session_id,
             ref_: Some("@e3".into()),
             selector: None,
@@ -734,6 +740,9 @@ async fn m7_tools_propagate_extension_errors() {
         &sock,
         Method::ToolClick,
         ClickParams {
+            capture_id: None,
+            image_x: None,
+            image_y: None,
             session_id: session_id.clone(),
             ref_: Some("@e1".into()),
             selector: None,

--- a/crates/bsk-protocol/schema/tool_click_params.json
+++ b/crates/bsk-protocol/schema/tool_click_params.json
@@ -16,6 +16,13 @@
         }
       ]
     },
+    "capture_id": {
+      "description": "Single-use capture returned by a visual-ref screenshot; requires image coordinates.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "click_count": {
       "description": "Number of consecutive mouse presses (double-click = 2).",
       "type": [
@@ -24,6 +31,20 @@
       ],
       "format": "uint32",
       "minimum": 1.0
+    },
+    "image_x": {
+      "type": [
+        "number",
+        "null"
+      ],
+      "format": "double"
+    },
+    "image_y": {
+      "type": [
+        "number",
+        "null"
+      ],
+      "format": "double"
     },
     "modifiers": {
       "type": [

--- a/crates/bsk-protocol/schema/tool_screenshot_result.json
+++ b/crates/bsk-protocol/schema/tool_screenshot_result.json
@@ -8,6 +8,20 @@
     "tab_id"
   ],
   "properties": {
+    "capture_id": {
+      "description": "Single-use visual point-click capture, in the original PNG coordinate space.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "capture_unavailable": {
+      "description": "Image remains viewable but cannot authorize a point click.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "dialogs": {
       "type": "array",
       "items": {

--- a/crates/bsk-protocol/src/tools/interaction.rs
+++ b/crates/bsk-protocol/src/tools/interaction.rs
@@ -40,6 +40,13 @@ pub enum MouseButton {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 pub struct ClickParams {
+    /// Single-use capture returned by a visual-ref screenshot; requires image coordinates.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub capture_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub image_x: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub image_y: Option<f64>,
     pub session_id: String,
     /// Optional `@e<N>` ref allocated by the last `tool.snapshot`.
     /// Mutually exclusive with `selector` (caller must supply exactly
@@ -356,6 +363,9 @@ mod tests {
     #[test]
     fn click_params_serialise_ref_field_name() {
         let p = ClickParams {
+            capture_id: None,
+            image_x: None,
+            image_y: None,
             session_id: "abcd".into(),
             ref_: Some("@e3".into()),
             selector: None,

--- a/crates/bsk-protocol/src/tools/observation.rs
+++ b/crates/bsk-protocol/src/tools/observation.rs
@@ -226,6 +226,12 @@ pub struct ScreenshotParams {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 pub struct ScreenshotResult {
+    /// Single-use visual point-click capture, in the original PNG coordinate space.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub capture_id: Option<String>,
+    /// Image remains viewable but cannot authorize a point click.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub capture_unavailable: Option<String>,
     /// Base64-encoded PNG payload (no `data:` prefix).
     pub image_base64: String,
     /// Pixel width parsed from the PNG IHDR. May be `0` when parsing
@@ -319,6 +325,8 @@ mod tests {
     #[test]
     fn screenshot_result_round_trips_with_image_fields() {
         let r = ScreenshotResult {
+            capture_id: None,
+            capture_unavailable: None,
             image_base64: "iVBORw0KGgo=".into(),
             width: 800,
             height: 600,

--- a/packages/dsh-plugin-browserskill/skill/SKILL.md
+++ b/packages/dsh-plugin-browserskill/skill/SKILL.md
@@ -113,15 +113,16 @@ Continue from returned sequence cursors instead of rereading the same buffer.
 Arbitrary page-script evaluation and interaction recording are intentionally unsupported. Do not
 invent tools or route around those limits.
 
-## Canvas and continued observations
+## Canvas and continuation
 
-`@eN canvas [visual:screenshot]` supports only `browser_inspect` action=screenshot with that
-ref. Names are optional; do not invent Canvas contents from nearby controls. First observe
-returns text. If you cannot understand images, tell the user to switch to an image-capable
-model and continue with available semantics; BrowserSkill does not detect model capabilities.
+[visual:screenshot] means screenshot that ref first; names are optional, not inferred from
+nearby controls. If needed images cannot be understood, ask to switch models and use semantics.
+Click via browser_interact(action=click,target=ref,captureId=...,imageX=...,imageY=...), using
+ORIGINAL PNG pixels. Captures are single-use, last two minutes, and expire on ref replacement
+or a new screenshot of that ref. captureUnavailable means view only; observe and screenshot
+again. Counts 1/2 and buttons/modifiers work, not Canvas fill/IME/drag/hover. Repainting is allowed:
+verify results; use DOM refs for revealed controls. Inspect before retrying effect_state=unknown.
 
-No token cap applies by default. With explicit maxTokens, follow nextCursor using
-browser_inspect action=observe and cursor. Use current refs first: each response replaces
-previous refs and may contain many Canvas entries. Continuation reads the same observation,
-without recapture; do not change depth. New observe/snapshot or DOM identity changes invalidate
-it. Use fresh observe for updated content.
+No default token cap. With maxTokens, follow nextCursor via observe(cursor=...); each page can
+contain many Canvas refs and replaces previous refs. This reads the same observation without
+recapture or depth changes. New observe/snapshot or DOM identity changes invalidate continuation.

--- a/packages/dsh-plugin-browserskill/src/browser-tools.ts
+++ b/packages/dsh-plugin-browserskill/src/browser-tools.ts
@@ -190,7 +190,16 @@ const BROWSER_TOOL_SPECS: BrowserToolSpec[] = [
       tabId: TAB_ID_PARAM,
       target: TARGET_PARAM,
       button: { type: "string", enum: ["left", "middle", "right"], description: "Click button." },
-      clickCount: { type: "integer", description: "Click count." },
+      clickCount: { type: "integer", description: "Click count; Canvas accepts 1 or 2." },
+      captureId: { type: "string", description: "Single-use Canvas screenshot capture for click." },
+      imageX: {
+        type: "number",
+        description: "Click X in original PNG pixels; requires captureId/imageY.",
+      },
+      imageY: {
+        type: "number",
+        description: "Click Y in original PNG pixels; requires captureId/imageX.",
+      },
       value: { type: "string", description: "Text for fill." },
       noClear: { type: "boolean", description: "Append instead of clearing for fill." },
       modifiers: {

--- a/packages/dsh-plugin-browserskill/src/tools.ts
+++ b/packages/dsh-plugin-browserskill/src/tools.ts
@@ -585,6 +585,16 @@ function defineBrowserOperations(deps: ToolDeps, register: DefinitionRegistrar):
           description: "Snapshot ref (@e3 / e3) or CSS selector of the element to click.",
         },
         session: SESSION_PARAM,
+        captureId: {
+          type: "string",
+          description: "Single-use capture from a Canvas screenshot; requires imageX/imageY.",
+        },
+        imageX: { type: "number", description: "X in the original screenshot PNG pixels." },
+        imageY: { type: "number", description: "Y in the original screenshot PNG pixels." },
+        modifiers: {
+          type: "array",
+          items: { type: "string", enum: ["alt", "ctrl", "meta", "shift"] },
+        },
         button: {
           type: "string",
           enum: ["left", "middle", "right"],
@@ -619,6 +629,23 @@ function defineBrowserOperations(deps: ToolDeps, register: DefinitionRegistrar):
         const cmdArgs = ["click", "--session", sessionId];
         if (args.button !== undefined) cmdArgs.push("--button", args.button);
         if (args.clickCount !== undefined) cmdArgs.push("--click-count", String(args.clickCount));
+        if (
+          args.captureId !== undefined ||
+          args.imageX !== undefined ||
+          args.imageY !== undefined
+        ) {
+          if (!args.captureId || !Number.isFinite(args.imageX) || !Number.isFinite(args.imageY))
+            throw new Error("Canvas click requires captureId, imageX and imageY");
+          cmdArgs.push(
+            "--capture",
+            args.captureId,
+            "--image-x",
+            String(args.imageX),
+            "--image-y",
+            String(args.imageY),
+          );
+        }
+        if (args.modifiers?.length) cmdArgs.push("--modifiers", args.modifiers.join(","));
         cmdArgs.push(args.target);
         const reply = (await runBsk(deps, exec, cmdArgs, "click", sessionId)) as {
           tab_id: number;
@@ -789,6 +816,8 @@ function defineBrowserOperations(deps: ToolDeps, register: DefinitionRegistrar):
             width: { type: "integer", required: true },
             height: { type: "integer", required: true },
             byteSize: { type: "integer", required: true },
+            captureId: { type: "string" },
+            captureUnavailable: { type: "string" },
             image: {
               type: "object",
               additionalProperties: false,
@@ -812,7 +841,12 @@ function defineBrowserOperations(deps: ToolDeps, register: DefinitionRegistrar):
             value.image !== undefined
               ? `[session ${value.session}] screenshot of tab ${value.tabId} (${value.width}x${value.height}px)`
               : `[session ${value.session}] screenshot saved to ${value.path} (${value.width}x${value.height}px, ${value.byteSize} bytes) — this deployment cannot inline images; read the file to view it`;
-          const blocks: ContentBlock[] = [{ type: "text", text }];
+          const captureText = value.captureId
+            ? `; captureId=${value.captureId}, single-use click with original PNG imageX/imageY`
+            : value.captureUnavailable
+              ? `; capture unavailable: ${value.captureUnavailable}`
+              : "";
+          const blocks: ContentBlock[] = [{ type: "text", text: text + captureText }];
           if (value.image !== undefined) {
             blocks.push({
               type: "image",
@@ -851,6 +885,8 @@ function defineBrowserOperations(deps: ToolDeps, register: DefinitionRegistrar):
             height: number;
             path: string;
             byte_size: number;
+            capture_id?: string;
+            capture_unavailable?: string;
           };
           writtenPath = reply.path;
           const data = await readFile(reply.path);
@@ -864,6 +900,8 @@ function defineBrowserOperations(deps: ToolDeps, register: DefinitionRegistrar):
             width: reply.width,
             height: reply.height,
             byteSize: reply.byte_size,
+            ...(reply.capture_id ? { captureId: reply.capture_id } : {}),
+            ...(reply.capture_unavailable ? { captureUnavailable: reply.capture_unavailable } : {}),
             ...(ref !== undefined
               ? {
                   image: {

--- a/packages/dsh-plugin-browserskill/tests/tools.test.ts
+++ b/packages/dsh-plugin-browserskill/tests/tools.test.ts
@@ -1000,7 +1000,15 @@ describe("inspect.screenshot", () => {
     const path = pngFile();
     const { tools, calls } = setup({
       "session start": START_REPLY("s1"),
-      screenshot: { tab_id: 7, width: 800, height: 600, format: "png", path, byte_size: 8 },
+      screenshot: {
+        tab_id: 7,
+        width: 800,
+        height: 600,
+        format: "png",
+        path,
+        byte_size: 8,
+        capture_id: "capture-1",
+      },
     });
     await startSession(tools);
     const screenshot = tools.get("inspect.screenshot");
@@ -1009,10 +1017,12 @@ describe("inspect.screenshot", () => {
       image?: unknown;
     };
     expect(value.path).toBe(path);
+    expect(value).toHaveProperty("captureId", "capture-1");
     expect(value.image).toBeUndefined();
     expect(calls[1].args.slice(0, 3)).toEqual(["screenshot", "--session", "s1"]);
     expect(calls[1].args).toContain("--ref");
     const rendered = screenshot?.output.render({ session: "s1" }, value as never);
+    expect(JSON.stringify(rendered)).toContain("captureId=capture-1");
     expect(rendered?.every((block) => block.type === "text")).toBe(true);
   });
 
@@ -1498,4 +1508,32 @@ it("inspect.observe forwards continuation cursors and exposes the next cursor", 
     "100",
   ]);
   expect(value).toMatchObject({ nextCursor: "page-three", truncated: true });
+});
+
+it("forwards screenshot-bound Canvas coordinates to click", async () => {
+  const { tools, calls } = setup({
+    "session start": START_REPLY("s1"),
+    click: { tab_id: 7, x: 40, y: 50 },
+  });
+  await startSession(tools);
+  await tools
+    .get("interact.click")!
+    .execute(
+      { target: "e1", captureId: "capture", imageX: 20, imageY: 30, modifiers: ["shift"] },
+      makeExec(),
+    );
+  expect(calls.at(-1)!.args).toEqual([
+    "click",
+    "--session",
+    "s1",
+    "--capture",
+    "capture",
+    "--image-x",
+    "20",
+    "--image-y",
+    "30",
+    "--modifiers",
+    "shift",
+    "e1",
+  ]);
 });

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -120,7 +120,8 @@ needed, obtain a fresh observation before acting on screenshot or HTML findings.
 
 `observe` may place `@eN canvas [visual:screenshot]` near related page controls. Names are
 optional: do not infer a table title or controls inside Canvas from adjacent labels. Visual refs
-support `screenshot --ref`, not click/fill/hover or HTML extraction. First observe returns text,
+support `screenshot --ref`; point clicks additionally require its `capture_id` and image coordinates.
+They do not support fill/hover or HTML extraction. First observe returns text,
 not an image. Use the surrounding semantics to decide whether a Canvas screenshot is needed.
 If you cannot receive and understand images in this session, tell the user the Canvas contents
 cannot be interpreted and ask them to switch to an image-capable model; continue with available
@@ -135,6 +136,17 @@ Continuation reads the same captured observation; it does not refresh or hover t
 combine it with depth changes or hover probing. A new observe/snapshot replaces the continuation;
 if the page identity changed, observe again. Screenshot execution checks current target identity
 and geometry, but permits Canvas repainting and does not freeze pixels.
+
+A Canvas screenshot can return `capture_id`. To click a point you identified in that image, use
+`bsk click eN --capture <id> --image-x <x> --image-y <y> --session <id>`.
+Use original PNG pixels (returned width/height), not resized display or viewport coordinates.
+Captures are single-use, expire after two minutes, and are invalidated by a newer screenshot of
+that ref or observation/continuation. With `capture_unavailable`, view the image but observe and
+screenshot again before clicking. Click counts 1/2, buttons and modifiers are supported.
+After clicking, observe or screenshot to verify the result; use DOM refs for revealed controls.
+A completed click does not prove business success. Canvas repainting is allowed; changed identity,
+geometry or hit target is rejected. If `effect_state=unknown`, inspect before retrying with a new
+capture. Do not infer cell-editing, IME, drag or hover support from point-click capability.
 
 ## Respect the Agent Window boundary
 


### PR DESCRIPTION
## 背景

现有观察链路已支持发现 Canvas、输出 visual ref 并按需截图，但 Agent 尚不能根据截图操作 Canvas 内部区域。
本 PR 补齐截图到点选的链路，使 Agent 能根据图片定位单元格等目标，完成点击，并继续通过语义观察操作新出现的 DOM 控件。

## 主要改动

- Canvas 截图在坐标映射有效时返回 capture_id，支持使用原始图片坐标执行单击、双击、右键及修饰键组合。
- 复用现有目标与 frame 路径校验，点击前检查 Canvas 身份、坐标映射和实际命中目标，支持 iframe 内的 Canvas。
- 截图凭证采用单次使用机制；过期、引用更新或目标变化后拒绝执行，提示重新观察和截图。
- 同步扩展协议、CLI、插件及 Skill 使用说明。

## 行为边界

- observe 保持现有 Canvas 条目形式，不自动截图或识别内部内容。
- 点击校验针对目标身份、几何与命中关系，允许 Canvas 内容正常重绘。
- 操作结果需通过后续观察或截图确认；本 PR 不包含 OCR、拖拽或 Canvas 内部编辑能力。

## 验证

- 扩展、CLI 与插件相关自动化测试、类型检查及构建通过。
- 真实浏览器验证顶层、同源及跨域 iframe Canvas 点选和双击。
- 验证圆角外、遮挡、位置变化及失效凭证会拒绝执行。
- 真实页面验证单元格点选、右键菜单展开，以及后续通过 observe 获取菜单 DOM ref。