### PR TITLE
fix(dsh-plugin-browserskill): guard undefined sidebar roots in observationTabOpen

### DIFF
--- a/packages/dsh-plugin-browserskill/src/client/observation-sidebar.tsx
+++ b/packages/dsh-plugin-browserskill/src/client/observation-sidebar.tsx
@@ -64,8 +64,14 @@ export interface SidebarSplitLike {
 export type SidebarNodeLike = SidebarLeafLike | SidebarSplitLike;
 
 export interface SidebarStateLike {
-  splits: SidebarNodeLike;
-  bottomSplits: SidebarNodeLike;
+  /**
+   * Optional because dsh-better-sidebar >= 0.19 removed the top-level splits
+   * workbench: at runtime `state.splits` is simply absent (undefined), and
+   * only `bottomSplits` is populated. Declaring it required made
+   * `observationTabOpen` crash on `node.kind` for the undefined root.
+   */
+  splits?: SidebarNodeLike;
+  bottomSplits?: SidebarNodeLike;
   /** Whether the right panel is expanded (the merged drawer on narrow screens). */
   panelOpen?: boolean;
 }
@@ -159,7 +165,12 @@ export function ObservationSidebarTab({
   return <div className={css["sidebar-tab"]}>{body}</div>;
 }
 
-function* leafNodes(node: SidebarNodeLike): Generator<SidebarLeafLike> {
+function* leafNodes(node: SidebarNodeLike | undefined): Generator<SidebarLeafLike> {
+  // Guard the undefined root: with dsh-better-sidebar >= 0.19 the top-level
+  // `state.splits` workbench no longer exists, so callers iterate over an
+  // undefined member of the root pair. Skip it instead of throwing
+  // "Cannot read properties of undefined (reading 'kind')".
+  if (node === undefined) return;
   if (node.kind === "leaf") {
     yield node;
     return;
@@ -171,6 +182,7 @@ function* leafNodes(node: SidebarNodeLike): Generator<SidebarLeafLike> {
 export function observationTabOpen(state: SidebarStateLike | undefined): boolean {
   if (state === undefined) return false;
   for (const root of [state.splits, state.bottomSplits]) {
+    if (root === undefined) continue;
     for (const leaf of leafNodes(root)) {
       if (leaf.tabs.some((tab) => tab.type === OBSERVATION_TAB_TYPE)) return true;
     }


### PR DESCRIPTION
## Summary
- With `dsh-better-sidebar >= 0.19` the top-level splits workbench no longer exists: the sidebar client state carries no `splits` field at runtime, while `SidebarStateLike` declared it as required.
- `observationTabOpen()` iterates `[state.splits, state.bottomSplits]` and feeds each entry into `leafNodes()`, so on every sidebar store notification the generator evaluated `node.kind` on `undefined` and threw, crashing the whole `Sidebar` React tree through its error boundary:

```
TypeError: Cannot read properties of undefined (reading 'kind')
    at leafNodes (.../client.js:122389)
    at leafNodes.next (<anonymous>)
    at observationTabOpen (.../client.js:122398)
    at SidebarStore.notify (.../client.js:135981)
    at SidebarStore.setSession (.../client.js:135881)
```

## Reproduction
- dsh 0.1.5-rc.2 + dsh-better-sidebar 0.19.x
- Open a conversation and toggle the right sidebar (any `setSession` notify with no splits workbench present)
- The sidebar renders blank; the error is persisted by the app's error boundary

## Fix
- `SidebarStateLike.splits` becomes optional (`splits?: SidebarNodeLike`), matching the >= 0.19 runtime shape
- `leafNodes()` accepts `SidebarNodeLike | undefined` and returns early on an undefined root
- `observationTabOpen()` skips undefined members of the root pair

## Test plan
- [x] Reproduced the crash on dsh 0.1.5-rc.2 + dsh-better-sidebar 0.19.x before the fix
- [x] With the patch applied (verified against the built plugin bundle), toggling the sidebar and switching sessions no longer throws, and observation-tab detection still finds tabs registered under `bottomSplits`
- [ ] Package `pnpm typecheck` (not run here — the patch is type-additive narrowing only)