### PR TITLE
Support host-managed daemons in sandboxed agents

### DIFF
--- a/AGENT_INSTALL.md
+++ b/AGENT_INSTALL.md
@@ -1,8 +1,9 @@
 # browser-skill — Install Guide for AI Agents
 
 You are an AI agent setting up browser-skill for the user. Done = `bsk doctor`
-reports every check `ok` (or `na`). Never use `sudo`; you cannot install the
-extension yourself (Step 3 is the user's job).
+reports no `fail` checks. Explain any remaining warnings to the user; a warning
+about local process identity permits browser use over working IPC. Never use
+`sudo`; you cannot install the extension yourself (Step 3 is the user's job).
 
 ## 1. Install the CLI and skill
 
@@ -24,12 +25,23 @@ bsk install-skill --yes
 
 ## 2. Run `bsk doctor`
 
+If this environment reaps child processes after every shell command, first follow
+the [sandbox setup guide](docs/sandboxed-agents.md): arrange a persistent daemon
+in the owning host environment, then use the same accessible `BSK_HOME` and
+`BSK_AUTO_START=0` for every sandboxed command, including `doctor` and the session
+commands. Keep normal browser commands sandboxed. Do not assume one `export`
+persists across separate shell tool calls.
+
 ```bash
 bsk doctor
 ```
 
-Each `fail` row prints a `hint` — follow it and re-run once. A fresh install
-where only `extension connected` fails is expected; go to Step 3.
+Each `fail` row prints a `hint` — follow it and re-run once. When auto-start is
+disabled, an unavailable daemon needs host-side startup using the same directory.
+For a path/permission failure, use the resolved path in the report to check the
+shared directory and sandbox access rules; do not guess `/home/<user>` or delete
+daemon files. A fresh install where only `extension connected` fails is expected;
+go to Step 3.
 
 ## 3. Open the extension install page
 
@@ -47,4 +59,4 @@ for Microsoft Edge — then tell the user:
 > on Edge), open the popup, and wait until it turns green. Reply when done.
 
 If opening the page fails, give the user the same link. Then run `bsk doctor`
-once more. All `ok`/`na` → tell the user it's ready.
+once more. No `fail` checks → tell the user it's ready and explain any warnings.

--- a/README.md
+++ b/README.md
@@ -47,6 +47,11 @@ extension.
 
 ## Quick Start
 
+Using an agent sandbox that reaps background processes after each command?
+Follow the [sandboxed agent setup](docs/sandboxed-agents.md) to keep the daemon
+in a persistent host environment and connect with a shared `BSK_HOME` plus
+`BSK_AUTO_START=0`. Ordinary local use keeps automatic startup by default.
+
 <details open>
 <summary><b>Install with your Agent (recommended)</b></summary>
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -36,6 +36,11 @@ BrowserSkill 由两个本地运行组件组成：`bsk` CLI/daemon 和浏览器�
 
 ## 快速开始
 
+如果 Agent 沙盒会在每条命令结束后回收后台进程，请先阅读
+[沙盒环境配置说明](docs/sandboxed-agents.md)：在宿主侧保持 daemon 存活，
+沙盒内通过共享的 `BSK_HOME` 和 `BSK_AUTO_START=0` 连接。
+普通本地环境仍默认自动启动，无需额外配置。
+
 <details open>
 <summary><b>让 Agent 帮你安装（推荐）</b></summary>
 

--- a/crates/bsk-cli/skill/SKILL.md
+++ b/crates/bsk-cli/skill/SKILL.md
@@ -29,7 +29,23 @@ Every browser task owns a bounded session:
 Do not rely on the idle timeout for cleanup. Stop the session as soon as the goal is met unless the
 user explicitly asks to keep it open. Stopping also returns borrowed tabs.
 
-Any `bsk` command auto-starts the background services it needs; never manage the daemon by hand.
+By default, browser commands auto-start the daemon when needed. Keep the shared daemon running;
+task cleanup is `bsk session stop`, not `bsk daemon stop` or `restart`.
+
+If the agent environment kills background children when each shell command ends (as reported for
+Linux WorkBuddy), arrange a persistent daemon outside that per-command sandbox first. The user
+can run `BSK_HOME=/absolute/shared/bsk bsk daemon start` in a normal host terminal. A host-managed
+background task can instead run `bsk daemon start --foreground` with the same `BSK_HOME`, using
+the host's approved execution path. Do not disable sandbox protection for browser task commands.
+
+In that environment, pass `BSK_HOME=/absolute/shared/bsk BSK_AUTO_START=0` to **every** `bsk`
+command. Replace the example path with one dedicated directory that both sides can access,
+including its IPC socket; an `export` in one shell tool call may not persist to the next. If the
+daemon is unavailable, ask for it to be started in the owning host environment; do not loop on
+auto-start, guess a home directory, delete runtime files, or restart the shared daemon. A doctor
+warning about local process identity does not prevent session commands over working IPC.
+See the [sandbox setup guide](https://github.com/Tencent/BrowserSkill/blob/main/docs/sandboxed-agents.md).
+
 When multiple browsers are connected, use `bsk browsers` and start with
 `bsk session start --browser <id-or-label>`. Add `--no-focus` to that same start command when the
 Agent Window does not need to interrupt the user's current work; it is not a flag on other commands.

--- a/crates/bsk-cli/src/cli/doctor.rs
+++ b/crates/bsk-cli/src/cli/doctor.rs
@@ -10,7 +10,7 @@ use serde::Serialize;
 use crate::cli::browser_wait::{
     browser_query_ipc_timeout, doctor_browser_connect_wait, wait_for_browser_ms,
 };
-use crate::cli::ensure_daemon::ensure_daemon;
+use crate::cli::ensure_daemon::{AUTO_START_DISABLED_HINT, auto_start_enabled, ensure_daemon};
 use crate::cli::status::Output;
 use crate::daemon::info::DaemonInfo;
 use crate::daemon::paths;
@@ -126,7 +126,7 @@ pub fn has_failures(checks: &[CheckResult]) -> bool {
 fn resolve_daemon_state(output: Output) -> DaemonState {
     let mut state = current_state(Duration::ZERO);
 
-    if matches!(state, DaemonState::Missing | DaemonState::NoListener(_)) {
+    if matches!(state, DaemonState::Missing | DaemonState::NoListener(_)) && auto_start_enabled() {
         if let Err(err) = ensure_daemon() {
             return DaemonState::ProbeError(format!("{err:#}"));
         }
@@ -152,7 +152,7 @@ fn resolve_daemon_state(output: Output) -> DaemonState {
 
 fn needs_browser_wait(state: &DaemonState) -> bool {
     match state {
-        DaemonState::Verified { status } => status.browsers.is_empty(),
+        DaemonState::Verified { status, .. } => status.browsers.is_empty(),
         _ => false,
     }
 }
@@ -163,13 +163,16 @@ enum DaemonState {
     Missing,
     NoListener(DaemonInfo),
     ProbeError(String),
-    Verified { status: StatusResult },
+    Verified {
+        status: StatusResult,
+        local_identity_error: Option<String>,
+    },
 }
 
 impl DaemonState {
     fn status(&self) -> Option<&StatusResult> {
         match self {
-            DaemonState::Verified { status } => Some(status),
+            DaemonState::Verified { status, .. } => Some(status),
             _ => None,
         }
     }
@@ -180,6 +183,7 @@ fn collect_checks(state: DaemonState) -> Vec<CheckResult> {
         check_home_writable(),
         check_skill_up_to_date(),
         check_daemon_running(&state),
+        check_daemon_management(&state),
         check_version_compatible(state.status()),
         check_extension_connected(state.status()),
         check_browsers_protocol_compatible(state.status()),
@@ -193,6 +197,10 @@ fn current_state(browser_wait: Duration) -> DaemonState {
     let timeout = browser_query_ipc_timeout(browser_wait, Duration::from_secs(2));
     match probe::probe_with_params(timeout, params) {
         Ok(Probe::Ready(daemon)) => DaemonState::Verified {
+            local_identity_error: daemon
+                .require_local_pid()
+                .err()
+                .map(|err| format!("{err:#}")),
             status: daemon.status,
         },
         Ok(Probe::Absent(Some(info))) => DaemonState::NoListener(info),
@@ -205,11 +213,7 @@ fn check_home_writable() -> CheckResult {
     let name = "bsk home writable";
     match paths::ensure_bsk_home() {
         Ok(home) => CheckResult::ok(name, home.display().to_string()),
-        Err(err) => CheckResult::fail(
-            name,
-            format!("{err:#}"),
-            "ensure $HOME or $BSK_HOME is writable",
-        ),
+        Err(err) => CheckResult::fail(name, format!("{err:#}"), paths::BSK_HOME_HINT),
     }
 }
 
@@ -297,7 +301,11 @@ fn check_daemon_running(state: &DaemonState) -> CheckResult {
         DaemonState::Missing => CheckResult::fail(
             name,
             "daemon.json not found",
-            "run `bsk daemon start` or any `bsk` command (daemon is auto-spawned)",
+            if auto_start_enabled() {
+                "run `bsk daemon start` or any `bsk` command (daemon is auto-spawned)"
+            } else {
+                AUTO_START_DISABLED_HINT
+            },
         ),
         DaemonState::NoListener(info) => CheckResult::fail(
             name,
@@ -306,13 +314,35 @@ fn check_daemon_running(state: &DaemonState) -> CheckResult {
                 info.sock_path.display(),
                 info.pid
             ),
-            "run `bsk daemon start`; check `bsk logs` if startup fails",
+            if auto_start_enabled() {
+                "run `bsk daemon start`; check `bsk logs` if startup fails"
+            } else {
+                AUTO_START_DISABLED_HINT
+            },
         ),
         DaemonState::ProbeError(err) => CheckResult::fail(
             name,
             err.clone(),
             "check daemon IPC permissions and `bsk logs`; keep existing runtime files",
         ),
+    }
+}
+
+fn check_daemon_management(state: &DaemonState) -> CheckResult {
+    let name = "daemon local process identity";
+    match state {
+        DaemonState::Verified {
+            local_identity_error: Some(err),
+            ..
+        } => CheckResult::warn(
+            name,
+            format!("IPC is available, but local process identity is unverified: {err}"),
+            "the daemon may be in another PID namespace, or IPC peer identity may be unavailable; browser commands can use IPC; run daemon management commands in the owning host environment",
+        ),
+        DaemonState::Verified { .. } => {
+            CheckResult::ok(name, "IPC peer PID matches daemon identity")
+        }
+        _ => CheckResult::na(name, "daemon IPC is unavailable"),
     }
 }
 
@@ -488,6 +518,20 @@ mod m2_tests {
             sessions: Vec::new(),
             version_skew_browsers: skew,
         }
+    }
+
+    #[test]
+    fn unverified_local_identity_warns_without_failing_usable_ipc() {
+        let state = DaemonState::Verified {
+            status: fake_status(Vec::new(), Vec::new()),
+            local_identity_error: Some("peer identity is unavailable".into()),
+        };
+        let running = check_daemon_running(&state);
+        let management = check_daemon_management(&state);
+        assert_eq!(running.status, CheckStatus::Ok);
+        assert_eq!(management.status, CheckStatus::Warning);
+        assert!(management.detail.contains("IPC is available"));
+        assert!(!has_failures(&[running, management]));
     }
 
     #[test]

--- a/crates/bsk-cli/src/cli/ensure_daemon.rs
+++ b/crates/bsk-cli/src/cli/ensure_daemon.rs
@@ -3,7 +3,8 @@
 //!
 //! Flow (per design §3.1):
 //! 1. Verify the daemon over IPC and return its discovery info.
-//! 2. Only if no endpoint is listening, spawn `bsk daemon start` (the same binary), inheriting
+//! 2. Only if no endpoint is listening and auto-start is enabled, spawn
+//!    `bsk daemon start` (the same binary), inheriting
 //!    `BSK_HOME` if set, and poll for verified IPC readiness until
 //!    [`SPAWN_DEADLINE`] elapses.
 //! 3. If polling times out, return an error with hints.
@@ -12,7 +13,7 @@ use std::path::PathBuf;
 use std::process::{Command, Stdio};
 use std::time::Duration;
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, ensure};
 
 use crate::daemon::info::DaemonInfo;
 use crate::daemon::probe::{self, PROBE_TIMEOUT, Probe};
@@ -20,12 +21,22 @@ use crate::daemon::probe::{self, PROBE_TIMEOUT, Probe};
 /// Maximum time to wait for an auto-spawned daemon to become ready.
 pub const SPAWN_DEADLINE: Duration = Duration::from_millis(3_000);
 
+/// Explicit opt-out for clients using a daemon managed by their host.
+/// All other values preserve the default automatic startup behavior.
+pub(crate) fn auto_start_enabled() -> bool {
+    std::env::var_os("BSK_AUTO_START").as_deref() != Some(std::ffi::OsStr::new("0"))
+}
+
+pub(crate) const AUTO_START_DISABLED_HINT: &str = "automatic daemon startup is disabled (BSK_AUTO_START=0); \
+    run `bsk daemon start` in the owning host environment with the same BSK_HOME, then retry";
+
 /// Return verified discovery info, starting a daemon only when its discovery
-/// file or IPC listener is absent.
+/// file or IPC listener is absent and auto-start is enabled.
 pub fn ensure_daemon() -> Result<DaemonInfo> {
     if let Probe::Ready(daemon) = probe::probe(PROBE_TIMEOUT)? {
         return Ok(daemon.info);
     }
+    ensure!(auto_start_enabled(), AUTO_START_DISABLED_HINT);
     spawn_daemon()?;
     probe::wait_for_ready(SPAWN_DEADLINE)
         .map(|daemon| daemon.info)

--- a/crates/bsk-cli/src/daemon/info.rs
+++ b/crates/bsk-cli/src/daemon/info.rs
@@ -106,7 +106,16 @@ pub fn write_to_path(info: &DaemonInfo, final_path: &Path) -> Result<()> {
 /// callers can distinguish "no daemon running" from "I/O error".
 pub fn read() -> Result<Option<DaemonInfo>> {
     let p = paths::info_path()?;
-    read_from_path(&p)
+    read_from_path(&p).map_err(|err| {
+        if err
+            .downcast_ref::<std::io::Error>()
+            .is_some_and(|io| io.kind() == std::io::ErrorKind::PermissionDenied)
+        {
+            err.context(paths::BSK_HOME_HINT)
+        } else {
+            err
+        }
+    })
 }
 
 pub fn read_from_path(path: &Path) -> Result<Option<DaemonInfo>> {

--- a/crates/bsk-cli/src/daemon/paths.rs
+++ b/crates/bsk-cli/src/daemon/paths.rs
@@ -23,6 +23,10 @@ use anyhow::{Context, Result};
 /// Environment variable that overrides the home directory.
 pub const BSK_HOME_ENV: &str = "BSK_HOME";
 
+pub(crate) const BSK_HOME_HINT: &str = "set BSK_HOME to a writable private directory; \
+    when using a host daemon, use the same shared directory and allow access to it \
+    and its IPC endpoint in the sandbox settings";
+
 /// Resolve the bsk home directory:
 /// 1. `BSK_HOME` env var (any non-empty value); or
 /// 2. `~/.bsk` (using [`dirs::home_dir`]).
@@ -32,27 +36,42 @@ pub fn bsk_home() -> Result<PathBuf> {
             return Ok(PathBuf::from(p));
         }
     }
-    let home = dirs::home_dir().context("could not determine user home directory")?;
+    let home = dirs::home_dir()
+        .with_context(|| format!("could not determine user home directory; {BSK_HOME_HINT}"))?;
     Ok(home.join(".bsk"))
 }
 
 /// Ensure `~/.bsk` (or `$BSK_HOME`) exists, creating it with restrictive
-/// permissions on Unix (`chmod 0700`). Returns the absolute path.
+/// permissions on Unix (`chmod 0700`). Returns the resolved path.
 pub fn ensure_bsk_home() -> Result<PathBuf> {
     let home = bsk_home()?;
+    prepare_home(&home).with_context(|| {
+        let source = if env::var(BSK_HOME_ENV).is_ok_and(|value| !value.is_empty()) {
+            "BSK_HOME"
+        } else {
+            "platform home lookup"
+        };
+        format!(
+            "cannot prepare bsk home {} (from {source}); {BSK_HOME_HINT}",
+            home.display()
+        )
+    })?;
+    Ok(home)
+}
+
+fn prepare_home(home: &Path) -> Result<()> {
     if !home.exists() {
-        std::fs::create_dir_all(&home)
+        std::fs::create_dir_all(home)
             .with_context(|| format!("create bsk home {}", home.display()))?;
     }
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
         let perms = std::fs::Permissions::from_mode(0o700);
-        std::fs::set_permissions(&home, perms)
+        std::fs::set_permissions(home, perms)
             .with_context(|| format!("chmod 0700 {}", home.display()))?;
     }
-    ensure_run_dir(&home)?;
-    Ok(home)
+    ensure_run_dir(home)
 }
 
 fn ensure_run_dir(home: &Path) -> Result<()> {
@@ -64,7 +83,8 @@ fn ensure_run_dir(home: &Path) -> Result<()> {
     {
         use std::os::unix::fs::PermissionsExt;
         let perms = std::fs::Permissions::from_mode(0o700);
-        std::fs::set_permissions(&run, perms)?;
+        std::fs::set_permissions(&run, perms)
+            .with_context(|| format!("chmod 0700 {}", run.display()))?;
     }
     Ok(())
 }

--- a/crates/bsk-cli/tests/auto_spawn.rs
+++ b/crates/bsk-cli/tests/auto_spawn.rs
@@ -17,8 +17,11 @@ fn command(home: &Path, args: &[&str]) -> Command {
     let mut cmd = Command::new(bsk_bin());
     cmd.args(args)
         .env("BSK_HOME", home)
+        .env("HOME", home)
+        .env_remove("BSK_AUTO_START")
         .env("BSK_AUTO_UPDATE", "off")
         .env("BSK_BROWSER_WAIT_MS", "0")
+        .env("BSK_DOCTOR_BROWSER_WAIT_MS", "0")
         .env("RUST_LOG", "warn");
     cmd
 }
@@ -125,4 +128,127 @@ fn ensure_daemon_idempotent_when_already_running() {
     // Clean up.
     let _ = command(&home, &["daemon", "stop"]).output();
     assert!(wait_for_pid_exit(pid_before, Duration::from_secs(5)));
+}
+
+#[test]
+fn disabled_auto_start_leaves_missing_and_stale_discovery_alone() {
+    for stale in [false, true] {
+        let temp = TempDir::new().unwrap();
+        let home = temp.path().join("bsk");
+        let info_path = home.join("daemon.json");
+        if stale {
+            std::fs::create_dir(&home).unwrap();
+            let sock = home.join("daemon.sock");
+            // Leave a socket file with no listener, as after a forced exit.
+            drop(std::os::unix::net::UnixListener::bind(&sock).unwrap());
+            let info = bsk::daemon::info::DaemonInfo::now(0x3fff_fffe, sock, 0, "0.2.1");
+            bsk::daemon::info::write_to_path(&info, &info_path).unwrap();
+        }
+        let original = std::fs::read(&info_path).ok();
+        for args in [vec!["--json", "status"], vec!["--json", "session", "start"]] {
+            let out = command(&home, &args)
+                .env("BSK_AUTO_START", "0")
+                .output()
+                .unwrap();
+            assert!(!out.status.success());
+            let error = String::from_utf8_lossy(&out.stdout);
+            assert!(error.contains("BSK_AUTO_START=0"), "{error}");
+            assert!(error.contains("owning host environment"), "{error}");
+            assert_eq!(std::fs::read(&info_path).ok(), original);
+            assert!(!home.join("daemon.lock").exists());
+        }
+        if !stale {
+            assert!(!home.exists(), "browser commands must not create a home");
+        }
+
+        let out = command(&home, &["--json", "doctor"])
+            .env("BSK_AUTO_START", "0")
+            .output()
+            .unwrap();
+        assert!(!out.status.success());
+        let checks: Vec<serde_json::Value> = serde_json::from_slice(&out.stdout).unwrap();
+        let daemon = checks
+            .iter()
+            .find(|c| c["name"] == "daemon running")
+            .unwrap();
+        assert_eq!(daemon["status"], "fail");
+        assert!(
+            daemon["hint"]
+                .as_str()
+                .unwrap()
+                .contains("BSK_AUTO_START=0")
+        );
+        let identity = checks
+            .iter()
+            .find(|c| c["name"] == "daemon local process identity")
+            .unwrap();
+        assert_eq!(identity["status"], "na");
+        assert_eq!(std::fs::read(&info_path).ok(), original);
+        assert!(!home.join("daemon.lock").exists());
+        if stale {
+            assert!(home.join("daemon.sock").exists());
+        }
+    }
+}
+
+#[test]
+fn disabled_auto_start_allows_explicit_start_and_reuses_daemon_across_commands() {
+    let temp = TempDir::new().unwrap();
+    let home = temp.path().join("bsk");
+    let _cleanup = StopOnDrop(home.clone());
+    let out = command(
+        &home,
+        &["daemon", "start", "--port", "0", "--daemon-idle", "60s"],
+    )
+    .env("BSK_AUTO_START", "0")
+    .output()
+    .unwrap();
+    assert!(
+        out.status.success(),
+        "{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let original = std::fs::read(home.join("daemon.json")).unwrap();
+    let info: bsk::daemon::info::DaemonInfo = serde_json::from_slice(&original).unwrap();
+    for _ in 0..2 {
+        let out = command(&home, &["--json", "status"])
+            .env("BSK_AUTO_START", "0")
+            .output()
+            .unwrap();
+        assert!(
+            out.status.success(),
+            "{}",
+            String::from_utf8_lossy(&out.stdout)
+        );
+        let status: bsk_protocol::StatusResult = serde_json::from_slice(&out.stdout).unwrap();
+        assert_eq!(status.pid, info.pid);
+    }
+    let doctor = command(&home, &["--json", "doctor"])
+        .env("BSK_AUTO_START", "0")
+        .output()
+        .unwrap();
+    let checks: Vec<serde_json::Value> = serde_json::from_slice(&doctor.stdout).unwrap();
+    let identity = checks
+        .iter()
+        .find(|c| c["name"] == "daemon local process identity")
+        .unwrap();
+    assert_eq!(identity["status"], "ok");
+    assert_eq!(std::fs::read(home.join("daemon.json")).unwrap(), original);
+
+    let stop = command(&home, &["daemon", "stop"])
+        .env("BSK_AUTO_START", "0")
+        .output()
+        .unwrap();
+    assert!(stop.status.success());
+    assert!(!home.join("daemon.json").exists());
+    let status = command(&home, &["--json", "status"])
+        .env("BSK_AUTO_START", "0")
+        .output()
+        .unwrap();
+    assert!(!status.status.success());
+    assert!(String::from_utf8_lossy(&status.stdout).contains("BSK_AUTO_START=0"));
+    assert!(
+        !home.join("daemon.json").exists(),
+        "must not replace the stopped host daemon"
+    );
 }

--- a/crates/bsk-cli/tests/daemon_discovery.rs
+++ b/crates/bsk-cli/tests/daemon_discovery.rs
@@ -23,7 +23,9 @@ fn command(home: &Path, args: &[&str]) -> Command {
     let mut cmd = Command::new(env!("CARGO_BIN_EXE_bsk"));
     cmd.args(args)
         .env("BSK_HOME", home)
-        .env("BSK_AUTO_UPDATE", "0")
+        .env("HOME", home)
+        .env_remove("BSK_AUTO_START")
+        .env("BSK_AUTO_UPDATE", "off")
         .env("BSK_BROWSER_WAIT_MS", "0")
         .env("BSK_DOCTOR_BROWSER_WAIT_MS", "0")
         .env("RUST_LOG", "warn");
@@ -165,15 +167,38 @@ fn discovery_accepts_ipc_without_local_pid_but_management_refuses_it() {
     let original = daemon.metadata();
     success(&run(daemon.home(), &["--json", "status"]));
     success(&run(daemon.home(), &["daemon", "start"]));
-    let doctor = run(daemon.home(), &["--json", "doctor"]);
-    let checks: Vec<serde_json::Value> = serde_json::from_slice(&doctor.stdout).unwrap();
-    assert_eq!(
-        checks
+    for auto_start in ["0", "1"] {
+        success(
+            &command(daemon.home(), &["--json", "status"])
+                .env("BSK_AUTO_START", auto_start)
+                .output()
+                .unwrap(),
+        );
+        let doctor = command(daemon.home(), &["--json", "doctor"])
+            .env("BSK_AUTO_START", auto_start)
+            .output()
+            .unwrap();
+        let checks: Vec<serde_json::Value> = serde_json::from_slice(&doctor.stdout).unwrap();
+        assert_eq!(
+            checks
+                .iter()
+                .find(|c| c["name"] == "daemon running")
+                .unwrap()["status"],
+            "ok"
+        );
+        let identity = checks
             .iter()
-            .find(|c| c["name"] == "daemon running")
-            .unwrap()["ok"],
-        true
-    );
+            .find(|c| c["name"] == "daemon local process identity")
+            .unwrap();
+        assert_eq!(identity["status"], "warn");
+        assert_eq!(identity["ok"], true);
+        assert!(
+            identity["hint"]
+                .as_str()
+                .unwrap()
+                .contains("owning host environment")
+        );
+    }
     for args in [["daemon", "stop"], ["daemon", "restart"]] {
         let out = run(daemon.home(), &args);
         assert!(!out.status.success());
@@ -204,10 +229,20 @@ fn unresponsive_endpoint_is_bounded_and_does_not_spawn_or_clean_up() {
     let daemon = MockDaemon::new(FOREIGN_PID, |_, _| None);
     let original = daemon.metadata();
     let start = Instant::now();
-    let out = run(daemon.home(), &["--json", "status"]);
-    assert!(!out.status.success());
+    for auto_start in ["0", "1"] {
+        let out = command(daemon.home(), &["--json", "status"])
+            .env("BSK_AUTO_START", auto_start)
+            .output()
+            .unwrap();
+        assert!(!out.status.success());
+        let error = String::from_utf8_lossy(&out.stdout);
+        assert!(error.contains("timed out"), "{error}");
+        assert!(
+            !error.contains("automatic daemon startup is disabled"),
+            "{error}"
+        );
+    }
     assert!(start.elapsed() < Duration::from_secs(3));
-    assert!(String::from_utf8_lossy(&out.stdout).contains("timed out"));
     assert_eq!(daemon.metadata(), original);
     assert!(!daemon.home().join("daemon.lock").exists());
 }
@@ -366,13 +401,24 @@ fn host_daemon_is_usable_but_not_signalable_from_a_child_pid_namespace() {
             .arg(env!("CARGO_BIN_EXE_bsk"))
             .args(args)
             .env("BSK_HOME", temp.path())
-            .env("BSK_AUTO_UPDATE", "0")
+            .env("HOME", temp.path())
+            .env("BSK_AUTO_START", "0")
+            .env("BSK_AUTO_UPDATE", "off")
             .env("BSK_BROWSER_WAIT_MS", "0")
+            .env("BSK_DOCTOR_BROWSER_WAIT_MS", "0")
             .output()
             .unwrap()
     };
     success(&inside(&["--json", "status"]));
     success(&inside(&["daemon", "start"]));
+    let doctor = inside(&["--json", "doctor"]);
+    let checks: Vec<serde_json::Value> = serde_json::from_slice(&doctor.stdout).unwrap();
+    let identity = checks
+        .iter()
+        .find(|c| c["name"] == "daemon local process identity")
+        .unwrap();
+    assert_eq!(identity["status"], "warn");
+    assert_eq!(identity["ok"], true);
     let out = inside(&["daemon", "stop"]);
     assert!(!out.status.success());
     assert!(String::from_utf8_lossy(&out.stderr).contains("cannot verify local daemon process"));
@@ -381,6 +427,10 @@ fn host_daemon_is_usable_but_not_signalable_from_a_child_pid_namespace() {
         serde_json::from_slice(&std::fs::read(temp.path().join("daemon.json")).unwrap()).unwrap();
     assert_eq!(after, original);
     success(&run(temp.path(), &["daemon", "stop"]));
+    let stopped = inside(&["--json", "status"]);
+    assert!(!stopped.status.success());
+    assert!(String::from_utf8_lossy(&stopped.stdout).contains("BSK_AUTO_START=0"));
+    assert!(!temp.path().join("daemon.json").exists());
 }
 
 struct ManagedChild(Child);

--- a/crates/bsk-cli/tests/daemon_paths.rs
+++ b/crates/bsk-cli/tests/daemon_paths.rs
@@ -1,0 +1,138 @@
+//! Path resolution stays compatible; failures identify the directory and repair action.
+#![cfg(unix)]
+
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+use std::process::Command;
+
+use tempfile::TempDir;
+
+#[test]
+fn home_resolution_preserves_platform_defaults_and_explicit_overrides() {
+    const CHILD: &str = "BSK_PATH_RESOLUTION_TEST";
+    if std::env::var_os(CHILD).is_some() {
+        let expected = std::env::var("BSK_HOME")
+            .ok()
+            .filter(|value| !value.is_empty())
+            .map(std::path::PathBuf::from)
+            .or_else(|| dirs::home_dir().map(|home| home.join(".bsk")))
+            .unwrap();
+        assert_eq!(bsk::daemon::paths::bsk_home().unwrap(), expected);
+        return;
+    }
+    // Use child environments so no test can change another test's HOME.
+    // Resolve only: do not prepare or write to the account's real home.
+    let temp = TempDir::new().unwrap();
+    for home in [None, Some(Path::new("")), Some(temp.path())] {
+        for bsk_home in [None, Some(Path::new("")), Some(temp.path())] {
+            let mut child = Command::new(std::env::current_exe().unwrap());
+            child
+                .args([
+                    "--exact",
+                    "home_resolution_preserves_platform_defaults_and_explicit_overrides",
+                ])
+                .env(CHILD, "1")
+                .env_remove("HOME")
+                .env_remove("BSK_HOME");
+            if let Some(home) = home {
+                child.env("HOME", home);
+            }
+            if let Some(home) = bsk_home {
+                child.env("BSK_HOME", home);
+            }
+            let out = child.output().unwrap();
+            assert!(
+                out.status.success(),
+                "{}",
+                String::from_utf8_lossy(&out.stdout)
+            );
+        }
+    }
+}
+
+#[test]
+fn doctor_reports_unwritable_resolved_home_without_changing_resolution() {
+    if unsafe { libc::geteuid() } == 0 {
+        eprintln!("skipping permission denial check for root");
+        return;
+    }
+    for explicit in [false, true] {
+        let temp = TempDir::new().unwrap();
+        let blocked = temp.path().join("blocked");
+        std::fs::create_dir(&blocked).unwrap();
+        let home = blocked.join(".bsk");
+        std::fs::set_permissions(&blocked, std::fs::Permissions::from_mode(0o500)).unwrap();
+        let mut cmd = Command::new(env!("CARGO_BIN_EXE_bsk"));
+        cmd.args(["--json", "doctor"])
+            .env("HOME", &blocked)
+            .env_remove("BSK_HOME")
+            .env("BSK_AUTO_START", "0")
+            .env("BSK_AUTO_UPDATE", "off")
+            .env("BSK_DOCTOR_BROWSER_WAIT_MS", "0");
+        if explicit {
+            cmd.env("BSK_HOME", &home);
+        }
+        let out = cmd.output().unwrap();
+        std::fs::set_permissions(&blocked, std::fs::Permissions::from_mode(0o700)).unwrap();
+        assert!(!out.status.success());
+        let checks: Vec<serde_json::Value> = serde_json::from_slice(&out.stdout).unwrap();
+        let check = checks
+            .iter()
+            .find(|c| c["name"] == "bsk home writable")
+            .unwrap();
+        assert_eq!(check["status"], "fail");
+        let detail = check["detail"].as_str().unwrap();
+        assert!(detail.contains(home.to_str().unwrap()), "{detail}");
+        assert!(detail.contains("create bsk home"), "{detail}");
+        assert!(detail.contains("Permission denied"), "{detail}");
+        assert!(
+            detail.contains(if explicit {
+                "from BSK_HOME"
+            } else {
+                "from platform home lookup"
+            }),
+            "{detail}"
+        );
+        assert!(check["hint"].as_str().unwrap().contains("BSK_HOME"));
+        assert!(
+            !home.exists(),
+            "must not create a daemon home or fall back elsewhere"
+        );
+    }
+}
+
+#[test]
+fn inaccessible_discovery_reports_the_path_and_bsk_home_hint() {
+    if unsafe { libc::geteuid() } == 0 {
+        eprintln!("skipping permission denial check for root");
+        return;
+    }
+    let temp = TempDir::new().unwrap();
+    let blocked = temp.path().join("blocked");
+    std::fs::create_dir(&blocked).unwrap();
+    let home = blocked.join("bsk");
+    std::fs::create_dir(&home).unwrap();
+    let info = home.join("daemon.json");
+    let original = b"inaccessible discovery must not be parsed or removed";
+    std::fs::write(&info, original).unwrap();
+    std::fs::set_permissions(&blocked, std::fs::Permissions::from_mode(0o0)).unwrap();
+    let out = Command::new(env!("CARGO_BIN_EXE_bsk"))
+        .args(["--json", "status"])
+        .env("BSK_HOME", &home)
+        .env("BSK_AUTO_START", "0")
+        .env("BSK_AUTO_UPDATE", "off")
+        .output()
+        .unwrap();
+    std::fs::set_permissions(&blocked, std::fs::Permissions::from_mode(0o700)).unwrap();
+    assert!(!out.status.success());
+    let error = String::from_utf8_lossy(&out.stdout);
+    assert!(error.contains(info.to_str().unwrap()), "{error}");
+    assert!(error.contains("Permission denied"), "{error}");
+    assert!(error.contains("set BSK_HOME"), "{error}");
+    assert!(
+        !error.contains("automatic daemon startup is disabled"),
+        "{error}"
+    );
+    assert_eq!(std::fs::read(info).unwrap(), original);
+    assert!(!home.join("daemon.lock").exists());
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -29,8 +29,11 @@ flowchart TB
 ### bsk CLI (`crates/bsk-cli`)
 
 - Parses verb-noun subcommands (`bsk session start`, `bsk click`, …).
-- On first use, **auto-spawns** the daemon if `~/.bsk/daemon.lock` is absent or stale.
-- Speaks JSON Lines over `~/.bsk/daemon.sock` (Unix) or a named pipe (Windows).
+- Uses IPC to discover a running daemon. Automatically starts one only when
+  discovery or its listener is absent, unless `BSK_AUTO_START=0` disables implicit
+  startup. See [sandboxed agent setup](sandboxed-agents.md) for host-managed daemons.
+- Speaks JSON Lines over `$BSK_HOME/run/daemon.sock` (Unix) or a named pipe (Windows);
+  the default home is `~/.bsk`.
 - Renders human-readable output by default; `--json` emits structured responses.
 
 Key modules:

--- a/docs/sandboxed-agents.md
+++ b/docs/sandboxed-agents.md
@@ -1,0 +1,123 @@
+# BrowserSkill in a sandboxed agent
+
+Some agent environments end a command by terminating its child processes,
+including detached daemons. Linux WorkBuddy users reported this with its
+bubblewrap-based Bash sandbox in [issue #214](https://github.com/Tencent/BrowserSkill/issues/214).
+In such an environment, keep the daemon in a persistent host execution context
+and run browser commands inside the sandbox over shared local IPC.
+
+Ordinary local use still auto-starts the daemon. No sandbox detection, service
+installation or global change to home-directory resolution is required.
+
+## 1. Choose one accessible directory
+
+Choose a dedicated, persistent directory owned by the user running the daemon.
+Replace `/absolute/shared/bsk` below with its actual absolute path. It does not
+have to be under the user's home directory.
+
+The host and sandbox must see the same underlying directory at the path used
+by the daemon, including `daemon.json` and `run/daemon.sock` on Unix. Matching
+environment-variable text alone is insufficient if the mounts differ. Configure
+the host's filesystem and IPC access rules to allow the sandbox to reach it;
+retain the directory's private permissions rather than making it world-writable.
+This is a local IPC arrangement, not a connection to a separate remote machine.
+
+`BSK_HOME` overrides the default daemon directory. Without a non-empty override,
+bsk keeps using the platform's normal home-directory lookup. On Unix, an unset
+or empty `HOME` may fall back to the current UID's account record; it does not
+necessarily select the directory that the agent's user expects. Configure
+`BSK_HOME` explicitly on both sides instead of guessing a username or changing
+the process's global `HOME`.
+
+## 2. Start the daemon in the owning host environment
+
+From the user's normal host terminal, outside the per-command sandbox:
+
+```bash
+BSK_HOME=/absolute/shared/bsk bsk daemon start
+```
+
+If the agent host provides a persistent background-task facility, let that task
+own the foreground daemon instead:
+
+```bash
+BSK_HOME=/absolute/shared/bsk bsk daemon start --foreground
+```
+
+Use the host's approved mechanism for that launch to run outside the sandbox.
+CodeBuddy's [tool reference](https://www.codebuddy.ai/docs/cli/tools-reference)
+documents background tasks and per-command sandbox exceptions; availability
+depends on the host's settings. Do not turn off sandbox protection for all
+browser commands. Verify that the chosen host task survives subsequent shell
+commands. Cancelling that task or shutting down its host can still stop the
+daemon; bsk cannot make a process outlive the environment that owns it.
+
+Start and stop the shared daemon in this owning environment. Browser task
+cleanup is `bsk session stop`, which leaves other sessions and the daemon alone.
+The daemon's existing idle-exit behavior is unchanged: with no connected
+browsers, active sessions or IPC clients, its default idle timeout is 10 minutes.
+If the host workflow needs a longer idle window, pass the existing `--daemon-idle`
+option when starting it, for example `--daemon-idle 2h`. After an idle exit, start
+it again from the host before the next sandboxed command.
+
+## 3. Connect from every sandboxed command
+
+Set both variables on each shell invocation, or use the host's documented
+persistent environment configuration. A previous `export` may not carry over
+to the next shell tool call.
+
+```bash
+BSK_HOME=/absolute/shared/bsk BSK_AUTO_START=0 bsk doctor
+BSK_HOME=/absolute/shared/bsk BSK_AUTO_START=0 bsk session start
+```
+
+Retain the session ID. In a separate shell invocation, replace `SESSION_ID`:
+
+```bash
+BSK_HOME=/absolute/shared/bsk BSK_AUTO_START=0 bsk navigate https://example.com --session SESSION_ID
+BSK_HOME=/absolute/shared/bsk BSK_AUTO_START=0 bsk snapshot --session SESSION_ID
+BSK_HOME=/absolute/shared/bsk BSK_AUTO_START=0 bsk session stop SESSION_ID
+```
+
+`BSK_AUTO_START=0` disables **implicit** startup by browser commands and doctor.
+It still connects to a working daemon. When discovery is missing or no endpoint
+is listening, it reports the problem and asks for host-side startup. It does not
+spawn a replacement or remove runtime files. Only the value `0` opts out;
+leaving the variable unset or setting it to `1` retains normal automatic startup.
+Explicit `bsk daemon start`, `stop`, `restart`, and update operations retain their
+existing management behavior; the variable is not a prohibition on those commands.
+Doctor retains its existing directory preparation and skill checks.
+
+## Diagnostics and recovery
+
+- **Automatic startup disabled:** start the daemon in its owning host environment
+  using the same `BSK_HOME`, then retry the browser command. Do not repeatedly
+  start a daemon inside a sandbox that will reap it.
+- **Directory or permission error:** check the exact resolved path and operation
+  in the error. Configure `BSK_HOME` and the host's access rules for that directory
+  and its IPC endpoint. There is no automatic fallback to a guessed user directory.
+- **IPC available, local process identity unverified:** browser/session commands
+  can continue. Another PID namespace or unavailable peer-identity information
+  may prevent local signal-based management. Run daemon management commands in
+  the environment that owns it. This warning does not itself fail doctor.
+- **IPC timeout or invalid reply:** inspect the daemon from its owning environment.
+  These errors do not authorize another automatic startup. Keep runtime files.
+
+An RPC shutdown mechanism is not part of this setup. Do not disable PID identity
+checks or delete lock files to work around a refused stop.
+
+## Verify the host integration
+
+1. Start the daemon outside the command sandbox and confirm `bsk status` works
+   from inside it with the two variables above.
+2. Create a browser session, let that shell invocation finish, then navigate and
+   take a snapshot in another invocation using the same session ID. Confirm the
+   daemon instance in `daemon.json` has not changed.
+3. Stop only that session. Confirm another status call still reaches the daemon.
+4. In a controlled setup with no other active sessions, stop the daemon from its
+   owning environment. The next sandboxed command must report it unavailable
+   without starting a new daemon. Restart it from the host when needed.
+
+This check validates the host's actual process lifetime and IPC permissions.
+Successful local CLI tests alone do not establish that a particular WorkBuddy
+version or configuration keeps its background tasks alive.

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -29,7 +29,23 @@ Every browser task owns a bounded session:
 Do not rely on the idle timeout for cleanup. Stop the session as soon as the goal is met unless the
 user explicitly asks to keep it open. Stopping also returns borrowed tabs.
 
-Any `bsk` command auto-starts the background services it needs; never manage the daemon by hand.
+By default, browser commands auto-start the daemon when needed. Keep the shared daemon running;
+task cleanup is `bsk session stop`, not `bsk daemon stop` or `restart`.
+
+If the agent environment kills background children when each shell command ends (as reported for
+Linux WorkBuddy), arrange a persistent daemon outside that per-command sandbox first. The user
+can run `BSK_HOME=/absolute/shared/bsk bsk daemon start` in a normal host terminal. A host-managed
+background task can instead run `bsk daemon start --foreground` with the same `BSK_HOME`, using
+the host's approved execution path. Do not disable sandbox protection for browser task commands.
+
+In that environment, pass `BSK_HOME=/absolute/shared/bsk BSK_AUTO_START=0` to **every** `bsk`
+command. Replace the example path with one dedicated directory that both sides can access,
+including its IPC socket; an `export` in one shell tool call may not persist to the next. If the
+daemon is unavailable, ask for it to be started in the owning host environment; do not loop on
+auto-start, guess a home directory, delete runtime files, or restart the shared daemon. A doctor
+warning about local process identity does not prevent session commands over working IPC.
+See the [sandbox setup guide](https://github.com/Tencent/BrowserSkill/blob/main/docs/sandboxed-agents.md).
+
 When multiple browsers are connected, use `bsk browsers` and start with
 `bsk session start --browser <id-or-label>`. Add `--no-focus` to that same start command when the
 Agent Window does not need to interrupt the user's current work; it is not a flag on other commands.


### PR DESCRIPTION
部分 Agent 沙盒会在命令结束后回收后台 daemon，导致后续命令失去连接和会话。本 PR 为 #214 第二期提供“宿主运行 daemon、沙盒通过共享 IPC 连接”的配置流程及诊断支持。

### 改动

- 更新 README、安装指南和 skill：说明宿主启动方式、共享 BSK_HOME、IPC 访问要求，以及每次沙盒命令都需传递环境变量。
- 增加 BSK_AUTO_START=0：仍连接已有 daemon；发现文件或监听端不存在时，提示在宿主启动，不隐式启动或清理残留。权限、超时等探测错误继续保持原有失败行为。
- 路径错误补充实际目录、失败操作和 BSK_HOME 配置提示，保留原有 HOME 解析与回退规则。
- doctor 增加本地进程身份检查：IPC 可用但无法验证本地 peer PID 时报告 warn，不因此判定 daemon 不可用，也不直接断言当前处于沙盒。

### 兼容性与范围

未设置 BSK_AUTO_START=0 时，自动启动行为不变；显式 start/stop/restart、更新流程和空闲退出策略不变。doctor 仍执行原有目录准备和 skill 检查。

宿主必须提供可持续运行的进程环境及可访问的共享 IPC。本 PR 不让 daemon 逃离沙盒，不新增服务安装器，也不包含 shutdown RPC 或会话重连调整。

### 验证

- macOS 全量 Rust 测试、cargo fmt、严格 Clippy 通过。
- 覆盖默认自动启动、禁用启动后的缺失/残留发现文件、跨命令复用、显式管理、路径权限错误及 doctor 警告语义。
- 扩展 Linux PID namespace 回归用例；本机未执行 Linux/Windows 运行时验证。
- 真实 Linux WorkBuddy 联调尚未执行，文档提供了跨命令会话存活及宿主停止后的验收步骤。

Related to #214