### PR TITLE
fix(client): guard observationTabOpen against a missing right-column tree (DSH 0.1.5 / better-sidebar 0.19+)

### DIFF
--- a/packages/dsh-plugin-browserskill/src/client/observation-sidebar.tsx
+++ b/packages/dsh-plugin-browserskill/src/client/observation-sidebar.tsx
@@ -64,7 +64,12 @@ export interface SidebarSplitLike {
 export type SidebarNodeLike = SidebarLeafLike | SidebarSplitLike;
 
 export interface SidebarStateLike {
-  splits: SidebarNodeLike;
+  /**
+   * Right-column split tree. DSH 0.1.5 (better-sidebar 0.19+) moved the right
+   * column to dsh's native Sidebar and no longer emits this field, so it is
+   * optional here; earlier versions always provide it.
+   */
+  splits?: SidebarNodeLike;
   bottomSplits: SidebarNodeLike;
   /** Whether the right panel is expanded (the merged drawer on narrow screens). */
   panelOpen?: boolean;
@@ -170,7 +175,11 @@ function* leafNodes(node: SidebarNodeLike): Generator<SidebarLeafLike> {
 /** Whether a tab of our type is already open in either sidebar workbench. */
 export function observationTabOpen(state: SidebarStateLike | undefined): boolean {
   if (state === undefined) return false;
+  // A root may be absent even when the snapshot exists: `splits` is gone on
+  // DSH 0.1.5+ (better-sidebar 0.19+), where the right column belongs to dsh's
+  // native Sidebar. Guard before walking so we do not dereference undefined.
   for (const root of [state.splits, state.bottomSplits]) {
+    if (root === undefined) continue;
     for (const leaf of leafNodes(root)) {
       if (leaf.tabs.some((tab) => tab.type === OBSERVATION_TAB_TYPE)) return true;
     }

--- a/packages/dsh-plugin-browserskill/tests/client/observation-sidebar.test.tsx
+++ b/packages/dsh-plugin-browserskill/tests/client/observation-sidebar.test.tsx
@@ -117,7 +117,7 @@ function withTabOpened(state: SidebarStateLike, type: string): SidebarStateLike 
     }
     return { ...node, children: node.children.map(walk) };
   };
-  return { ...state, splits: walk(state.splits) };
+  return { ...state, splits: state.splits === undefined ? undefined : walk(state.splits) };
 }
 
 function makeSidebar(
@@ -279,6 +279,16 @@ describe("observationTabOpen", () => {
       },
     };
     expect(observationTabOpen(inBottom)).toBe(true);
+  });
+
+  it("does not crash when the right-column tree is absent (DSH 0.1.5+)", () => {
+    // better-sidebar 0.19+ no longer emits `splits` (the right column moved to
+    // dsh's native Sidebar); the walk must skip absent roots, not dereference.
+    const noSplits: SidebarStateLike = {
+      bottomSplits: { kind: "leaf", id: "p2", active: null, tabs: [] },
+    };
+    expect(() => observationTabOpen(noSplits)).not.toThrow();
+    expect(observationTabOpen(noSplits)).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

`observationTabOpen()` crashes whenever the sidebar snapshot exists but carries no right-column tree — which is the normal shape on **DSH 0.1.5 with better-sidebar 0.19+**, so the observation tab probe throws on every render.

## Root cause

DSH 0.1.5 moved the right column to dsh's native Sidebar. better-sidebar 0.19.x therefore no longer emits `splits` in its sidebar state (`makeDefaultState()` now returns only `bottomSplits`), but this plugin still declares it as required and walks it:

```ts
export interface SidebarStateLike {
  splits: SidebarNodeLike;        // declared required — absent at runtime on 0.1.5+
  bottomSplits: SidebarNodeLike;
  panelOpen?: boolean;
}

export function observationTabOpen(state: SidebarStateLike | undefined): boolean {
  if (state === undefined) return false;
  for (const root of [state.splits, state.bottomSplits]) {   // state.splits === undefined
    for (const leaf of leafNodes(root)) {                    // leafNodes(undefined)
```

`leafNodes()` dereferences `node.kind` on entry, so the first iteration throws:

```
TypeError: Cannot read properties of undefined (reading 'kind')
    at leafNodes (...)
```

## User-visible impact

The observation tab is registered inside better-sidebar's render tree, so the throw is contained by *its* error boundary and rendered as a persistent red banner in the bottom-left corner of the UI:

```
dsh-better-sidebar: Cannot read properties of undefined (reading 'kind')   [重试]
```

It appears on every page load and misattributes the fault to `dsh-better-sidebar`, which sends users chasing the wrong plugin. The "is my observation tab already open?" probe also fails every time it runs.

## Fix

- Mark `splits` optional — it genuinely is absent on 0.1.5+ while earlier versions still provide it.
- Skip absent roots before walking.

```diff
 export interface SidebarStateLike {
-  splits: SidebarNodeLike;
+  splits?: SidebarNodeLike;
   bottomSplits: SidebarNodeLike;
```

```diff
   for (const root of [state.splits, state.bottomSplits]) {
+    if (root === undefined) continue;
     for (const leaf of leafNodes(root)) {
```

## Verification

Reproduced and verified against a live install (Windows, dsh `0.1.5-rc.2` + `dsh-better-sidebar` `0.19.0-alpha.1`, pulled in through `@linxin666/dsh-web-all` `0.3.20`):

- Client console captured with a headless Chromium session against the running UI.
  - **Before:** `TypeError: Cannot read properties of undefined (reading 'kind') at leafNodes` plus the red banner.
  - **After** applying this same guard to the built `lib/client.cjs`: no console TypeError, no banner, and observation-tab detection still behaves correctly (re-opening an already-open tab is suppressed as before).
- `node --check` on the patched bundle passes.

Happy to reshape the fix if you'd rather keep `splits` required and only guard at the call site — the type change is included because the field is genuinely optional on current DSH.
