### PR TITLE
fix(dsh-plugin): tolerate an unpopulated sidebar layout on first paint

### DIFF
--- a/packages/dsh-plugin-browserskill/src/client/observation-sidebar.tsx
+++ b/packages/dsh-plugin-browserskill/src/client/observation-sidebar.tsx
@@ -70,7 +70,8 @@ export interface SidebarStateLike {
    * optional here; earlier versions always provide it.
    */
   splits?: SidebarNodeLike;
-  bottomSplits: SidebarNodeLike;
+  /** Absent as well on the host's first frames, before either tree is populated. */
+  bottomSplits?: SidebarNodeLike;
   /** Whether the right panel is expanded (the merged drawer on narrow screens). */
   panelOpen?: boolean;
 }
@@ -164,12 +165,15 @@ export function ObservationSidebarTab({
   return <div className={css["sidebar-tab"]}>{body}</div>;
 }
 
-function* leafNodes(node: SidebarNodeLike): Generator<SidebarLeafLike> {
+function* leafNodes(node: SidebarNodeLike | undefined): Generator<SidebarLeafLike> {
+  // The workbench layout is not populated yet on the first paint, so a root
+  // (or a split's children) can be missing; an absent subtree has no leaves.
+  if (node === undefined) return;
   if (node.kind === "leaf") {
     yield node;
     return;
   }
-  for (const child of node.children) yield* leafNodes(child);
+  for (const child of node.children ?? []) yield* leafNodes(child);
 }
 
 /** Whether a tab of our type is already open in either sidebar workbench. */

--- a/packages/dsh-plugin-browserskill/tests/client/observation-sidebar.test.tsx
+++ b/packages/dsh-plugin-browserskill/tests/client/observation-sidebar.test.tsx
@@ -290,6 +290,23 @@ describe("observationTabOpen", () => {
     expect(() => observationTabOpen(noSplits)).not.toThrow();
     expect(observationTabOpen(noSplits)).toBe(false);
   });
+
+  it("tolerates a layout whose trees are not populated yet (first paint, #232)", () => {
+    // better-sidebar 0.19 publishes the state before either workbench tree
+    // exists; the first open used to throw "Cannot read properties of
+    // undefined (reading 'kind')" and land in the host's error boundary.
+    expect(observationTabOpen({})).toBe(false);
+    // Only one tree present: the tab is still found in it.
+    expect(observationTabOpen({ splits: leafWith(OBSERVATION_TAB_TYPE).splits })).toBe(true);
+    expect(observationTabOpen({ bottomSplits: leafWith(OBSERVATION_TAB_TYPE).splits })).toBe(true);
+    // A split whose children are not populated yet is treated as empty.
+    const halfBuilt: SidebarStateLike = {
+      splits: { kind: "split", id: "s1", dir: "row", sizes: [1] } as SidebarStateLike["splits"],
+      bottomSplits: leafWith(OBSERVATION_TAB_TYPE).splits,
+    };
+    expect(observationTabOpen(halfBuilt)).toBe(true);
+    expect(observationTabOpen({ splits: halfBuilt.splits })).toBe(false);
+  });
 });
 
 describe("ObservationSidebarTab", () => {


### PR DESCRIPTION
Closes #232.

## What happened

Under `dsh-better-sidebar` 0.19 the workbench state reaches the plugin before either layout tree exists, so `observationTabOpen()` handed an `undefined` root to `leafNodes()`, which read `.kind` and threw `Cannot read properties of undefined (reading 'kind')`. The host's error boundary caught it, and the Browser Skill tab failed on every first open until the user pressed Retry (which always worked, because by then the layout was populated).

## Change

`leafNodes()` treats a missing node, and a split whose `children` are not populated yet, as having no leaves, so `observationTabOpen()` simply reports "not open" on those frames. `SidebarStateLike.splits` / `bottomSplits` are marked optional to document that the host can publish them absent; the only other reader, the test helper `withTabOpened`, handles that.

Not touched here: the related note in the issue about `service.openTab({ type, path })` resolving `path` as a file under the 0.19 tab contract. That is a separate contract migration and deserves its own change.

## Tests

New case in `tests/client/observation-sidebar.test.tsx`: an empty state, a state with only one of the two trees, a split without children next to a populated tree, and a lone childless split.

```
pnpm run build:css && pnpm run build:skill && npx vitest run tests/client/observation-sidebar.test.tsx   # 13 passed
npx tsc --noEmit   # clean
npx biome check <changed files>   # clean
```