### PR TITLE
Fix/canvas visual geometry

### DIFF
--- a/apps/extension/src/session-manager/__tests__/ref-store.test.ts
+++ b/apps/extension/src/session-manager/__tests__/ref-store.test.ts
@@ -23,11 +23,12 @@ describe("RefStore", () => {
     s.set("@e1", 1);
     s.set("@e2", 2);
     s.replace([
-      ["e10", { backendNodeId: 10, tabId: 1 }],
+      ["e10", { backendNodeId: 10, tabId: 1, name: "Save" }],
       ["@e11", { backendNodeId: 11, tabId: 1 }],
     ]);
     expect(s.resolve("@e1")).toBeNull();
     expect(s.resolve("@e10")).toBe(10);
+    expect(s.resolveEntry("e10")).toMatchObject({ kind: "dom", name: "Save" });
     expect(s.resolve("@e10", { tabId: 1 })).toBe(10);
     expect(s.resolve("@e10", { tabId: 2 })).toBeNull();
     expect(s.resolve("@e11")).toBe(11);

--- a/apps/extension/src/session-manager/ref-store.ts
+++ b/apps/extension/src/session-manager/ref-store.ts
@@ -1,19 +1,11 @@
-/**
- * Per-session map from `@e<N>` snapshot refs to a CDP node address.
- *
- * Each fresh `tool.snapshot` resets the store: M6 will call
- * `replace(...)` with the new ref → node address pairs. A node address
- * includes the owning flat CDP session/frame when the element lives in
- * an OOPIF; tools resolve live geometry from that identity at call time.
- *
- * Refs are session-scoped (§7): looking up a ref in the wrong session
- * returns `null`, never silently leaks. Storing values in different
- * sessions is fine; they live in independent `RefStore` instances
- * inside the `SessionContext`.
- */
+import type { VisualCandidate } from "@/tools/vom/visual-discovery";
+
+/** Session-local refs describe the latest observation. Reusing eN does not identify
+ * which observation a caller read; generation is internal bookkeeping only. */
 export type BackendNodeId = number;
 
-export interface RefEntry {
+export interface DomRefEntry {
+  readonly kind: "dom";
   name?: string;
   backendNodeId: BackendNodeId;
   tabId: number | null;
@@ -22,7 +14,15 @@ export interface RefEntry {
   generation: number;
 }
 
+export interface VisualRefInput {
+  readonly kind: "visual-region";
+  readonly candidate: VisualCandidate;
+}
+
+export type RefEntry = DomRefEntry | (VisualRefInput & { readonly generation: number });
+
 export type RefInput =
+  | VisualRefInput
   | BackendNodeId
   | {
       name?: string;
@@ -33,7 +33,7 @@ export type RefInput =
     };
 
 export class RefStore {
-  private readonly map = new Map<string, RefEntry>();
+  private map = new Map<string, RefEntry>();
   private generation = 0;
 
   size(): number {
@@ -46,7 +46,7 @@ export class RefStore {
 
   resolve(ref: string, opts: { tabId?: number } = {}): BackendNodeId | null {
     const entry = this.map.get(normaliseRef(ref));
-    if (!entry) return null;
+    if (!entry || entry.kind !== "dom") return null;
     if (opts.tabId !== undefined && entry.tabId !== opts.tabId) return null;
     return entry.backendNodeId;
   }
@@ -60,9 +60,11 @@ export class RefStore {
    * Used after every fresh `tool.snapshot`.
    */
   replace(entries: Iterable<readonly [string, RefInput]>): void {
-    this.map.clear();
-    this.generation += 1;
-    for (const [ref, input] of entries) this.map.set(normaliseRef(ref), this.entry(input));
+    const generation = this.generation + 1;
+    const next = new Map<string, RefEntry>();
+    for (const [ref, input] of entries) next.set(normaliseRef(ref), this.entry(input, generation));
+    this.map = next;
+    this.generation = generation;
   }
 
   set(
@@ -75,6 +77,7 @@ export class RefStore {
     } = {},
   ): void {
     this.map.set(normaliseRef(ref), {
+      kind: "dom",
       backendNodeId: id,
       tabId: opts.tabId ?? null,
       ...(opts.frameId ? { frameId: opts.frameId } : {}),
@@ -91,21 +94,38 @@ export class RefStore {
     return this.map.entries();
   }
 
-  private entry(input: RefInput): RefEntry {
+  private entry(input: RefInput, generation: number): RefEntry {
+    if (typeof input !== "number" && "kind" in input) {
+      const { document } = input.candidate;
+      if (
+        !document?.attachmentId ||
+        !document.frameId ||
+        !Number.isSafeInteger(document.target?.tabId) ||
+        !Number.isSafeInteger(document.documentElementBackendNodeId) ||
+        document.documentElementBackendNodeId <= 0 ||
+        !Number.isSafeInteger(input.candidate.backendNodeId) ||
+        input.candidate.backendNodeId <= 0
+      )
+        throw new TypeError("visual ref requires a verified DOM identity and anchor");
+      // Preserve the read-only evidence and shared clipping chain; do not clone ancestors per ref.
+      return { kind: "visual-region", candidate: input.candidate, generation };
+    }
     if (typeof input === "number") {
       return {
+        kind: "dom",
         backendNodeId: input,
         tabId: null,
-        generation: this.generation,
+        generation,
       };
     }
     return {
+      kind: "dom",
       ...(input.name ? { name: input.name } : {}),
       backendNodeId: input.backendNodeId,
       tabId: input.tabId,
       ...(input.frameId ? { frameId: input.frameId } : {}),
       ...(input.cdpSessionId ? { cdpSessionId: input.cdpSessionId } : {}),
-      generation: this.generation,
+      generation,
     };
   }
 }

--- a/apps/extension/src/session-manager/ref-store.ts
+++ b/apps/extension/src/session-manager/ref-store.ts
@@ -36,6 +36,10 @@ export class RefStore {
   private map = new Map<string, RefEntry>();
   private generation = 0;
 
+  get revision(): number {
+    return this.generation;
+  }
+
   size(): number {
     return this.map.size;
   }
@@ -87,6 +91,7 @@ export class RefStore {
   }
 
   clear(): void {
+    this.generation++;
     this.map.clear();
   }
 

--- a/apps/extension/src/tools/__tests__/human-loop.test.ts
+++ b/apps/extension/src/tools/__tests__/human-loop.test.ts
@@ -405,6 +405,7 @@ describe("handleRequestHelp", () => {
               agentWindowId: 99,
               refStore: {
                 resolveEntry: () => ({
+                  kind: "dom",
                   backendNodeId: 42,
                   tabId: 5,
                   frameId: "child",

--- a/apps/extension/src/tools/__tests__/observation.test.ts
+++ b/apps/extension/src/tools/__tests__/observation.test.ts
@@ -3813,7 +3813,9 @@ describe("handleSnapshot", () => {
 
     if ("code" in result) throw new Error(`unexpected error: ${JSON.stringify(result)}`);
     expect(result.text).toContain('@e1 button "Frame action"');
-    const frameRef = [...ctx.refStore.entries()].find(([, entry]) => entry.backendNodeId === 22);
+    const frameRef = [...ctx.refStore.entries()].find(
+      ([, entry]) => entry.kind === "dom" && entry.backendNodeId === 22,
+    );
     expect(frameRef?.[1]).toMatchObject({
       tabId: 4,
       frameId: "child",

--- a/apps/extension/src/tools/__tests__/visual-geometry.browser.test.ts
+++ b/apps/extension/src/tools/__tests__/visual-geometry.browser.test.ts
@@ -1,0 +1,335 @@
+// @vitest-environment node
+import { describe, expect, it } from "vitest";
+import type { CdpFrame } from "@/browser-driver/frame-graph";
+import type { CdpRunner } from "../shared";
+import { captureVisualScreenshot } from "../visual-screenshot";
+import { resolveVisualRegionNow, verifyVisualHit } from "../visual-target";
+import { captureObservationFacts } from "../vom/capture-coordinator";
+import { discoverVisualCandidates, type VisualCandidate } from "../vom/visual-discovery";
+
+type Send = <T = Record<string, unknown>>(
+  method: string,
+  params?: object,
+  sessionId?: string,
+) => Promise<T>;
+type Tree = { frame: { id: string }; childFrames?: Tree[] };
+type Rect = { x: number; y: number; width: number; height: number };
+
+// Uses an isolated native Chrome profile and the production snapshot/live/screenshot
+// paths. Fixture dimensions and browser hit testing provide independent expectations.
+async function withPage(
+  run: (page: {
+    cdp: CdpRunner;
+    send: Send;
+    load: (html: string) => Promise<void>;
+    evaluate: <T>(expression: string) => Promise<T>;
+    observe: () => Promise<VisualCandidate>;
+  }) => Promise<void>,
+) {
+  const evalRoot = new URL("../../../../../evals/browser/", import.meta.url);
+  const { withChrome } = await import(
+    new URL("cases/regression/snapshot-coordinates/chrome.mjs", evalRoot).href
+  );
+  await withChrome(
+    { executable: process.env.BSK_GEOMETRY_CHROME, deviceScale: 1, zoom: 1 },
+    async (send: Send) => {
+      const { targetId } = await send<{ targetId: string }>("Target.createTarget", {
+        url: "about:blank",
+      });
+      const { sessionId } = await send<{ sessionId: string }>("Target.attachToTarget", {
+        targetId,
+        flatten: true,
+      });
+      await send("Target.activateTarget", { targetId });
+      const local: Send = (method, params) => send(method, params, sessionId);
+      const { frameTree } = await local<{ frameTree: Tree }>("Page.getFrameTree");
+      const cdp: CdpRunner = {
+        send: (_tab, method, params) => local(method, params),
+        getAttachmentId: () => "visual-geometry-browser-test",
+        getFrameGraph: async () => {
+          const { frameTree } = await local<{ frameTree: Tree }>("Page.getFrameTree");
+          const frames: CdpFrame[] = [];
+          const visit = async (tree: Tree, parentFrameId?: string) => {
+            const owner = parentFrameId
+              ? await local<{ backendNodeId: number }>("DOM.getFrameOwner", {
+                  frameId: tree.frame.id,
+                })
+              : undefined;
+            frames.push({
+              frameId: tree.frame.id,
+              target: { tabId: 1 },
+              parentFrameId,
+              ownerBackendNodeId: owner?.backendNodeId,
+            });
+            for (const child of tree.childFrames ?? []) await visit(child, tree.frame.id);
+          };
+          await visit(frameTree);
+          return { rootFrameId: frameTree.frame.id, frames };
+        },
+      };
+      await run({
+        cdp,
+        send: local,
+        load: async (html) => {
+          await local("Page.setDocumentContent", {
+            frameId: frameTree.frame.id,
+            html: `<!doctype html>${html}`,
+          });
+          await local("Runtime.evaluate", {
+            expression:
+              "new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)))",
+            awaitPromise: true,
+          });
+        },
+        evaluate: async <T>(expression: string) => {
+          const reply = await local<{ result: { value: T }; exceptionDetails?: unknown }>(
+            "Runtime.evaluate",
+            { expression, returnByValue: true, awaitPromise: true },
+          );
+          expect(reply.exceptionDetails).toBeUndefined();
+          return reply.result.value;
+        },
+        observe: async () => {
+          const facts = await captureObservationFacts(cdp, 1, undefined, undefined, {
+            includeVisualFacts: true,
+          });
+          const discovered = await discoverVisualCandidates(facts);
+          expect(discovered.issues).toEqual([]);
+          expect(discovered.candidates).toHaveLength(1);
+          return discovered.candidates[0];
+        },
+      });
+    },
+  );
+}
+
+async function expectCapture(cdp: CdpRunner, candidate: VisualCandidate, crop: Rect) {
+  expect(candidate.region.crop).toEqual(crop);
+  const live = await resolveVisualRegionNow(cdp, candidate);
+  if ("code" in live) throw new Error(live.message);
+  expect(live.crop).toEqual(crop);
+  const shot = await captureVisualScreenshot(cdp, candidate);
+  if ("code" in shot) throw new Error(shot.message);
+  expect(shot.mapping?.crop).toEqual(crop);
+  // Read the actual PNG header, not just the requested clip or response metadata.
+  const png = Buffer.from(shot.image_base64, "base64");
+  expect([png.readUInt32BE(16), png.readUInt32BE(20)]).toEqual([crop.width, crop.height]);
+  const point = { x: crop.x + crop.width - 1, y: crop.y + crop.height - 1 };
+  expect(await verifyVisualHit(cdp, live, point)).toBe(true);
+  return live;
+}
+
+const canvas = '<canvas width="200" height="200" style="display:block;background:red"></canvas>';
+const bodyStyle = "margin:0;width:100px;height:100px;";
+
+describe.skipIf(!process.env.BSK_GEOMETRY_CHROME)(
+  "native Canvas viewport overflow and rendered ancestry",
+  { timeout: 30_000 },
+  () => {
+    it.each([
+      { name: "body hidden propagates", root: "", body: "overflow:hidden", size: 200 },
+      { name: "body auto propagates", root: "", body: "overflow:auto", size: 200 },
+      { name: "body clip propagates", root: "", body: "overflow:clip", size: 200 },
+      {
+        name: "root hidden clips the viewport",
+        root: "overflow:hidden;width:100px;height:100px",
+        body: "",
+        size: 200,
+      },
+      {
+        name: "root clip clips the viewport",
+        root: "overflow:clip;width:100px;height:100px",
+        body: "",
+        size: 200,
+      },
+      {
+        name: "body remains local under root hidden",
+        root: "overflow:hidden",
+        body: "overflow:hidden",
+        size: 100,
+      },
+      {
+        name: "body remains local under root axis overflow",
+        root: "overflow-x:clip",
+        body: "overflow:hidden",
+        size: 100,
+      },
+      ...[
+        "contain:size",
+        "contain:layout",
+        "contain:style",
+        "container-type:inline-size",
+        "content-visibility:auto",
+      ].flatMap((containment) => [
+        {
+          name: `root ${containment} prevents propagation`,
+          root: containment,
+          body: "overflow:hidden",
+          size: 100,
+        },
+        {
+          name: `body ${containment} prevents propagation`,
+          root: "",
+          body: `overflow:hidden;${containment}`,
+          size: 100,
+        },
+      ]),
+    ])("$name", async ({ root, body, size }) => {
+      await withPage(async ({ cdp, load, evaluate, observe }) => {
+        await load(`<style>html{${root}}body{${bodyStyle}${body}}</style>${canvas}`);
+        // This point lies outside the body's 100px box but inside the Canvas box.
+        expect(
+          await evaluate("document.elementFromPoint(150,150) === document.querySelector('canvas')"),
+        ).toBe(size === 200);
+        await expectCapture(cdp, await observe(), { x: 0, y: 0, width: size, height: size });
+      });
+    });
+
+    it("retains nested element clipping and rejects changed overflow propagation", async () => {
+      await withPage(async ({ cdp, load, evaluate, observe }) => {
+        await load(
+          `<style>body{${bodyStyle}overflow:hidden}</style><div style="width:80px;height:70px;overflow:hidden">${canvas}</div>`,
+        );
+        await expectCapture(cdp, await observe(), { x: 0, y: 0, width: 80, height: 70 });
+        await load(`<style>body{${bodyStyle}overflow:hidden}</style>${canvas}`);
+        const candidate = await observe();
+        await evaluate("document.documentElement.style.overflow = 'hidden'");
+        expect(await resolveVisualRegionNow(cdp, candidate)).toMatchObject({
+          data: { reason: "visual_target_changed" },
+        });
+        await expectCapture(cdp, await observe(), { x: 0, y: 0, width: 100, height: 100 });
+      });
+    });
+
+    it("applies body propagation inside a clipped iframe viewport", async () => {
+      await withPage(async ({ cdp, load, evaluate, observe }) => {
+        await load(
+          "<style>body{margin:0}iframe{display:block;border:0;width:160px;height:140px;margin:20px}</style><iframe></iframe>",
+        );
+        await evaluate(`new Promise(resolve => {
+        const frame = document.querySelector('iframe'); frame.onload = () => resolve(true);
+        frame.srcdoc = ${JSON.stringify(`<!doctype html><style>body{${bodyStyle}overflow:hidden}</style>${canvas}`)};
+      })`);
+        expect(
+          await evaluate(
+            "document.querySelector('iframe').contentDocument.elementFromPoint(150,130).tagName",
+          ),
+        ).toBe("CANVAS");
+        await expectCapture(cdp, await observe(), { x: 20, y: 20, width: 160, height: 140 });
+      });
+    });
+
+    it.each([
+      "open",
+      "closed",
+    ])("follows %s slot clips and invalidates changed distribution", async (mode) => {
+      await withPage(async ({ cdp, load, evaluate, observe }) => {
+        await load(`<style>body{margin:0}</style><div id="host">${canvas}</div>`);
+        await evaluate(`{
+        const root = document.querySelector('#host').attachShadow({mode:${JSON.stringify(mode)}});
+        root.innerHTML = '<div style="width:100px;height:100px;overflow:hidden"><slot style="display:block;overflow:hidden;width:80px;height:90px"></slot></div><slot name="other" style="display:block"></slot>';
+        window.testRoot = root;
+      }`);
+        const candidate = await observe();
+        const live = await expectCapture(cdp, candidate, { x: 0, y: 0, width: 80, height: 90 });
+        expect(await verifyVisualHit(cdp, live, { x: 90, y: 50 })).toBe(false);
+        await evaluate("window.testRoot.querySelector('slot').style.width = '70px'");
+        expect(await resolveVisualRegionNow(cdp, candidate)).toMatchObject({
+          data: { reason: "visual_target_changed" },
+        });
+        const beforeRedistribution = await observe();
+        await expectCapture(cdp, beforeRedistribution, { x: 0, y: 0, width: 70, height: 90 });
+        await evaluate("document.querySelector('canvas').slot = 'other'");
+        expect(await resolveVisualRegionNow(cdp, beforeRedistribution)).toMatchObject({
+          data: { reason: "visual_target_changed" },
+        });
+        await expectCapture(cdp, await observe(), { x: 0, y: 100, width: 200, height: 200 });
+      });
+    });
+
+    it.each([
+      "open",
+      "closed",
+    ])("follows nested %s slots with reassigned slot elements", async (mode) => {
+      await withPage(async ({ cdp, load, evaluate, observe }) => {
+        await load(`<style>body{margin:0}</style><div id="host">${canvas}</div>`);
+        await evaluate(`{
+        const outer = document.querySelector('#host').attachShadow({mode:${JSON.stringify(mode)}});
+        outer.innerHTML = '<div id="inner"><slot style="display:block"></slot></div>';
+        const inner = outer.querySelector('#inner').attachShadow({mode:${JSON.stringify(mode)}});
+        inner.innerHTML = '<div style="width:90px;height:60px;overflow:hidden"><slot style="display:block"></slot></div>';
+      }`);
+        await expectCapture(cdp, await observe(), { x: 0, y: 0, width: 90, height: 60 });
+      });
+    });
+
+    it("does not shift the viewport clip by the root margin or border", async () => {
+      await withPage(async ({ cdp, load, evaluate, observe }) => {
+        await load(
+          `<style>html{margin:30px 0 0 40px;border:5px solid;overflow:hidden;width:100px;height:100px}body{margin:0}canvas{position:relative;left:-40px;top:-30px}</style>${canvas}`,
+        );
+        expect(
+          await evaluate("document.elementFromPoint(10,10) === document.querySelector('canvas')"),
+        ).toBe(true);
+        await expectCapture(cdp, await observe(), { x: 5, y: 5, width: 200, height: 200 });
+      });
+    });
+
+    it("clips propagated overflow at the viewport after scrolling", async () => {
+      await withPage(async ({ cdp, load, evaluate, observe }) => {
+        await load(
+          `<style>body{${bodyStyle}overflow:hidden}canvas{width:2000px;height:2000px}</style>${canvas}`,
+        );
+        await evaluate("scrollTo(20,30)");
+        const viewport = await evaluate<Rect>("({x:0,y:0,width:innerWidth,height:innerHeight})");
+        const candidate = await observe();
+        expect(candidate.region.borderBox).toMatchObject({ x: -20, y: -30 });
+        await expectCapture(cdp, candidate, viewport);
+      });
+    });
+
+    it("rejects a closed slot reassigned during the live read and releases its objects", async () => {
+      await withPage(async ({ cdp, load, evaluate, observe }) => {
+        await load(`<style>body{margin:0}</style><div id="host">${canvas}</div>`);
+        await evaluate(
+          `document.querySelector('#host').attachShadow({mode:'closed'}).innerHTML = '<slot style="display:block;width:100px;height:100px;overflow:hidden"></slot><slot name="other" style="display:block"></slot>'`,
+        );
+        const candidate = await observe();
+        let changed = false;
+        const resolvedGroups: string[] = [],
+          releasedGroups: string[] = [];
+        const racing: CdpRunner = {
+          ...cdp,
+          send: async <T>(tabId: number, method: string, params?: object) => {
+            const reply = await cdp.send<T>(tabId, method, params);
+            if (method === "DOM.resolveNode")
+              resolvedGroups.push((params as { objectGroup: string }).objectGroup);
+            if (method === "Runtime.releaseObjectGroup")
+              releasedGroups.push((params as { objectGroup: string }).objectGroup);
+            if (method === "DOM.describeNode" && !changed) {
+              changed = true;
+              await evaluate("document.querySelector('canvas').slot = 'other'");
+            }
+            return reply;
+          },
+        };
+        expect(await resolveVisualRegionNow(racing, candidate)).toMatchObject({
+          data: { reason: "visual_target_changed" },
+        });
+        expect(changed).toBe(true);
+        expect(resolvedGroups).toHaveLength(2);
+        expect(new Set(resolvedGroups)).toEqual(new Set(releasedGroups));
+      });
+    });
+
+    it("preserves direct children of closed shadow roots", async () => {
+      await withPage(async ({ cdp, load, evaluate, observe }) => {
+        await load('<style>body{margin:0}</style><div id="host"></div>');
+        await evaluate(
+          `document.querySelector('#host').attachShadow({mode:'closed'}).innerHTML = ${JSON.stringify(canvas)}`,
+        );
+        await expectCapture(cdp, await observe(), { x: 0, y: 0, width: 200, height: 200 });
+      });
+    });
+  },
+);

--- a/apps/extension/src/tools/__tests__/visual-ref.test.ts
+++ b/apps/extension/src/tools/__tests__/visual-ref.test.ts
@@ -1,0 +1,208 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { SessionManager } from "@/session-manager/manager";
+import { RefStore, type VisualRefInput } from "@/session-manager/ref-store";
+import { handleDownload } from "../download";
+import { handleRequestHelp, resetHelpLifecycleForTests } from "../human-loop";
+import { handleClick, handleFill, handleHover, handlePress, handleSelect } from "../interaction";
+import { handleGetHtml, handleScreenshot } from "../observation";
+import type { CdpRunner } from "../shared";
+import { lookupRefTarget, lookupSnapshotRef, resolveSnapshotRef } from "../snapshot-ref";
+import { handleUpload } from "../upload";
+
+function visual(): VisualRefInput {
+  return {
+    kind: "visual-region",
+    candidate: {
+      document: {
+        attachmentId: "a",
+        target: { tabId: 4, sessionId: "child" },
+        frameId: "frame",
+        documentElementBackendNodeId: 1,
+      },
+      backendNodeId: 42,
+      parentBackendNodeId: 1,
+      region: {
+        status: "available",
+        borderBox: { x: 0, y: 0, width: 100, height: 50 },
+        crop: { x: 0, y: 0, width: 100, height: 50 },
+      },
+    },
+  };
+}
+
+async function setup() {
+  const manager = new SessionManager({
+    agentWindow: {
+      create: async () => 100,
+      remove: async () => {},
+      ensureActiveTab: async () => 4,
+    },
+  });
+  const ctx = await manager.start("test");
+  ctx.refStore.replace([
+    ["e1", visual()],
+    ["e2", { backendNodeId: 43, tabId: 4 }],
+  ]);
+  const send = vi.fn(async () => {
+    throw new Error("unexpected target operation");
+  });
+  const cdp = { send, sendToTarget: send, trackSessionTab: vi.fn() } as unknown as CdpRunner;
+  const tab = { id: 4, windowId: 100, active: true, url: "https://example.com" } as chrome.tabs.Tab;
+  const tabsApi = { get: vi.fn(async () => tab), query: vi.fn(async () => [tab]) };
+  return { manager, ctx, send, cdp, tabsApi };
+}
+
+describe("typed visual refs", () => {
+  afterEach(() => resetHelpLifecycleForTests());
+
+  it("keeps candidate evidence and cannot resolve a visual anchor as a bare DOM node", () => {
+    const store = new RefStore();
+    const input = visual();
+    store.replace([
+      ["@e1", input],
+      ["e2", { backendNodeId: 43, tabId: 4 }],
+    ]);
+    const entry = store.resolveEntry("e1");
+    expect(entry?.kind).toBe("visual-region");
+    if (entry?.kind !== "visual-region") throw new Error("missing visual ref");
+    expect(entry.candidate).toBe(input.candidate);
+    expect(entry.generation).toBe(1);
+    expect(store.resolve("@e1")).toBeNull();
+    expect(store.resolve("e2")).toBe(43);
+    // The latest observation replaces both target kinds; eN strings carry no generation.
+    store.replace([["e1", { backendNodeId: 99, tabId: 4 }]]);
+    expect(store.resolve("e1")).toBe(99);
+    expect(store.resolveEntry("e1")).toMatchObject({ kind: "dom", generation: 2 });
+    expect(store.resolveEntry("e2")).toBeNull();
+  });
+
+  it("rejects missing visual identity without partially publishing a replacement", () => {
+    const store = new RefStore();
+    store.set("e1", 10, { tabId: 4 });
+    const invalid = visual();
+    invalid.candidate.document.attachmentId = "";
+    expect(() =>
+      store.replace([
+        ["e2", 20],
+        ["e3", invalid],
+      ]),
+    ).toThrow(TypeError);
+    expect(store.resolveEntry("e1")).toMatchObject({ generation: 0, backendNodeId: 10 });
+    expect(store.size()).toBe(1);
+    store.replace([["e1", visual()]]);
+    expect(store.resolveEntry("e1")?.generation).toBe(1);
+  });
+
+  it("isolates tabs/sessions and distinguishes unsupported targets from missing refs", async () => {
+    const { ctx } = await setup();
+    expect(lookupRefTarget(ctx, "@e1", 4)?.kind).toBe("visual-region");
+    expect(lookupRefTarget(ctx, "e1", 5)).toBeNull();
+    expect(lookupSnapshotRef(ctx, "e1", 4)).toBeNull();
+    expect(resolveSnapshotRef(ctx, "e1", 4)).toMatchObject({
+      code: "unsupported",
+      data: { reason: "ref_kind_unsupported" },
+    });
+    expect(resolveSnapshotRef(ctx, "e1", 5)).toMatchObject({
+      code: "not_found",
+      data: { reason: "ref_not_found" },
+    });
+    expect(lookupRefTarget({ ...ctx, refStore: new RefStore() }, "e1", 4)).toBeNull();
+    expect(lookupSnapshotRef(ctx, "e2", 4)).toMatchObject({ backendNodeId: 43 });
+  });
+
+  it.each([
+    "click",
+    "fill",
+    "hover",
+    "press",
+    "select",
+    "get_html",
+    "screenshot",
+  ])("rejects visual refs in %s before target effects", async (tool) => {
+    const { manager, send, cdp, tabsApi } = await setup();
+    const params = { session_id: "test", tab_id: 4, ref: "@e1" };
+    const deps = { cdp, tabsApi };
+    const captureVisibleTab = vi.fn();
+    let result: unknown;
+    switch (tool) {
+      case "click":
+        result = await handleClick(manager, params, deps);
+        break;
+      case "fill":
+        result = await handleFill(manager, { ...params, value: "hello" }, deps);
+        break;
+      case "hover":
+        result = await handleHover(manager, params, deps);
+        break;
+      case "press":
+        result = await handlePress(manager, { ...params, key: "Enter" }, deps);
+        break;
+      case "select":
+        result = await handleSelect(manager, { ...params, values: ["one"] }, deps);
+        break;
+      case "get_html":
+        result = await handleGetHtml(manager, params, deps);
+        break;
+      case "screenshot":
+        result = await handleScreenshot(manager, params, {
+          ...deps,
+          captureApi: { ...tabsApi, captureVisibleTab },
+        });
+        break;
+    }
+    expect(result).toMatchObject({ code: "unsupported", data: { reason: "ref_kind_unsupported" } });
+    expect(send).not.toHaveBeenCalled();
+    expect(captureVisibleTab).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    "input",
+    "drop",
+    "download",
+  ] as const)("rejects visual refs before %s file-transfer setup", async (mode) => {
+    const { manager, send, cdp, tabsApi } = await setup();
+    const params = { session_id: "test", tab_id: 4, ref: "e1" };
+    const result =
+      mode === "download"
+        ? await handleDownload(
+            manager,
+            { ...params, browser_relative_dir: "test" },
+            { cdp, tabsApi },
+          )
+        : await handleUpload(
+            manager,
+            {
+              ...params,
+              mode,
+              files: [{ transfer_id: "test", name: "test.txt", staged_path: "/unused/test.txt" }],
+            },
+            { cdp, tabsApi },
+          );
+    expect(result).toMatchObject({ code: "unsupported", data: { reason: "ref_kind_unsupported" } });
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("does not scroll or highlight a visual anchor in human help", async () => {
+    const { manager, cdp, tabsApi, send } = await setup();
+    const sendToTab = vi.fn(async (_tab: number, _message: unknown) => ({
+      type: "bsk-help-response",
+      outcome: "continued",
+    }));
+    const result = await handleRequestHelp(
+      manager,
+      { session_id: "test", tab_id: 4, prompt: "help", targets: [{ ref: "@e1" }] },
+      {
+        cdp,
+        tabsApi,
+        sendToTab,
+        windows: { update: vi.fn(async () => ({}) as never) },
+        activateTab: vi.fn(async () => {}),
+        notifications: null,
+        autoAttachLifecycle: false,
+      },
+    );
+    expect(result).toMatchObject({ resolved_targets: [{ ref: "@e1", matched: false }] });
+    expect(send).not.toHaveBeenCalled();
+    expect(sendToTab.mock.calls[0][1]).toMatchObject({ rects: [], selectors: [] });
+  });
+});

--- a/apps/extension/src/tools/__tests__/visual-ref.test.ts
+++ b/apps/extension/src/tools/__tests__/visual-ref.test.ts
@@ -4,7 +4,7 @@ import { RefStore, type VisualRefInput } from "@/session-manager/ref-store";
 import { handleDownload } from "../download";
 import { handleRequestHelp, resetHelpLifecycleForTests } from "../human-loop";
 import { handleClick, handleFill, handleHover, handlePress, handleSelect } from "../interaction";
-import { handleGetHtml, handleScreenshot } from "../observation";
+import { handleGetHtml } from "../observation";
 import type { CdpRunner } from "../shared";
 import { lookupRefTarget, lookupSnapshotRef, resolveSnapshotRef } from "../snapshot-ref";
 import { handleUpload } from "../upload";
@@ -117,12 +117,10 @@ describe("typed visual refs", () => {
     "press",
     "select",
     "get_html",
-    "screenshot",
   ])("rejects visual refs in %s before target effects", async (tool) => {
     const { manager, send, cdp, tabsApi } = await setup();
     const params = { session_id: "test", tab_id: 4, ref: "@e1" };
     const deps = { cdp, tabsApi };
-    const captureVisibleTab = vi.fn();
     let result: unknown;
     switch (tool) {
       case "click":
@@ -143,16 +141,9 @@ describe("typed visual refs", () => {
       case "get_html":
         result = await handleGetHtml(manager, params, deps);
         break;
-      case "screenshot":
-        result = await handleScreenshot(manager, params, {
-          ...deps,
-          captureApi: { ...tabsApi, captureVisibleTab },
-        });
-        break;
     }
     expect(result).toMatchObject({ code: "unsupported", data: { reason: "ref_kind_unsupported" } });
     expect(send).not.toHaveBeenCalled();
-    expect(captureVisibleTab).not.toHaveBeenCalled();
   });
 
   it.each([

--- a/apps/extension/src/tools/__tests__/visual-screenshot.test.ts
+++ b/apps/extension/src/tools/__tests__/visual-screenshot.test.ts
@@ -126,6 +126,15 @@ function fixture(child = false, oopif = false) {
         };
       }
       if (method === "Runtime.releaseObjectGroup") return {};
+      // OOPIF projection uses the full viewport for scale, independently of
+      // the scrollbar-excluding layout viewport used for clipping.
+      if (method === "Runtime.evaluate" && target.sessionId === "oopif") {
+        expect(params).toMatchObject({
+          expression: "({ width: window.innerWidth, height: window.innerHeight })",
+          returnByValue: true,
+        });
+        return { result: { value: { width: 200, height: 100 } } };
+      }
       if (method === "Page.getLayoutMetrics")
         return {
           cssLayoutViewport: { clientWidth: 1200, clientHeight: 800, pageX: 0, pageY: 0 },

--- a/apps/extension/src/tools/__tests__/visual-screenshot.test.ts
+++ b/apps/extension/src/tools/__tests__/visual-screenshot.test.ts
@@ -6,6 +6,7 @@ import { handleScreenshot } from "../observation";
 import type { CdpRunner } from "../shared";
 import { consumeVisualCapture, issueVisualCapture } from "../visual-capture";
 import { captureVisualScreenshot, visualScreenshotScale } from "../visual-screenshot";
+import { resolveVisualRegionNow, verifyVisualHit } from "../visual-target";
 import type { VisualCandidate, VisualFramePath } from "../vom/visual-discovery";
 
 const styles = {
@@ -678,4 +679,82 @@ it.each([
   ).toHaveProperty("code", "invalid_params");
   expect(f.input).toHaveLength(0);
   expect(await handleClick(f.manager, f.params, f.deps)).not.toHaveProperty("code");
+});
+
+describe("visual hit shadow boundaries", () => {
+  it.each([
+    "plain",
+    "open",
+    "closed",
+    "nested",
+    "slotted",
+    "iframe",
+  ])("executes the hit script for %s targets and rejects occlusion in every scope", async (kind) => {
+    const container = document.createElement("div");
+    document.body.append(container);
+    const target = document.createElement(kind === "iframe" ? "iframe" : "canvas");
+    const scopes: { root: Document | ShadowRoot; node: Element }[] = [];
+    let parent: Element | ShadowRoot = container;
+    const modes: ShadowRootMode[] =
+      kind === "nested"
+        ? ["closed", "open", "closed"]
+        : kind === "plain"
+          ? []
+          : [kind === "open" ? "open" : "closed"];
+    let scope: Document | ShadowRoot = document;
+    for (const mode of modes) {
+      const host = document.createElement("div");
+      parent.append(host);
+      if (kind === "slotted") {
+        host.attachShadow({ mode }).append(document.createElement("slot"));
+        parent = host;
+        break;
+      }
+      scopes.push({ root: scope, node: host });
+      scope = host.attachShadow({ mode });
+      if (mode === "closed") expect(host.shadowRoot).toBeNull();
+      parent = scope;
+    }
+    parent.append(target);
+    scopes.push({ root: scope, node: target });
+    // happy-dom has no layout hit testing. Stub only the browser hit results;
+    // execute the actual CDP script against real DOM roots, including closed ones.
+    const hits = scopes.map(({ root, node }) => {
+      const original = Object.getOwnPropertyDescriptor(root, "elementFromPoint");
+      const hit = vi.fn((): Element | null => node);
+      Object.defineProperty(root, "elementFromPoint", { configurable: true, value: hit });
+      return { root, original, hit, node };
+    });
+    try {
+      const f = fixture();
+      const state = await resolveVisualRegionNow(f.cdp, f.candidate);
+      if ("code" in state) throw new Error(state.message);
+      const original = f.send.getMockImplementation()!;
+      f.send.mockImplementation(async (cdpTarget, method, params = {}) => {
+        if (
+          method === "Runtime.callFunctionOn" &&
+          String(params.functionDeclaration).includes("elementFromPoint")
+        ) {
+          const run = new Function(`return (${params.functionDeclaration});`)();
+          return { result: { value: run.call(target, 20, 30) } };
+        }
+        return original(cdpTarget, method, params);
+      });
+      expect(await verifyVisualHit(f.cdp, state, { x: 20, y: 30 })).toBe(true);
+      for (const { hit, node } of hits) {
+        hit.mockReturnValue(document.createElement("div"));
+        expect(await verifyVisualHit(f.cdp, state, { x: 20, y: 30 })).toBe(false);
+        hit.mockReturnValue(node);
+      }
+      target.remove();
+      expect(await verifyVisualHit(f.cdp, state, { x: 20, y: 30 })).toBe(false);
+      expect(f.cdp.getFrameGraph).not.toHaveBeenCalled();
+    } finally {
+      for (const { root, original } of hits) {
+        if (original) Object.defineProperty(root, "elementFromPoint", original);
+        else Reflect.deleteProperty(root, "elementFromPoint");
+      }
+      container.remove();
+    }
+  });
 });

--- a/apps/extension/src/tools/__tests__/visual-screenshot.test.ts
+++ b/apps/extension/src/tools/__tests__/visual-screenshot.test.ts
@@ -758,3 +758,86 @@ describe("visual hit shadow boundaries", () => {
     }
   });
 });
+
+it.each([
+  ["upper", "upper", true],
+  ["lower", "upper", false],
+  ["lower", "lower", true],
+  ["upper", "lower", false],
+] as const)("keeps overlapping target identity: requested=%s hit=%s", async (requested, hit, allowed) => {
+  const f = await pointFixture();
+  const lower = document.createElement("canvas");
+  const upper = document.createElement("canvas");
+  document.body.append(lower, upper);
+  const hitDescriptor = Object.getOwnPropertyDescriptor(document, "elementFromPoint");
+  // Model the browser's hit result: upper receives events, or passes them to lower.
+  Object.defineProperty(document, "elementFromPoint", {
+    configurable: true,
+    value: () => (hit === "upper" ? upper : lower),
+  });
+  const original = f.send.getMockImplementation()!;
+  f.send.mockImplementation(async (target, method, params = {}) => {
+    if (
+      method === "Runtime.callFunctionOn" &&
+      String(params.functionDeclaration).includes("elementFromPoint")
+    ) {
+      const run = new Function(`return (${params.functionDeclaration});`)();
+      const node = params.objectId === "4" ? upper : lower;
+      const coordinates = (params.arguments as { value: number }[]).map((arg) => arg.value);
+      return { result: { value: run.call(node, ...coordinates) } };
+    }
+    if (
+      method === "Runtime.callFunctionOn" &&
+      params.objectId === "4" &&
+      String(params.functionDeclaration).includes("styleNames")
+    ) {
+      const rows = [{ ...f.topRows[0], node: { backend: 4 } }, ...f.topRows.slice(1)];
+      return { result: { deepSerializedValue: encode({ top: true, dpr: 1, rows }) } };
+    }
+    return original(target, method, params);
+  });
+  try {
+    f.ctx.refStore.replace([
+      ["e1", { kind: "visual-region", candidate: f.candidate }],
+      ["e2", { kind: "visual-region", candidate: { ...f.candidate, backendNodeId: 4 } }],
+    ]);
+    const ref = requested === "upper" ? "e2" : "e1";
+    const shot = await handleScreenshot(
+      f.manager,
+      { session_id: "point", ref },
+      {
+        cdp: f.cdp,
+        tabsApi: f.deps.tabsApi,
+        captureApi: { ...f.deps.tabsApi, captureVisibleTab: vi.fn() },
+        sendToTab: vi.fn(async () => ({})),
+      },
+    );
+    expect(shot).toHaveProperty("capture_id");
+    const result = await handleClick(
+      f.manager,
+      {
+        ...f.params,
+        ref,
+        capture_id: (shot as { capture_id: string }).capture_id,
+      },
+      f.deps,
+    );
+    if (allowed) {
+      expect(result).toMatchObject({ x: 60, y: 40 });
+      expect(f.input.map((event) => event.type)).toEqual([
+        "mouseMoved",
+        "mousePressed",
+        "mouseReleased",
+      ]);
+    } else {
+      expect(result).toHaveProperty("data.reason", "visual_capture_stale");
+      expect(f.input).toHaveLength(0);
+    }
+    expect(f.cdp.getFrameGraph).not.toHaveBeenCalled();
+  } finally {
+    if (hitDescriptor) Object.defineProperty(document, "elementFromPoint", hitDescriptor);
+    else Reflect.deleteProperty(document, "elementFromPoint");
+    lower.remove();
+    upper.remove();
+  }
+});

--- a/apps/extension/src/tools/__tests__/visual-screenshot.test.ts
+++ b/apps/extension/src/tools/__tests__/visual-screenshot.test.ts
@@ -87,6 +87,10 @@ function fixture(child = false, oopif = false) {
   const childRows = [row(12, "canvas"), row(11, "html", rect(0, 0, 200, 100))];
   let calls = 0;
   const control = {
+    attachmentId: "a",
+    detached: false,
+    failIdentity: false,
+    onShot: (_attempt: number) => {},
     wrongOwner: false,
     rootChanged: false,
     failRead: false,
@@ -100,10 +104,12 @@ function fixture(child = false, oopif = false) {
       if (method === "DOM.getFrameOwner") return { backendNodeId: control.wrongOwner ? 999 : 2 };
       if (method === "Page.createIsolatedWorld")
         return { executionContextId: params.frameId === "child" ? 11 : 1 };
+      if (method === "DOM.resolveNode" && control.failIdentity) throw new Error("target gone");
       if (method === "DOM.resolveNode")
         return { object: { objectId: String(params.backendNodeId) } };
       if (method === "Runtime.callFunctionOn") {
         const isChild = params.objectId === "12";
+        if (control.detached) return { result: { deepSerializedValue: { type: "null" } } };
         if (!(params.functionDeclaration as string).includes("styleNames"))
           return {
             result: {
@@ -142,8 +148,11 @@ function fixture(child = false, oopif = false) {
         };
       if (method === "DOM.getBoxModel")
         return { model: { content: [100, 200, 500, 200, 500, 400, 100, 400] } };
-      if (method === "Page.captureScreenshot")
-        return { data: control.shots[Math.min(calls++, control.shots.length - 1)] };
+      if (method === "Page.captureScreenshot") {
+        const data = control.shots[Math.min(calls++, control.shots.length - 1)];
+        control.onShot(calls);
+        return { data };
+      }
       throw new Error(`unexpected ${method} ${target.sessionId}`);
     },
   );
@@ -151,7 +160,7 @@ function fixture(child = false, oopif = false) {
     send: ((tabId, method, params) =>
       send({ tabId }, method, params as Record<string, unknown>)) as CdpRunner["send"],
     sendToTarget: send as unknown as CdpRunner["sendToTarget"],
-    getAttachmentId: () => "a",
+    getAttachmentId: () => control.attachmentId,
     getFrameGraph: vi.fn(async () => {
       throw new Error("whole page discovery forbidden");
     }),
@@ -170,8 +179,8 @@ describe("visual screenshot", () => {
     expect(result).toMatchObject({ width: child ? 200 : 100, height: child ? 80 : 40 });
     expect(f.cdp.getFrameGraph).not.toHaveBeenCalled();
     const names = f.send.mock.calls.map((c) => c[1]);
-    expect(names.filter((n) => n === "DOM.getFrameOwner")).toHaveLength(child ? 1 : 0);
-    expect(names.filter((n) => n === "DOM.resolveNode")).toHaveLength(child ? 2 : 1);
+    expect(names.filter((n) => n === "DOM.getFrameOwner")).toHaveLength(child ? 2 : 0);
+    expect(names.filter((n) => n === "DOM.resolveNode")).toHaveLength(child ? 4 : 2);
     expect(names.some((n) => /scroll|DOMSnapshot|getFrameTree|Accessibility/.test(n))).toBe(false);
     expect(f.send.mock.calls.find((c) => c[1] === "Page.captureScreenshot")?.[2]).toMatchObject({
       clip: { ...f.candidate.region.crop, scale: 1 },
@@ -236,7 +245,7 @@ describe("visual screenshot", () => {
       width: 40,
       height: 20,
     });
-    expect(f.send.mock.calls.filter((c) => c[1] === "DOM.getFrameOwner")).toHaveLength(2);
+    expect(f.send.mock.calls.filter((c) => c[1] === "DOM.getFrameOwner")).toHaveLength(4);
     expect(f.send.mock.calls.find((c) => c[1] === "Page.captureScreenshot")?.[2]).toMatchObject({
       clip: crop,
     });
@@ -349,6 +358,75 @@ describe("visual screenshot", () => {
       data: { reason: "visual_pixel_budget_exceeded" },
     });
     expect(fail.send.mock.calls.filter((c) => c[1] === "Page.captureScreenshot")).toHaveLength(2);
+  });
+  it.each([
+    "attachment",
+    "root",
+    "anchor",
+    "owner",
+    "unavailable",
+    "cancel",
+  ])("rejects %s changes during capture", async (change) => {
+    const f = fixture(true, true);
+    f.control.onShot = () => {
+      if (change === "attachment") f.control.attachmentId = "new";
+      if (change === "root") f.control.rootChanged = true;
+      if (change === "anchor") f.control.detached = true;
+      if (change === "owner") f.control.wrongOwner = true;
+      if (change === "unavailable") f.control.failIdentity = true;
+      if (change === "cancel") f.controller.abort();
+    };
+    const result = await captureVisualScreenshot(f.cdp, f.candidate, f.controller.signal);
+    expect(result).toMatchObject(
+      change === "cancel" ? { code: "cancelled" } : { data: { reason: "visual_target_changed" } },
+    );
+    expect(f.send.mock.calls.filter((c) => c[1] === "Page.captureScreenshot")).toHaveLength(1);
+  });
+  it("accepts post-capture layout and style updates without rereading geometry", async () => {
+    const f = fixture();
+    f.control.onShot = () => {
+      f.topRows[0].box.x += 100;
+      f.topRows[0].styles.opacity = "0.5";
+      f.control.failRead = true;
+    };
+    expect(await captureVisualScreenshot(f.cdp, f.candidate)).toMatchObject({
+      width: 100,
+      height: 40,
+    });
+    const after = f.send.mock.calls.slice(
+      f.send.mock.calls.findIndex((c) => c[1] === "Page.captureScreenshot") + 1,
+    );
+    expect(after.filter((c) => c[1] === "DOM.resolveNode")).toHaveLength(1);
+    expect(
+      after.some(
+        (c) =>
+          c[1] === "Page.getLayoutMetrics" ||
+          c[1] === "DOM.getBoxModel" ||
+          String(c[2]?.functionDeclaration).includes("styleNames"),
+      ),
+    ).toBe(false);
+  });
+  it("remeasures geometry before a pixel-budget retry", async () => {
+    const f = fixture();
+    f.control.shots = [png(3000, 3000), png(100, 40)];
+    f.control.onShot = () => {
+      f.topRows[0].box.x += 100;
+    };
+    expect(await captureVisualScreenshot(f.cdp, f.candidate)).toMatchObject({
+      data: { reason: "visual_target_changed" },
+    });
+    expect(f.send.mock.calls.filter((c) => c[1] === "Page.captureScreenshot")).toHaveLength(1);
+  });
+  it("also checks identity after the second raster attempt", async () => {
+    const f = fixture();
+    f.control.shots = [png(3000, 3000), png(100, 40)];
+    f.control.onShot = (attempt) => {
+      if (attempt === 2) f.control.rootChanged = true;
+    };
+    expect(await captureVisualScreenshot(f.cdp, f.candidate)).toMatchObject({
+      data: { reason: "visual_target_changed" },
+    });
+    expect(f.send.mock.calls.filter((c) => c[1] === "Page.captureScreenshot")).toHaveLength(2);
   });
   it("rejects invalid PNG without guessing dimensions", async () => {
     const f = fixture();

--- a/apps/extension/src/tools/__tests__/visual-screenshot.test.ts
+++ b/apps/extension/src/tools/__tests__/visual-screenshot.test.ts
@@ -1,0 +1,373 @@
+import { describe, expect, it, vi } from "vitest";
+import type { CdpTarget } from "@/browser-driver/frame-graph";
+import { SessionManager } from "@/session-manager/manager";
+import { handleScreenshot } from "../observation";
+import type { CdpRunner } from "../shared";
+import { captureVisualScreenshot, visualScreenshotScale } from "../visual-screenshot";
+import type { VisualCandidate, VisualFramePath } from "../vom/visual-discovery";
+
+const styles = {
+  position: "static",
+  visibility: "visible",
+  opacity: "1",
+  display: "block",
+  "overflow-x": "visible",
+  "overflow-y": "visible",
+  transform: "none",
+  zoom: "1",
+  "clip-path": "none",
+  "mask-image": "none",
+  rotate: "none",
+  scale: "none",
+  perspective: "none",
+  clip: "auto",
+  contain: "none",
+  "overflow-clip-margin": "0px",
+};
+const rect = (x = 10, y = 20, width = 100, height = 40) => ({ x, y, width, height });
+const root = {
+  attachmentId: "a",
+  target: { tabId: 4 },
+  frameId: "top",
+  documentElementBackendNodeId: 1,
+};
+function row(id: number, tag: string, box = rect()) {
+  return {
+    node: { backend: id },
+    tag,
+    box,
+    client: box,
+    contentSize: { width: box.width, height: box.height },
+    styles: { ...styles },
+  };
+}
+function encode(value: unknown): unknown {
+  if (value === null) return { type: "null" };
+  if (Array.isArray(value)) return { type: "array", value: value.map(encode) };
+  if (typeof value === "object") {
+    const record = value as Record<string, unknown>;
+    if ("backend" in record) return { type: "node", value: { backendNodeId: record.backend } };
+    return { type: "object", value: Object.entries(record).map(([k, v]) => [k, encode(v)]) };
+  }
+  return { type: typeof value, value };
+}
+function png(width: number, height: number) {
+  const bytes = new Uint8Array(33);
+  bytes.set([137, 80, 78, 71, 13, 10, 26, 10, 0, 0, 0, 13, 73, 72, 68, 82]);
+  const view = new DataView(bytes.buffer);
+  view.setUint32(16, width);
+  view.setUint32(20, height);
+  return btoa(String.fromCharCode(...bytes));
+}
+function fixture(child = false, oopif = false) {
+  const parent: VisualFramePath = { document: root };
+  const frame: VisualFramePath = child
+    ? {
+        document: {
+          ...root,
+          frameId: "child",
+          documentElementBackendNodeId: 11,
+          target: oopif ? { tabId: 4, sessionId: "oopif" } : { tabId: 4 },
+        },
+        parent: { frame: parent, ownerBackendNodeId: 2 },
+      }
+    : parent;
+  const crop = child ? rect(120, 240, 200, 80) : rect();
+  const candidate: VisualCandidate = {
+    document: frame.document,
+    backendNodeId: child ? 12 : 3,
+    parentBackendNodeId: frame.document.documentElementBackendNodeId,
+    framePath: frame,
+    region: { status: "available", borderBox: crop, crop },
+  };
+  const topRows = child
+    ? [row(2, "iframe", rect(100, 200, 400, 200)), row(1, "html", rect(0, 0, 1200, 800))]
+    : [row(3, "canvas"), row(1, "html", rect(0, 0, 1200, 800))];
+  if (child) topRows[0].contentSize = { width: 200, height: 100 };
+  const childRows = [row(12, "canvas"), row(11, "html", rect(0, 0, 200, 100))];
+  let calls = 0;
+  const control = {
+    wrongOwner: false,
+    rootChanged: false,
+    failRead: false,
+    abortRead: false,
+    dpr: 1,
+    shots: [png(crop.width, crop.height)],
+  };
+  const controller = new AbortController();
+  const send = vi.fn(
+    async (target: CdpTarget, method: string, params: Record<string, unknown> = {}) => {
+      if (method === "DOM.getFrameOwner") return { backendNodeId: control.wrongOwner ? 999 : 2 };
+      if (method === "Page.createIsolatedWorld")
+        return { executionContextId: params.frameId === "child" ? 11 : 1 };
+      if (method === "DOM.resolveNode")
+        return { object: { objectId: String(params.backendNodeId) } };
+      if (method === "Runtime.callFunctionOn") {
+        const isChild = params.objectId === "12";
+        if (!(params.functionDeclaration as string).includes("styleNames"))
+          return {
+            result: {
+              deepSerializedValue: {
+                type: "node",
+                value: { backendNodeId: control.rootChanged ? 999 : isChild ? 11 : 1 },
+              },
+            },
+          };
+        if (control.failRead) throw new Error("read failed");
+        if (control.abortRead) controller.abort();
+        return {
+          result: {
+            deepSerializedValue: encode({
+              top: !isChild,
+              dpr: control.dpr,
+              rows: isChild ? childRows : topRows,
+            }),
+          },
+        };
+      }
+      if (method === "Runtime.releaseObjectGroup") return {};
+      if (method === "Page.getLayoutMetrics")
+        return {
+          cssLayoutViewport: { clientWidth: 1200, clientHeight: 800, pageX: 0, pageY: 0 },
+          cssVisualViewport: { scale: 1, zoom: 1 },
+        };
+      if (method === "DOM.getBoxModel")
+        return { model: { content: [100, 200, 500, 200, 500, 400, 100, 400] } };
+      if (method === "Page.captureScreenshot")
+        return { data: control.shots[Math.min(calls++, control.shots.length - 1)] };
+      throw new Error(`unexpected ${method} ${target.sessionId}`);
+    },
+  );
+  const cdp = {
+    send: ((tabId, method, params) =>
+      send({ tabId }, method, params as Record<string, unknown>)) as CdpRunner["send"],
+    sendToTarget: send as unknown as CdpRunner["sendToTarget"],
+    getAttachmentId: () => "a",
+    getFrameGraph: vi.fn(async () => {
+      throw new Error("whole page discovery forbidden");
+    }),
+  };
+  return { candidate, cdp, send, control, controller, topRows, childRows };
+}
+
+describe("visual screenshot", () => {
+  it.each([
+    [false, false],
+    [true, false],
+    [true, true],
+  ])("screenshots the local target child=%s oopif=%s without whole-page discovery", async (child, oopif) => {
+    const f = fixture(child, oopif);
+    const result = await captureVisualScreenshot(f.cdp, f.candidate);
+    expect(result).toMatchObject({ width: child ? 200 : 100, height: child ? 80 : 40 });
+    expect(f.cdp.getFrameGraph).not.toHaveBeenCalled();
+    const names = f.send.mock.calls.map((c) => c[1]);
+    expect(names.filter((n) => n === "DOM.getFrameOwner")).toHaveLength(child ? 1 : 0);
+    expect(names.filter((n) => n === "DOM.resolveNode")).toHaveLength(child ? 2 : 1);
+    expect(names.some((n) => /scroll|DOMSnapshot|getFrameTree|Accessibility/.test(n))).toBe(false);
+    expect(f.send.mock.calls.find((c) => c[1] === "Page.captureScreenshot")?.[2]).toMatchObject({
+      clip: { ...f.candidate.region.crop, scale: 1 },
+    });
+  });
+  it.each([
+    false,
+    true,
+  ])("projects a nested child through a parent target oopif=%s", async (oopif) => {
+    const f = fixture(true, oopif);
+    const parent = f.candidate.framePath!;
+    const document = {
+      ...parent.document,
+      frameId: "grandchild",
+      documentElementBackendNodeId: 21,
+    };
+    const crop = rect(130, 250, 40, 20);
+    const candidate: VisualCandidate = {
+      ...f.candidate,
+      document,
+      backendNodeId: 22,
+      framePath: { document, parent: { frame: parent, ownerBackendNodeId: 12 } },
+      region: { status: "available", borderBox: crop, crop },
+    };
+    f.childRows[0].tag = "iframe";
+    f.control.shots = [png(40, 20)];
+    const original = f.send.getMockImplementation()!;
+    f.send.mockImplementation(async (target, method, params = {}) => {
+      if (method === "DOM.getFrameOwner" && params.frameId === "grandchild")
+        return { backendNodeId: 12 };
+      if (method === "Runtime.callFunctionOn" && params.objectId === "22") {
+        if (!(params.functionDeclaration as string).includes("styleNames"))
+          return {
+            result: { deepSerializedValue: { type: "node", value: { backendNodeId: 21 } } },
+          };
+        return {
+          result: {
+            deepSerializedValue: encode({
+              top: false,
+              dpr: 1,
+              rows: [row(22, "canvas", rect(5, 5, 20, 10)), row(21, "html", rect(0, 0, 100, 40))],
+            }),
+          },
+        };
+      }
+      if (method === "DOM.getBoxModel" && params.backendNodeId === 12)
+        return {
+          model: {
+            content: oopif
+              ? [10, 20, 110, 20, 110, 60, 10, 60]
+              : [120, 240, 320, 240, 320, 320, 120, 320],
+          },
+        };
+      if (method === "Page.getLayoutMetrics" && target.sessionId)
+        return {
+          cssLayoutViewport: { clientWidth: 200, clientHeight: 100, pageX: 0, pageY: 0 },
+          cssVisualViewport: { scale: 1, zoom: 1 },
+        };
+      return original(target, method, params);
+    });
+    expect(await captureVisualScreenshot(f.cdp, candidate)).toMatchObject({
+      width: 40,
+      height: 20,
+    });
+    expect(f.send.mock.calls.filter((c) => c[1] === "DOM.getFrameOwner")).toHaveLength(2);
+    expect(f.send.mock.calls.find((c) => c[1] === "Page.captureScreenshot")?.[2]).toMatchObject({
+      clip: crop,
+    });
+    expect(f.cdp.getFrameGraph).not.toHaveBeenCalled();
+  });
+
+  it("runs the live reader on only connected local ancestry", async () => {
+    const f = fixture();
+    await captureVisualScreenshot(f.cdp, f.candidate);
+    const params = f.send.mock.calls.find(
+      (c) =>
+        c[1] === "Runtime.callFunctionOn" &&
+        String(c[2]?.functionDeclaration).includes("styleNames"),
+    )![2]!;
+    const read = new Function(`return (${params.functionDeclaration});`)() as (
+      this: Element,
+      names: string[],
+    ) => { rows: { node: Element }[] } | null;
+    const canvas = document.createElement("canvas");
+    document.body.append(canvas);
+    try {
+      const result = read.call(canvas, ["display"]);
+      expect(result?.rows.map((row) => row.node)).toEqual([
+        canvas,
+        document.body,
+        document.documentElement,
+      ]);
+      canvas.remove();
+      expect(read.call(canvas, ["display"])).toBeNull();
+      const other = document.implementation.createHTMLDocument();
+      const foreign = other.createElement("canvas");
+      other.body.append(foreign);
+      expect(foreign.ownerDocument).toBe(other);
+      expect(read.call(foreign, ["display"])).toBeNull();
+    } finally {
+      canvas.remove();
+    }
+  });
+
+  it("keeps requests constant as ordinary ancestry grows", async () => {
+    const small = fixture(),
+      large = fixture();
+    large.topRows.splice(
+      1,
+      0,
+      ...Array.from({ length: 100 }, (_, i) => row(100 + i, "div", rect(0, 0, 1200, 800))),
+    );
+    await captureVisualScreenshot(small.cdp, small.candidate);
+    await captureVisualScreenshot(large.cdp, large.candidate);
+    expect(large.send.mock.calls.map((c) => c[1])).toEqual(small.send.mock.calls.map((c) => c[1]));
+  });
+  it("preserves missing-path candidates but cannot execute them", async () => {
+    const f = fixture();
+    const { framePath: _, ...candidate } = f.candidate;
+    expect(await captureVisualScreenshot(f.cdp, candidate)).toMatchObject({
+      data: { reason: "visual_target_changed" },
+    });
+    expect(f.send).not.toHaveBeenCalled();
+  });
+  it.each([0.249, 0.25, 0.251])("compares rectangle edges with tolerance %s", async (delta) => {
+    const f = fixture();
+    f.topRows[0].box.x += delta;
+    const result = await captureVisualScreenshot(f.cdp, f.candidate);
+    expect("code" in result).toBe(delta > 0.25);
+  });
+  it("rejects a new clipping ancestor even if the resulting crop is identical", async () => {
+    const f = fixture();
+    const clip = row(8, "div", rect(0, 0, 1200, 800));
+    clip.styles["overflow-x"] = "hidden";
+    f.topRows.splice(1, 0, clip);
+    expect(await captureVisualScreenshot(f.cdp, f.candidate)).toMatchObject({
+      data: { reason: "visual_target_changed" },
+    });
+    expect(f.send.mock.calls.some((c) => c[1] === "Page.captureScreenshot")).toBe(false);
+  });
+  it("rejects changed owner and changed DOM before capture", async () => {
+    for (const kind of ["wrongOwner", "rootChanged"] as const) {
+      const f = fixture(true);
+      f.control[kind] = true;
+      expect(await captureVisualScreenshot(f.cdp, f.candidate)).toMatchObject({
+        data: { reason: "visual_target_changed" },
+      });
+      expect(f.send.mock.calls.some((c) => c[1] === "Page.captureScreenshot")).toBe(false);
+    }
+  });
+  it("releases retained objects on read failure and cancellation", async () => {
+    for (const kind of ["failRead", "abortRead"] as const) {
+      const f = fixture();
+      f.control[kind] = true;
+      const result = await captureVisualScreenshot(f.cdp, f.candidate, f.controller.signal);
+      expect(result).toMatchObject({ code: kind === "abortRead" ? "cancelled" : "cdp_failed" });
+      expect(f.send.mock.calls.at(-1)?.[1]).toBe("Runtime.releaseObjectGroup");
+    }
+  });
+  it("plans pixels without enlarging images and retries at most once", async () => {
+    expect(visualScreenshotScale(4096, 2048, 2)).toBe(0.25);
+    expect(visualScreenshotScale(4000, 4000, 1)).toBe(0.5);
+    const f = fixture();
+    f.control.shots = [png(3000, 3000), png(1800, 1800)];
+    expect(await captureVisualScreenshot(f.cdp, f.candidate)).toMatchObject({
+      width: 1800,
+      height: 1800,
+    });
+    const shots = f.send.mock.calls.filter((c) => c[1] === "Page.captureScreenshot");
+    expect(shots).toHaveLength(2);
+    expect((shots[1][2]!.clip as { scale: number }).scale).toBeLessThan(1);
+    const fail = fixture();
+    fail.control.shots = [png(3000, 3000)];
+    expect(await captureVisualScreenshot(fail.cdp, fail.candidate)).toMatchObject({
+      data: { reason: "visual_pixel_budget_exceeded" },
+    });
+    expect(fail.send.mock.calls.filter((c) => c[1] === "Page.captureScreenshot")).toHaveLength(2);
+  });
+  it("rejects invalid PNG without guessing dimensions", async () => {
+    const f = fixture();
+    f.control.shots = ["invalid"];
+    expect(await captureVisualScreenshot(f.cdp, f.candidate)).toMatchObject({
+      data: { reason: "screenshot_capture_failed" },
+    });
+  });
+  it("dispatches a visual ref through the screenshot tool and restores overlays", async () => {
+    const f = fixture();
+    const manager = new SessionManager({
+      agentWindow: {
+        create: async () => 100,
+        remove: async () => {},
+        ensureActiveTab: async () => 4,
+      },
+    });
+    const ctx = await manager.start("test");
+    ctx.refStore.replace([["e1", { kind: "visual-region", candidate: f.candidate }]]);
+    const tab = { id: 4, windowId: 100, active: true } as chrome.tabs.Tab;
+    const tabsApi = { get: async () => tab, query: async () => [tab] };
+    const sendToTab = vi.fn(async () => ({}));
+    const result = await handleScreenshot(
+      manager,
+      { session_id: "test", ref: "e1" },
+      { cdp: f.cdp, tabsApi, captureApi: { ...tabsApi, captureVisibleTab: vi.fn() }, sendToTab },
+    );
+    expect(result).toMatchObject({ width: 100, height: 40, format: "png" });
+    expect(sendToTab).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/extension/src/tools/__tests__/visual-screenshot.test.ts
+++ b/apps/extension/src/tools/__tests__/visual-screenshot.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
 import type { CdpTarget } from "@/browser-driver/frame-graph";
 import { SessionManager } from "@/session-manager/manager";
+import { handleClick } from "../interaction";
 import { handleScreenshot } from "../observation";
 import type { CdpRunner } from "../shared";
+import { consumeVisualCapture, issueVisualCapture } from "../visual-capture";
 import { captureVisualScreenshot, visualScreenshotScale } from "../visual-screenshot";
 import type { VisualCandidate, VisualFramePath } from "../vom/visual-discovery";
 
@@ -100,7 +102,11 @@ function fixture(child = false, oopif = false) {
   };
   const controller = new AbortController();
   const send = vi.fn(
-    async (target: CdpTarget, method: string, params: Record<string, unknown> = {}) => {
+    async (
+      target: CdpTarget,
+      method: string,
+      params: Record<string, unknown> = {},
+    ): Promise<Record<string, unknown>> => {
       if (method === "DOM.getFrameOwner") return { backendNodeId: control.wrongOwner ? 999 : 2 };
       if (method === "Page.createIsolatedWorld")
         return { executionContextId: params.frameId === "child" ? 11 : 1 };
@@ -382,7 +388,7 @@ describe("visual screenshot", () => {
     );
     expect(f.send.mock.calls.filter((c) => c[1] === "Page.captureScreenshot")).toHaveLength(1);
   });
-  it("accepts post-capture layout and style updates without rereading geometry", async () => {
+  it("keeps the image viewable when post-capture mapping reads fail", async () => {
     const f = fixture();
     f.control.onShot = () => {
       f.topRows[0].box.x += 100;
@@ -392,11 +398,12 @@ describe("visual screenshot", () => {
     expect(await captureVisualScreenshot(f.cdp, f.candidate)).toMatchObject({
       width: 100,
       height: 40,
+      capture_unavailable: expect.any(String),
     });
     const after = f.send.mock.calls.slice(
       f.send.mock.calls.findIndex((c) => c[1] === "Page.captureScreenshot") + 1,
     );
-    expect(after.filter((c) => c[1] === "DOM.resolveNode")).toHaveLength(1);
+    expect(after.filter((c) => c[1] === "DOM.resolveNode")).toHaveLength(2);
     expect(
       after.some(
         (c) =>
@@ -404,7 +411,7 @@ describe("visual screenshot", () => {
           c[1] === "DOM.getBoxModel" ||
           String(c[2]?.functionDeclaration).includes("styleNames"),
       ),
-    ).toBe(false);
+    ).toBe(true);
   });
   it("remeasures geometry before a pixel-budget retry", async () => {
     const f = fixture();
@@ -457,4 +464,218 @@ describe("visual screenshot", () => {
     expect(result).toMatchObject({ width: 100, height: 40, format: "png" });
     expect(sendToTab).toHaveBeenCalledTimes(2);
   });
+});
+
+async function pointFixture(child = false, oopif = false) {
+  const f = fixture(child, oopif);
+  const manager = new SessionManager({
+    agentWindow: {
+      create: async () => 100,
+      remove: async () => {},
+      ensureActiveTab: async () => 4,
+    },
+  });
+  const ctx = await manager.start("point");
+  ctx.refStore.replace([["e1", { kind: "visual-region", candidate: f.candidate }]]);
+  const tab = { id: 4, windowId: 100, active: true } as chrome.tabs.Tab;
+  const tabsApi = { get: async () => tab, query: async () => [tab] };
+  const bypassOverlay = vi.fn(async (_tab: number, _enabled: boolean) => {});
+  const original = f.send.getMockImplementation()!;
+  const input: Record<string, unknown>[] = [];
+  const hitPoints: number[][] = [];
+  const control = { hit: true, onMove: () => {}, failPress: false };
+  f.send.mockImplementation(async (target, method, params = {}) => {
+    if (
+      method === "Runtime.callFunctionOn" &&
+      String(params.functionDeclaration).includes("elementFromPoint")
+    ) {
+      hitPoints.push((params.arguments as { value: number }[]).map((a) => a.value));
+      return { result: { value: control.hit } };
+    }
+    if (method === "Input.dispatchMouseEvent") {
+      input.push(params);
+      if (params.type === "mouseMoved") control.onMove();
+      if (params.type === "mousePressed" && control.failPress) throw new Error("transport lost");
+      return {};
+    }
+    return original(target, method, params);
+  });
+  const shot = await handleScreenshot(
+    manager,
+    { session_id: "point", ref: "e1" },
+    {
+      cdp: f.cdp,
+      tabsApi,
+      captureApi: { ...tabsApi, captureVisibleTab: vi.fn() },
+      sendToTab: vi.fn(async () => ({})),
+    },
+  );
+  expect(shot).toHaveProperty("capture_id");
+  const params = {
+    session_id: "point",
+    ref: "e1",
+    capture_id: (shot as { capture_id: string }).capture_id,
+    image_x: child ? 100 : 50,
+    image_y: child ? 40 : 20,
+  };
+  return {
+    ...f,
+    manager,
+    ctx,
+    params,
+    input,
+    hitPoints,
+    pointControl: control,
+    deps: { cdp: f.cdp, tabsApi, bypassOverlay },
+    shot,
+  };
+}
+
+it.each([
+  [false, false],
+  [true, false],
+  [true, true],
+])("clicks only the captured Canvas through the frame path child=%s oopif=%s", async (child, oopif) => {
+  const f = await pointFixture(child, oopif);
+  const result = await handleClick(f.manager, f.params, f.deps);
+  expect(result).toMatchObject({ x: child ? 220 : 60, y: child ? 280 : 40 });
+  expect(f.hitPoints.at(-1)).toEqual([60, 40]);
+  expect(f.input.map((e) => e.type)).toEqual(["mouseMoved", "mousePressed", "mouseReleased"]);
+  expect(f.cdp.getFrameGraph).not.toHaveBeenCalled();
+  const count = f.input.length;
+  expect(await handleClick(f.manager, f.params, f.deps)).toHaveProperty(
+    "data.reason",
+    "visual_capture_stale",
+  );
+  expect(f.input).toHaveLength(count);
+  expect(f.deps.bypassOverlay.mock.calls).toEqual([
+    [4, true],
+    [4, false],
+  ]);
+});
+
+it.each([
+  "replace",
+  "geometry",
+  "occluded",
+  "expired",
+  "wrong-ref",
+  "wrong-session",
+])("rejects unusable captures before moving: %s", async (kind) => {
+  const f = await pointFixture();
+  if (kind === "replace")
+    f.ctx.refStore.replace([["e1", { kind: "visual-region", candidate: f.candidate }]]);
+  if (kind === "geometry") f.topRows[0].box.x += 10;
+  if (kind === "occluded") f.pointControl.hit = false;
+  if (kind === "wrong-ref") f.params.ref = "e2";
+  if (kind === "wrong-session") f.params.session_id = "other";
+  const now = Date.now();
+  const clock =
+    kind === "expired" ? vi.spyOn(Date, "now").mockReturnValue(now + 120001) : undefined;
+  try {
+    expect(await handleClick(f.manager, f.params, f.deps)).toHaveProperty("code");
+    expect(f.input).toHaveLength(0);
+  } finally {
+    clock?.mockRestore();
+  }
+});
+
+it.each([
+  "geometry",
+  "occluded",
+  "cancel",
+  "press-failed",
+])("does not silently replay after %s during click", async (kind) => {
+  const f = await pointFixture();
+  const controller = new AbortController();
+  f.pointControl.onMove = () => {
+    if (kind === "geometry") f.topRows[0].box.x += 10;
+    if (kind === "occluded") f.pointControl.hit = false;
+    if (kind === "cancel") controller.abort();
+  };
+  f.pointControl.failPress = kind === "press-failed";
+  const result = await handleClick(f.manager, f.params, { ...f.deps, signal: controller.signal });
+  expect(result).toHaveProperty("data.effect_state", kind === "press-failed" ? "unknown" : "none");
+  expect(f.input.map((e) => e.type)).toEqual(
+    kind === "press-failed" ? ["mouseMoved", "mousePressed", "mouseReleased"] : ["mouseMoved"],
+  );
+  expect(await handleClick(f.manager, f.params, f.deps)).toHaveProperty(
+    "data.reason",
+    "visual_capture_stale",
+  );
+});
+
+it("dispatches two complete clicks with modifiers for a double-click", async () => {
+  const f = await pointFixture();
+  expect(
+    await handleClick(f.manager, { ...f.params, click_count: 2, modifiers: ["shift"] }, f.deps),
+  ).not.toHaveProperty("code");
+  expect(f.input.map((e) => [e.type, e.clickCount])).toEqual([
+    ["mouseMoved", undefined],
+    ["mousePressed", 1],
+    ["mouseReleased", 1],
+    ["mousePressed", 2],
+    ["mouseReleased", 2],
+  ]);
+  expect(f.input.every((e) => e.modifiers === 8)).toBe(true);
+});
+
+it("returns a viewable image without a click capture when the mapping changes during capture", async () => {
+  const f = fixture();
+  f.control.onShot = () => {
+    f.topRows[0].box.x += 1;
+  };
+  const shot = await captureVisualScreenshot(f.cdp, f.candidate);
+  expect(shot).toMatchObject({ width: 100, height: 40, capture_unavailable: expect.any(String) });
+  expect(shot).not.toHaveProperty("mapping");
+});
+
+it("bounds capture storage and invalidates superseded images without retaining pixels", async () => {
+  const f = await pointFixture();
+  const shot = await captureVisualScreenshot(f.cdp, f.candidate);
+  if ("code" in shot || !shot.mapping) throw new Error("expected mapping");
+  f.ctx.refStore.replace(
+    Array.from(
+      { length: 33 },
+      (_, i) => [`e${i + 1}`, { kind: "visual-region" as const, candidate: f.candidate }] as const,
+    ),
+  );
+  const ids: string[] = [];
+  for (let i = 1; i <= 33; i++) {
+    const entry = f.ctx.refStore.resolveEntry(`e${i}`)!;
+    if (entry.kind !== "visual-region") throw new Error("expected visual");
+    ids.push(issueVisualCapture(f.ctx.refStore, `e${i}`, entry, shot.mapping, 100, 40)!);
+  }
+  const request = (ref: string, id: string) =>
+    consumeVisualCapture(f.ctx.refStore, 4, {
+      session_id: "point",
+      ref,
+      capture_id: id,
+      image_x: 50,
+      image_y: 20,
+    });
+  expect(request("e1", ids[0])).toHaveProperty("code");
+  expect(request("e2", ids[1])).toHaveProperty("point", { x: 60, y: 40 });
+  const entry = f.ctx.refStore.resolveEntry("e33")!;
+  if (entry.kind !== "visual-region") throw new Error("expected visual");
+  const newest = issueVisualCapture(f.ctx.refStore, "e33", entry, shot.mapping, 100, 40)!;
+  expect(request("e33", ids[32])).toHaveProperty("code");
+  expect(request("e33", newest)).toHaveProperty("point");
+  f.ctx.refStore.clear();
+  expect(issueVisualCapture(f.ctx.refStore, "e33", entry, shot.mapping, 100, 40)).toBeUndefined();
+});
+
+it.each([
+  [-1, 0],
+  [100, 0],
+  [0, 40],
+  [NaN, 0],
+  [0, Infinity],
+])("rejects invalid PNG point %s,%s without consuming its capture", async (x, y) => {
+  const f = await pointFixture();
+  expect(
+    await handleClick(f.manager, { ...f.params, image_x: x, image_y: y }, f.deps),
+  ).toHaveProperty("code", "invalid_params");
+  expect(f.input).toHaveLength(0);
+  expect(await handleClick(f.manager, f.params, f.deps)).not.toHaveProperty("code");
 });

--- a/apps/extension/src/tools/audit-context.ts
+++ b/apps/extension/src/tools/audit-context.ts
@@ -28,6 +28,8 @@ export async function auditContext(
     operation_id: params._audit_id,
     tab_id: tab.id,
     ...(url ? { url } : {}),
-    ...(ref?.tabId === tab.id && ref.name ? { target: ref.name.slice(0, 160) } : {}),
+    ...(ref?.kind === "dom" && ref.tabId === tab.id && ref.name
+      ? { target: ref.name.slice(0, 160) }
+      : {}),
   };
 }

--- a/apps/extension/src/tools/geometry/frame-context.ts
+++ b/apps/extension/src/tools/geometry/frame-context.ts
@@ -212,11 +212,16 @@ export class GeometryContext {
     ownerBackendNodeId: number,
     ancestorClips: Polygon[],
     viewport: Size,
+    contentSize?: Size,
   ): Promise<SnapshotProjectionResult> {
     const key = `${cdpTargetKey(source.target)}:${ownerBackendNodeId}`;
     let promise = this.snapshotOwners.get(key);
     if (!promise) {
-      promise = this.snapshotOwner(source.target, ownerBackendNodeId);
+      promise = contentSize
+        ? this.ownerContent(source.target, ownerBackendNodeId).then((quad) =>
+            quad ? { quad, size: contentSize } : null,
+          )
+        : this.snapshotOwner(source.target, ownerBackendNodeId);
       this.snapshotOwners.set(key, promise);
     }
     let owner: { quad: Quad; size: Size } | null;

--- a/apps/extension/src/tools/geometry/frame-context.ts
+++ b/apps/extension/src/tools/geometry/frame-context.ts
@@ -20,8 +20,13 @@ import type { CoordinateOwner, CssViewport, SnapshotProjectionResult } from "./c
 import { readSnapshotOwnerSizes } from "./snapshot-owner-sizes";
 
 export interface LayoutMetrics {
-  cssVisualViewport?: { zoom?: number; clientWidth?: number; clientHeight?: number };
-  visualViewport?: { zoom?: number; clientWidth?: number; clientHeight?: number };
+  cssVisualViewport?: {
+    zoom?: number;
+    scale?: number;
+    clientWidth?: number;
+    clientHeight?: number;
+  };
+  visualViewport?: { zoom?: number; scale?: number; clientWidth?: number; clientHeight?: number };
   cssLayoutViewport?: {
     clientWidth?: number;
     clientHeight?: number;

--- a/apps/extension/src/tools/interaction.ts
+++ b/apps/extension/src/tools/interaction.ts
@@ -1,3 +1,6 @@
+import { consumeVisualCapture, isVisualPointRequest } from "./visual-capture";
+import { resolveVisualRegionNow, sameVisualMapping, verifyVisualHit } from "./visual-target";
+import { isAbortError } from "./vom/capture-abort";
 // DOM interaction tools — click, hover, focus/blur, fill, press, and select.
 //
 // All interaction tools:
@@ -460,6 +463,7 @@ export async function handleClick(
   if (isRpcError(target)) return target;
   const denied = enforceAgentWindow(ctx, target, "click");
   if (denied) return denied;
+  if (isVisualPointRequest(params)) return clickVisualPoint(ctx, target, params, deps);
   const resolved = await resolveActionTarget(deps.cdp, ctx, target, params, "click");
   if (isRpcError(resolved)) return resolved;
   return clickResolvedTarget(ctx, resolved, params, deps);
@@ -496,13 +500,10 @@ export async function clickResolvedTarget(
     return { code: "cancelled", message: "click aborted" };
   }
 
-  const button: MouseButton = params.button ?? "left";
   const clickCount = params.click_count ?? 1;
   if (clickCount < 1) {
     return { code: "invalid_params", message: "click_count must be greater than zero" };
   }
-  const modifiers = modifiersBitfield(params.modifiers);
-
   const overlayBlocking = await checkOverlayAtPoint(deps.cdp, target.tabId, centre.x, centre.y);
   let automationBypassEnabled = false;
   if (overlayBlocking && deps.bypassOverlay) {
@@ -515,52 +516,8 @@ export async function clickResolvedTarget(
   }
 
   try {
-    // Move first so hover state activates, then press → release.
-    await deps.cdp.send(target.tabId, "Input.dispatchMouseEvent", {
-      type: "mouseMoved",
-      x: centre.x,
-      y: centre.y,
-      modifiers,
-    });
-    if (throwIfAborted(deps.signal)) {
-      return { code: "cancelled", message: "click aborted" };
-    }
-    await deps.cdp.send(target.tabId, "Input.dispatchMouseEvent", {
-      type: "mousePressed",
-      x: centre.x,
-      y: centre.y,
-      button,
-      clickCount,
-      modifiers,
-    });
-    if (throwIfAborted(deps.signal)) {
-      try {
-        await deps.cdp.send(target.tabId, "Input.dispatchMouseEvent", {
-          type: "mouseReleased",
-          x: centre.x,
-          y: centre.y,
-          button,
-          clickCount,
-          modifiers,
-        });
-      } catch (err) {
-        console.debug("[bsk interaction] best-effort mouseReleased after abort failed", err);
-      }
-      return { code: "cancelled", message: "click aborted" };
-    }
-    await deps.cdp.send(target.tabId, "Input.dispatchMouseEvent", {
-      type: "mouseReleased",
-      x: centre.x,
-      y: centre.y,
-      button,
-      clickCount,
-      modifiers,
-    });
-  } catch (err) {
-    return {
-      code: "cdp_failed",
-      message: err instanceof Error ? err.message : String(err),
-    };
+    const error = await dispatchClickAtPoint(target.tabId, centre, params, deps);
+    if (error) return error;
   } finally {
     if (automationBypassEnabled && deps.bypassOverlay && !deps.keepOverlayBypassAfterHover) {
       try {
@@ -578,6 +535,153 @@ export async function clickResolvedTarget(
     x: centre.x,
     y: centre.y,
   });
+}
+
+/** Shared mouse lifecycle; visual clicks additionally verify after move and emit full double clicks. */
+async function dispatchClickAtPoint(
+  tabId: number,
+  point: { x: number; y: number },
+  params: Pick<ClickParams, "button" | "click_count" | "modifiers">,
+  deps: InteractionDeps,
+  beforePress?: () => Promise<RpcError | null>,
+): Promise<RpcError | null> {
+  const button = params.button ?? "left",
+    modifiers = modifiersBitfield(params.modifiers);
+  let releaseNeeded = false,
+    attempted = false,
+    moved = false,
+    count = params.click_count ?? 1;
+  const release = () =>
+    deps.cdp.send(tabId, "Input.dispatchMouseEvent", {
+      type: "mouseReleased",
+      ...point,
+      button,
+      clickCount: count,
+      modifiers,
+    });
+  const failure = (error: RpcError): RpcError =>
+    beforePress
+      ? {
+          ...error,
+          data: {
+            ...error.data,
+            effect_state: attempted ? "unknown" : "none",
+            pointer_moved: moved,
+          },
+        }
+      : error;
+  try {
+    if (deps.signal?.aborted) return failure({ code: "cancelled", message: "click aborted" });
+    moved = true;
+    await deps.cdp.send(tabId, "Input.dispatchMouseEvent", {
+      type: "mouseMoved",
+      ...point,
+      modifiers,
+    });
+    if (beforePress) {
+      const error = await beforePress();
+      if (error) return failure(error);
+    }
+    const counts = beforePress
+      ? Array.from({ length: params.click_count ?? 1 }, (_, i) => i + 1)
+      : [count];
+    for (count of counts) {
+      if (beforePress && count > 1) {
+        const error = await beforePress();
+        if (error) return failure(error);
+      }
+      if (deps.signal?.aborted) return failure({ code: "cancelled", message: "click aborted" });
+      attempted = true;
+      releaseNeeded = true;
+      await deps.cdp.send(tabId, "Input.dispatchMouseEvent", {
+        type: "mousePressed",
+        ...point,
+        button,
+        clickCount: count,
+        modifiers,
+      });
+      await release();
+      releaseNeeded = false;
+    }
+    if (deps.signal?.aborted) return failure({ code: "cancelled", message: "click aborted" });
+    return null;
+  } catch (error) {
+    return failure({
+      code: deps.signal?.aborted || isAbortError(error) ? "cancelled" : "cdp_failed",
+      message: error instanceof Error ? error.message : String(error),
+    });
+  } finally {
+    if (releaseNeeded) await release().catch(() => {});
+  }
+}
+
+async function clickVisualPoint(
+  ctx: SessionContext,
+  target: ResolvedTargetTab,
+  params: ClickParams,
+  deps: InteractionDeps,
+): Promise<ClickResult | RpcError> {
+  const consumed = consumeVisualCapture(ctx.refStore, target.tabId, params);
+  if (isRpcError(consumed)) return consumed;
+  const { capture, point } = consumed;
+  const dialogCursor = markDialogCursor(deps.cdp, target.tabId);
+  const changed = () =>
+    rpcError(
+      "not_found",
+      "visual_capture_stale",
+      "visual target, mapping or hit target changed; observe and screenshot again",
+    );
+  const validate = async (): Promise<RpcError | null> => {
+    if (
+      ctx.refStore.resolveEntry(capture.ref) !== capture.entry ||
+      ctx.refStore.revision !== capture.generation
+    )
+      return changed();
+    const current = await resolveVisualRegionNow(deps.cdp, capture.entry.candidate, deps.signal);
+    if (isRpcError(current)) return current;
+    if (
+      !sameVisualMapping(capture.mapping, current) ||
+      !(await verifyVisualHit(deps.cdp, current, point, deps.signal))
+    )
+      return changed();
+    if (
+      ctx.refStore.resolveEntry(capture.ref) !== capture.entry ||
+      ctx.refStore.revision !== capture.generation ||
+      current.mappings.some(
+        (m) => deps.cdp.getAttachmentId?.(target.tabId) !== m.document.attachmentId,
+      )
+    )
+      return changed();
+    return null;
+  };
+  let bypass = false;
+  try {
+    deps.cdp.trackSessionTab?.(ctx.sessionId, target.tabId);
+    if (deps.bypassOverlay) {
+      await deps.bypassOverlay(target.tabId, true);
+      bypass = true;
+    }
+    const invalid = await validate();
+    if (invalid) return { ...invalid, data: { ...invalid.data, effect_state: "none" } };
+    const error = await dispatchClickAtPoint(target.tabId, point, params, deps, async () => {
+      await wait(32, deps.signal); // Scheduling opportunity, not a claim of page stability.
+      return validate();
+    });
+    if (error) return error;
+    return attachDialogs(deps.cdp, target.tabId, dialogCursor, {
+      tab_id: target.tabId,
+      used_ref: capture.ref,
+      ...point,
+    });
+  } catch (error) {
+    return {
+      code: deps.signal?.aborted || isAbortError(error) ? "cancelled" : "cdp_failed",
+      message: error instanceof Error ? error.message : String(error),
+      data: { effect_state: "none" },
+    };
+  } finally {
+    if (bypass) await deps.bypassOverlay!(target.tabId, false).catch(() => {});
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/extension/src/tools/observation.ts
+++ b/apps/extension/src/tools/observation.ts
@@ -1143,7 +1143,8 @@ async function handleVomObservation(
         : {}),
     });
   } catch (err) {
-    clearObservationContinuation(ctx.refStore);
+    // Fresh observations clear their predecessor before capture. Continuation owns
+    // invalidation; cancellation must preserve its unpublished page for retry.
     if (isAbortError(err)) return cancelled(toolName);
     return {
       code: "cdp_failed",

--- a/apps/extension/src/tools/observation.ts
+++ b/apps/extension/src/tools/observation.ts
@@ -1,4 +1,5 @@
 import { parsePngDimensions } from "./png";
+import { clearVisualCapture, issueVisualCapture } from "./visual-capture";
 import { captureVisualScreenshot } from "./visual-screenshot";
 import { deduplicateVisualCandidates } from "./vom/visual-dedup";
 import { discoverVisualCandidates } from "./vom/visual-discovery";
@@ -291,6 +292,7 @@ export async function handleScreenshot(
     }
     const entry = lookupRefTarget(ctx, ref, target.tabId);
     if (entry?.kind === "visual-region") {
+      clearVisualCapture(ctx.refStore, ref);
       deps.cdp.trackSessionTab?.(ctx.sessionId, target.tabId);
       const captured = await withExtensionOverlayHidden(
         target.tabId,
@@ -298,7 +300,22 @@ export async function handleScreenshot(
         deps.sendToTab,
       );
       if (isRpcError(captured)) return captured;
-      return withShotDialogs({ ...captured, format: "png", tab_id: target.tabId });
+      const { mapping, ...image } = captured;
+      const captureId = mapping
+        ? issueVisualCapture(ctx.refStore, ref, entry, mapping, image.width, image.height)
+        : undefined;
+      return withShotDialogs({
+        ...image,
+        format: "png",
+        tab_id: target.tabId,
+        ...(captureId
+          ? { capture_id: captureId }
+          : {
+              capture_unavailable:
+                image.capture_unavailable ??
+                "observation replaced during capture; observe and screenshot again",
+            }),
+      });
     }
     const node = resolveSnapshotRef(ctx, ref, target.tabId);
     if (isRpcError(node)) return node;

--- a/apps/extension/src/tools/observation.ts
+++ b/apps/extension/src/tools/observation.ts
@@ -48,7 +48,7 @@ import {
   normaliseRef as sharedNormaliseRef,
   type ToolEffect,
 } from "./shared";
-import { resolveSnapshotRef } from "./snapshot-ref";
+import { lookupRefTarget, resolveSnapshotRef } from "./snapshot-ref";
 import { type CapturedNode, type CapturedSurfaceProbe, probeHoverSurfaces } from "./vom/capture";
 import { captureObservationFacts, semanticCapture } from "./vom/capture-coordinator";
 import type { FrameDocument as CapturedFrameDocument } from "./vom/frame-document";
@@ -308,6 +308,12 @@ export async function handleScreenshot(
     if (!deps.cdp) {
       return { code: "cdp_failed", message: "screenshot ref capture requires CDP" };
     }
+    if (lookupRefTarget(ctx, ref, target.tabId)?.kind === "visual-region")
+      return rpcError(
+        "unsupported",
+        "ref_kind_unsupported",
+        "visual-region screenshot execution is not available in this build",
+      );
     const node = resolveSnapshotRef(ctx, ref, target.tabId);
     if (isRpcError(node)) return node;
     if (signal?.aborted) return cancelled("screenshot");

--- a/apps/extension/src/tools/observation.ts
+++ b/apps/extension/src/tools/observation.ts
@@ -1,5 +1,13 @@
 import { parsePngDimensions } from "./png";
 import { captureVisualScreenshot } from "./visual-screenshot";
+import { deduplicateVisualCandidates } from "./vom/visual-dedup";
+import { discoverVisualCandidates } from "./vom/visual-discovery";
+import {
+  clearObservationContinuation,
+  type ObservationOutput,
+  prepareVisualObservation,
+  publishObservationPage,
+} from "./vom/visual-observation";
 
 export { parsePngDimensions } from "./png";
 
@@ -864,6 +872,7 @@ async function runHoverProbes(
 }
 
 export interface CaptureVomObservationOptions extends VomOptions {
+  includeVisualFacts?: boolean;
   conditionalSurfaceProbe?: boolean;
   hoverProbeBypassOverlay?: (tabId: number, enabled: boolean) => Promise<void>;
   signal?: AbortSignal;
@@ -874,11 +883,13 @@ export async function captureVomObservation(
   tabId: number,
   url: string | undefined,
   options: CaptureVomObservationOptions = {},
-): Promise<CaptureVomObservationResult> {
+): Promise<CaptureVomObservationResult & { visualOutput?: ObservationOutput }> {
   throwIfAborted(options.signal, "observation");
   await cdp.ensureAttachedToUrl?.(tabId, url);
   throwIfAborted(options.signal, "observation");
-  const facts = await captureObservationFacts<CdpAxNode>(cdp, tabId, options.signal, url);
+  const facts = await captureObservationFacts<CdpAxNode>(cdp, tabId, options.signal, url, {
+    includeVisualFacts: options.includeVisualFacts,
+  });
   const { captured, documents: normalizedDocuments } = semanticCapture(facts);
   throwIfAborted(options.signal, "observation");
   const semanticGraph = buildSemanticGraph({
@@ -897,11 +908,10 @@ export async function captureVomObservation(
     options,
   );
   throwIfAborted(options.signal, "observation");
-  const scene = projectSemanticGraph(
-    normalizeSemanticStructure(
-      resolveSemanticGraph(semanticGraph, { supplementalNames: hoverProbes.tooltipNames }),
-    ),
+  const structured = normalizeSemanticStructure(
+    resolveSemanticGraph(semanticGraph, { supplementalNames: hoverProbes.tooltipNames }),
   );
+  const scene = projectSemanticGraph(structured);
   const decoratedScene = attachCapturedSceneAnnotations(
     scene,
     normalizedDocuments,
@@ -934,6 +944,39 @@ export async function captureVomObservation(
     notices.push(
       "@warning document identity unverified: some retained documents could not be checked for changes during capture.",
     );
+  if (options.includeVisualFacts) {
+    const discovery = await deduplicateVisualCandidates(
+      await discoverVisualCandidates(facts, options.signal),
+      options.signal,
+    );
+    const identities = new Map(
+      facts.documents.flatMap((doc) =>
+        doc.identity ? [[doc.frame.frameId, doc.identity] as const] : [],
+      ),
+    );
+    const visualOutput = prepareVisualObservation(
+      decoratedScene,
+      structured,
+      discovery,
+      identities,
+      captured.rootFrameId ?? "root",
+      notices,
+      options,
+    );
+    return {
+      ...projectRecordSafeObservation({
+        rootFrameId: captured.rootFrameId ?? "root",
+        frameDocuments: normalizedDocuments,
+        rendered: { text: "", refs: [], truncated: false },
+        surfaceProbes: hoverProbes.surfaceProbes,
+        hoverProbe: {
+          performed: hoverProbes.performed,
+          revealedContent: hoverProbes.revealedContent,
+        },
+      }),
+      visualOutput,
+    };
+  }
   const captureNotice = notices.join("\n");
   const rendered = renderVom(decoratedScene, {
     maxDepth: options.maxDepth,
@@ -989,7 +1032,29 @@ async function handleVomObservation(
     deps.cdp.trackSessionTab?.(ctx.sessionId, target.tabId);
     const effectiveConditionalSurfaceProbe =
       deps.conditionalSurfaceProbe ?? conditionalSurfaceProbe;
+    const cursor = toolName === "observe" ? (params as ObserveParams).cursor : undefined;
+    if (cursor) {
+      if (
+        params.max_depth !== undefined ||
+        (params as ObserveParams).probe_hover ||
+        (params as ObserveParams).debug_surfaces
+      )
+        return {
+          code: "invalid_params",
+          message: "cursor cannot change depth or request hover/debug probes",
+        };
+      const page = await publishObservationPage(
+        ctx.refStore,
+        deps.cdp,
+        target.tabId,
+        { cursor, maxTokens: params.max_tokens },
+        signal,
+      );
+      return isRpcError(page) ? page : attachDialogs(deps.cdp, target.tabId, dialogCursor, page);
+    }
+    clearObservationContinuation(ctx.refStore);
     const observation = await captureVomObservation(deps.cdp, target.tabId, target.url, {
+      includeVisualFacts: toolName === "observe",
       maxDepth: params.max_depth,
       maxTokens: params.max_tokens,
       activeRegionPolicy: true,
@@ -998,6 +1063,40 @@ async function handleVomObservation(
       signal,
     });
     throwIfAborted(signal, toolName);
+    if (observation.visualOutput) {
+      const page = await publishObservationPage(
+        ctx.refStore,
+        deps.cdp,
+        target.tabId,
+        { output: observation.visualOutput },
+        signal,
+      );
+      if (isRpcError(page)) return page;
+      return attachDialogs(deps.cdp, target.tabId, dialogCursor, {
+        ...page,
+        ...(observation.hoverProbe?.performed
+          ? {
+              hover_probe: {
+                performed: true,
+                revealed_content: observation.hoverProbe.revealedContent,
+              },
+            }
+          : {}),
+        ...((params as ObserveParams).debug_surfaces
+          ? {
+              debug: {
+                surface_probes: (observation.surfaceProbes ?? []).map((probe) => ({
+                  trigger_backend_node_id: probe.triggerBackendNodeId,
+                  trigger_action: probe.triggerAction,
+                  sub_items: probe.subItems,
+                  ...(probe.triggerPoint ? { trigger_point: probe.triggerPoint } : {}),
+                  ...(probe.confidence ? { confidence: probe.confidence } : {}),
+                })),
+              },
+            }
+          : {}),
+      });
+    }
     const targetByFrameId = new Map(
       observation.frames.map((frame) => [frame.frameId, frame.target]),
     );
@@ -1044,6 +1143,7 @@ async function handleVomObservation(
         : {}),
     });
   } catch (err) {
+    clearObservationContinuation(ctx.refStore);
     if (isAbortError(err)) return cancelled(toolName);
     return {
       code: "cdp_failed",

--- a/apps/extension/src/tools/observation.ts
+++ b/apps/extension/src/tools/observation.ts
@@ -1,3 +1,8 @@
+import { parsePngDimensions } from "./png";
+import { captureVisualScreenshot } from "./visual-screenshot";
+
+export { parsePngDimensions } from "./png";
+
 import type { CapturedSceneInput } from "./vom/facts";
 // Observation handlers — `tool.snapshot`, `tool.get_html`, `tool.screenshot`,
 // and semantic `tool.observe` (design §7). Each handler resolves the target
@@ -99,38 +104,6 @@ export const normaliseRef = sharedNormaliseRef;
 export function stripDataUrlPrefix(dataUrl: string): string {
   const m = /^data:image\/[a-z+]+;base64,/i.exec(dataUrl);
   return m ? dataUrl.slice(m[0].length) : dataUrl;
-}
-
-/**
- * Parse a PNG's IHDR chunk and return `(width, height)`. Returns
- * `null` on any malformed input so callers fall back to `0/0` instead
- * of throwing.
- *
- * PNG layout: 8-byte signature, then a 4-byte length, 4-byte type
- * ("IHDR"), then the chunk data — width is bytes 16-19 BE, height is
- * 20-23 BE.
- */
-export function parsePngDimensions(base64: string): { width: number; height: number } | null {
-  try {
-    // atob is available in MV3 service workers.
-    const head = base64.length > 64 ? base64.slice(0, 64) : base64;
-    const bin = atob(head);
-    if (bin.length < 24) return null;
-    if (bin.charCodeAt(0) !== 0x89 || bin.charCodeAt(1) !== 0x50 || bin.charCodeAt(2) !== 0x4e) {
-      return null;
-    }
-    const u32 = (off: number) =>
-      (bin.charCodeAt(off) << 24) |
-      (bin.charCodeAt(off + 1) << 16) |
-      (bin.charCodeAt(off + 2) << 8) |
-      bin.charCodeAt(off + 3);
-    const width = u32(16) >>> 0;
-    const height = u32(20) >>> 0;
-    if (width === 0 || height === 0) return null;
-    return { width, height };
-  } catch {
-    return null;
-  }
 }
 
 export interface ScreenshotDeps {
@@ -308,12 +281,17 @@ export async function handleScreenshot(
     if (!deps.cdp) {
       return { code: "cdp_failed", message: "screenshot ref capture requires CDP" };
     }
-    if (lookupRefTarget(ctx, ref, target.tabId)?.kind === "visual-region")
-      return rpcError(
-        "unsupported",
-        "ref_kind_unsupported",
-        "visual-region screenshot execution is not available in this build",
+    const entry = lookupRefTarget(ctx, ref, target.tabId);
+    if (entry?.kind === "visual-region") {
+      deps.cdp.trackSessionTab?.(ctx.sessionId, target.tabId);
+      const captured = await withExtensionOverlayHidden(
+        target.tabId,
+        () => captureVisualScreenshot(deps.cdp!, entry.candidate, signal),
+        deps.sendToTab,
       );
+      if (isRpcError(captured)) return captured;
+      return withShotDialogs({ ...captured, format: "png", tab_id: target.tabId });
+    }
     const node = resolveSnapshotRef(ctx, ref, target.tabId);
     if (isRpcError(node)) return node;
     if (signal?.aborted) return cancelled("screenshot");

--- a/apps/extension/src/tools/png.ts
+++ b/apps/extension/src/tools/png.ts
@@ -1,0 +1,31 @@
+/**
+ * Parse a PNG's IHDR chunk and return `(width, height)`. Returns
+ * `null` on any malformed input so callers fall back to `0/0` instead
+ * of throwing.
+ *
+ * PNG layout: 8-byte signature, then a 4-byte length, 4-byte type
+ * ("IHDR"), then the chunk data — width is bytes 16-19 BE, height is
+ * 20-23 BE.
+ */
+export function parsePngDimensions(base64: string): { width: number; height: number } | null {
+  try {
+    // atob is available in MV3 service workers.
+    const head = base64.length > 64 ? base64.slice(0, 64) : base64;
+    const bin = atob(head);
+    if (bin.length < 33) return null;
+    if (bin.slice(0, 8) !== "\x89PNG\r\n\x1a\n" || bin.slice(8, 16) !== "\x00\x00\x00\x0dIHDR") {
+      return null;
+    }
+    const u32 = (off: number) =>
+      (bin.charCodeAt(off) << 24) |
+      (bin.charCodeAt(off + 1) << 16) |
+      (bin.charCodeAt(off + 2) << 8) |
+      bin.charCodeAt(off + 3);
+    const width = u32(16) >>> 0;
+    const height = u32(20) >>> 0;
+    if (width === 0 || height === 0) return null;
+    return { width, height };
+  } catch {
+    return null;
+  }
+}

--- a/apps/extension/src/tools/snapshot-ref.ts
+++ b/apps/extension/src/tools/snapshot-ref.ts
@@ -3,7 +3,7 @@
 // `ref_not_found` errors for hard-failure tool paths.
 
 import type { SessionContext } from "@/session-manager/manager";
-import { normaliseRef } from "@/session-manager/ref-store";
+import { normaliseRef, type RefEntry } from "@/session-manager/ref-store";
 import type { RpcError } from "@/transport/types";
 import { rpcError } from "./errors";
 
@@ -14,14 +14,22 @@ export interface SnapshotRefLookup {
   cdpSessionId?: string;
 }
 
-function refEntryForTab(ctx: SessionContext, refKey: string, tabId: number) {
+/** Typed lookup never turns a visual anchor into a DOM operation target. */
+export function lookupRefTarget(
+  ctx: SessionContext,
+  refKey: string,
+  tabId: number,
+): RefEntry | null {
   const entry = ctx.refStore.resolveEntry(refKey);
-  return entry?.tabId === tabId ? entry : null;
+  if (!entry) return null;
+  const ownerTabId =
+    entry.kind === "visual-region" ? entry.candidate.document.target.tabId : entry.tabId;
+  return ownerTabId === tabId ? entry : null;
 }
 
 /**
  * Soft lookup: returns `null` when the ref is unknown or bound to a
- * different tab. Used by paths that report `matched: false` instead of
+ * different tab, or is a visual region. Used by paths that report `matched: false` instead of
  * emitting an RPC error (e.g. `tool.request_help`).
  */
 export function lookupSnapshotRef(
@@ -30,8 +38,8 @@ export function lookupSnapshotRef(
   tabId: number,
 ): SnapshotRefLookup | null {
   const refKey = normaliseRef(ref);
-  const entry = refEntryForTab(ctx, refKey, tabId);
-  if (!entry) return null;
+  const entry = lookupRefTarget(ctx, refKey, tabId);
+  if (!entry || entry.kind !== "dom") return null;
   return {
     backendNodeId: entry.backendNodeId,
     refKey,
@@ -50,6 +58,13 @@ export function resolveSnapshotRef(
   ref: string,
   tabId: number,
 ): SnapshotRefLookup | RpcError {
+  const entry = lookupRefTarget(ctx, ref, tabId);
+  if (entry?.kind === "visual-region")
+    return rpcError(
+      "unsupported",
+      "ref_kind_unsupported",
+      `ref ${ref} is a visual region, not a DOM operation target`,
+    );
   const looked = lookupSnapshotRef(ctx, ref, tabId);
   if (looked === null) {
     return rpcError(

--- a/apps/extension/src/tools/visual-capture.ts
+++ b/apps/extension/src/tools/visual-capture.ts
@@ -1,0 +1,112 @@
+import { normaliseRef, type RefStore, type VisualRefInput } from "@/session-manager/ref-store";
+import type { ClickParams, RpcError } from "@/transport/types";
+import { rpcError } from "./errors";
+import type { VisualTargetState } from "./visual-target";
+
+const TTL_MS = 120_000;
+const MAX_CAPTURES = 32;
+interface Capture {
+  id: string;
+  ref: string;
+  generation: number;
+  entry: VisualRefInput;
+  mapping: VisualTargetState;
+  width: number;
+  height: number;
+  expiresAt: number;
+}
+const stores = new WeakMap<RefStore, Map<string, Capture>>();
+function captures(store: RefStore): Map<string, Capture> {
+  let result = stores.get(store);
+  if (!result) stores.set(store, (result = new Map()));
+  for (const [ref, capture] of result)
+    if (capture.expiresAt <= Date.now() || capture.generation !== store.revision)
+      result.delete(ref);
+  return result;
+}
+export function clearVisualCapture(store: RefStore, ref: string): void {
+  captures(store).delete(normaliseRef(ref));
+}
+export function issueVisualCapture(
+  store: RefStore,
+  ref: string,
+  entry: VisualRefInput & { generation: number },
+  mapping: VisualTargetState,
+  width: number,
+  height: number,
+): string | undefined {
+  ref = normaliseRef(ref);
+  if (store.resolveEntry(ref) !== entry || entry.generation !== store.revision) return undefined;
+  const items = captures(store);
+  items.delete(ref);
+  if (items.size >= MAX_CAPTURES) items.delete(items.keys().next().value!);
+  const id = crypto.randomUUID();
+  items.set(ref, {
+    id,
+    ref,
+    entry,
+    generation: store.revision,
+    mapping,
+    width,
+    height,
+    expiresAt: Date.now() + TTL_MS,
+  });
+  return id;
+}
+export function isVisualPointRequest(params: ClickParams): boolean {
+  return (
+    params.capture_id !== undefined || params.image_x !== undefined || params.image_y !== undefined
+  );
+}
+export function consumeVisualCapture(
+  store: RefStore,
+  tabId: number,
+  params: ClickParams,
+): { capture: Capture; point: { x: number; y: number } } | RpcError {
+  if (
+    !params.ref ||
+    params.selector ||
+    typeof params.capture_id !== "string" ||
+    !params.capture_id ||
+    !Number.isFinite(params.image_x) ||
+    !Number.isFinite(params.image_y) ||
+    ![1, 2].includes(params.click_count ?? 1)
+  )
+    return rpcError(
+      "invalid_params",
+      "visual_capture_invalid",
+      "Canvas point clicks require a visual ref, capture_id, finite image_x/image_y and click_count 1 or 2",
+    );
+  const ref = normaliseRef(params.ref);
+  const entry = store.resolveEntry(ref);
+  const items = captures(store);
+  const capture = items.get(ref);
+  if (
+    !capture ||
+    capture.id !== params.capture_id ||
+    entry !== capture.entry ||
+    entry.kind !== "visual-region" ||
+    entry.candidate.document.target.tabId !== tabId
+  )
+    return rpcError(
+      "not_found",
+      "visual_capture_stale",
+      "capture expired, consumed or does not match the current visual ref; observe and screenshot again",
+    );
+  const x = params.image_x!,
+    y = params.image_y!;
+  if (x < 0 || y < 0 || x >= capture.width || y >= capture.height)
+    return rpcError(
+      "invalid_params",
+      "visual_coordinate_invalid",
+      "image coordinates must be inside the original PNG dimensions",
+    );
+  items.delete(ref); // Before the first await or input: never dispatch twice with this image.
+  return {
+    capture,
+    point: {
+      x: capture.mapping.crop.x + (x / capture.width) * capture.mapping.crop.width,
+      y: capture.mapping.crop.y + (y / capture.height) * capture.mapping.crop.height,
+    },
+  };
+}

--- a/apps/extension/src/tools/visual-screenshot.ts
+++ b/apps/extension/src/tools/visual-screenshot.ts
@@ -1,77 +1,16 @@
-import type { CdpFrame } from "@/browser-driver/frame-graph";
 import type { RpcError } from "@/transport/types";
 import { rpcError } from "./errors";
-import {
-  type GeometryProjection,
-  projectRectToViewport,
-  type Size,
-  type ViewportRect,
-} from "./geometry";
-import { type CssViewport, screenshotPageRect } from "./geometry/coordinate-types";
-import { cssViewport, GeometryContext } from "./geometry/frame-context";
+import { screenshotPageRect } from "./geometry/coordinate-types";
 import { parsePngDimensions } from "./png";
-import { type CdpRunner, sendToCdpTarget } from "./shared";
-import { isAbortError, throwIfAborted } from "./vom/capture-abort";
-import { resolveVerifiedNode } from "./vom/document-identity";
-import type { DocumentIdentity } from "./vom/facts";
-import { VISUAL_STYLES } from "./vom/snapshot";
-import type { VisualCandidate, VisualFramePath } from "./vom/visual-discovery";
+import type { CdpRunner } from "./shared";
 import {
-  EMPTY_VISUAL_CONTEXT,
-  extendVisualContext,
-  projectVisualBox,
-  resolveVisualRegion,
-  type VisualClipSource,
-  type VisualContext,
-  visualProjectionIssue,
-} from "./vom/visual-region";
-
-interface LiveRow {
-  node: number;
-  tag: string;
-  box: ViewportRect;
-  client: ViewportRect;
-  contentSize: Size;
-  styles: Record<string, string>;
-}
-interface LiveFrame {
-  top: boolean;
-  dpr: number;
-  rows: LiveRow[]; // Anchor first, root last.
-}
-
-// Read only one current ancestry, including shadow hosts, in the verified isolated world.
-const READ_ANCESTRY = `function(styleNames) {
-  if (!this.isConnected || this.ownerDocument !== document) return null;
-  const rows = [];
-  for (let node = this; node; node = node.parentElement || node.getRootNode().host) {
-    if (!(node instanceof Element)) return null;
-    const s = getComputedStyle(node), r = node.getBoundingClientRect();
-    rows.push({ node, tag: node.localName,
-      box: { x:r.x, y:r.y, width:r.width, height:r.height },
-      client: { x:r.x+node.clientLeft, y:r.y+node.clientTop, width:node.clientWidth, height:node.clientHeight },
-      contentSize: { width:node.clientWidth-parseFloat(s.paddingLeft)-parseFloat(s.paddingRight), height:node.clientHeight-parseFloat(s.paddingTop)-parseFloat(s.paddingBottom) },
-      styles: Object.fromEntries(styleNames.map(key => [key,s.getPropertyValue(key)])) });
-  }
-  return { top: window === window.top, dpr: devicePixelRatio, rows };
-}`;
-
-interface DeepValue {
-  type: string;
-  value?: unknown;
-}
-/** This read returns JSON primitives plus DOM nodes (backend IDs), never remote object handles. */
-function decode(value: DeepValue): unknown {
-  if (value.type === "node") return (value.value as { backendNodeId?: number })?.backendNodeId;
-  if (value.type === "array") return (value.value as DeepValue[]).map(decode);
-  if (value.type === "object")
-    return Object.fromEntries(
-      (value.value as [string, DeepValue][]).map(([key, item]) => [key, decode(item)]),
-    );
-  if (value.type === "null") return null;
-  if (["string", "number", "boolean"].includes(value.type)) return value.value;
-  throw new Error("unexpected live ancestry serialization");
-}
+  resolveVisualRegionNow,
+  sameVisualMapping,
+  type VisualTargetState,
+  verifyCapturedTarget,
+} from "./visual-target";
+import { isAbortError, throwIfAborted } from "./vom/capture-abort";
+import type { VisualCandidate } from "./vom/visual-discovery";
 
 function stale(message: string): RpcError {
   return rpcError(
@@ -80,44 +19,6 @@ function stale(message: string): RpcError {
     `${message}; observe again before requesting a screenshot`,
   );
 }
-
-function sameIdentity(a: DocumentIdentity, b: DocumentIdentity): boolean {
-  return (
-    a.attachmentId === b.attachmentId &&
-    a.frameId === b.frameId &&
-    a.target.tabId === b.target.tabId &&
-    a.target.sessionId === b.target.sessionId &&
-    a.documentElementBackendNodeId === b.documentElementBackendNodeId
-  );
-}
-
-function closeRect(a: ViewportRect, b: ViewportRect): boolean {
-  return [
-    a.x - b.x,
-    a.y - b.y,
-    a.x + a.width - b.x - b.width,
-    a.y + a.height - b.y - b.height,
-  ].every((delta) => Number.isFinite(delta) && Math.abs(delta) <= 0.25);
-}
-
-function sameClips(a?: VisualClipSource, b?: VisualClipSource): boolean {
-  while (a && b) {
-    if (
-      !sameIdentity(a.document, b.document) ||
-      a.backendNodeId !== b.backendNodeId ||
-      a.x !== b.x ||
-      a.y !== b.y ||
-      a.overflowX !== b.overflowX ||
-      a.overflowY !== b.overflowY ||
-      !closeRect(a.box, b.box)
-    )
-      return false;
-    a = a.parent;
-    b = b.parent;
-  }
-  return !a && !b;
-}
-
 /** Scale affects raster size only, never the selected CSS region. */
 export function visualScreenshotScale(width: number, height: number, pixelsPerCss: number): number {
   if (![width, height, pixelsPerCss].every((n) => Number.isFinite(n) && n > 0))
@@ -129,256 +30,21 @@ export function visualScreenshotScale(width: number, height: number, pixelsPerCs
   );
 }
 
-async function readFrame(
-  cdp: CdpRunner,
-  document: DocumentIdentity,
-  anchor: number,
-  signal?: AbortSignal,
-): Promise<LiveFrame | RpcError> {
-  const verified = await resolveVerifiedNode(cdp, document, anchor, signal);
-  if (verified.status !== "current") return stale(`visual DOM identity ${verified.status}`);
-  try {
-    throwIfAborted(signal);
-    const reply = await sendToCdpTarget<{
-      result?: { deepSerializedValue?: DeepValue };
-      exceptionDetails?: unknown;
-    }>(cdp, document.target, "Runtime.callFunctionOn", {
-      objectId: verified.objectId,
-      objectGroup: verified.objectGroup,
-      functionDeclaration: READ_ANCESTRY,
-      arguments: [{ value: VISUAL_STYLES }],
-      serializationOptions: {
-        serialization: "deep",
-        additionalParameters: { maxNodeDepth: 0, includeShadowTree: "none" },
-      },
-    });
-    throwIfAborted(signal);
-    if (reply.exceptionDetails || !reply.result?.deepSerializedValue)
-      return stale("visual ancestry unavailable");
-    const result = decode(reply.result.deepSerializedValue) as LiveFrame | null;
-    if (
-      !result?.rows?.length ||
-      result.rows[0].node !== anchor ||
-      result.rows.at(-1)?.node !== document.documentElementBackendNodeId ||
-      !result.rows.every((row) => Number.isSafeInteger(row.node) && row.node > 0)
-    )
-      return stale("visual ancestry incomplete");
-    if (cdp.getAttachmentId?.(document.target.tabId) !== document.attachmentId)
-      return stale("visual attachment changed");
-    return result;
-  } finally {
-    await sendToCdpTarget(cdp, document.target, "Runtime.releaseObjectGroup", {
-      objectGroup: verified.objectGroup,
-    }).catch(() => {});
-    throwIfAborted(signal);
-  }
-}
-
-/** All live reads for one screenshot use this one measurement context. */
-async function resolveVisualRegionNow(
-  cdp: CdpRunner,
-  candidate: VisualCandidate,
-  signal?: AbortSignal,
-): Promise<{ crop: ViewportRect; viewport: CssViewport; dpr: number } | RpcError> {
-  throwIfAborted(signal);
-  if (!candidate.framePath || !sameIdentity(candidate.document, candidate.framePath.document))
-    return stale("visual frame path unavailable");
-  const path: { frame: VisualFramePath; anchor: number }[] = [];
-  const seen = new Set<string>();
-  let frame: VisualFramePath | undefined = candidate.framePath;
-  let anchor = candidate.backendNodeId;
-  while (frame) {
-    if (
-      seen.has(frame.document.frameId) ||
-      frame.document.target.tabId !== candidate.document.target.tabId ||
-      cdp.getAttachmentId?.(frame.document.target.tabId) !== frame.document.attachmentId
-    )
-      return stale("invalid visual frame path");
-    seen.add(frame.document.frameId);
-    path.push({ frame, anchor });
-    anchor = frame.parent?.ownerBackendNodeId ?? 0;
-    frame = frame.parent?.frame;
-  }
-  path.reverse();
-  const frames: CdpFrame[] = path.map(({ frame }) => ({
-    frameId: frame.document.frameId,
-    target: frame.document.target,
-    ...(frame.parent
-      ? {
-          parentFrameId: frame.parent.frame.document.frameId,
-          ownerBackendNodeId: frame.parent.ownerBackendNodeId,
-        }
-      : {}),
-  }));
-  // Validate each recorded edge instead of asking the driver to fill all page owners.
-  for (const { frame } of path) {
-    if (!frame.parent) continue;
-    throwIfAborted(signal);
-    const owner = await sendToCdpTarget<{ backendNodeId?: number }>(
-      cdp,
-      frame.parent.frame.document.target,
-      "DOM.getFrameOwner",
-      { frameId: frame.document.frameId },
-    );
-    if (owner.backendNodeId !== frame.parent.ownerBackendNodeId)
-      return stale("visual frame owner changed");
-  }
-  const geometry = new GeometryContext(
-    cdp,
-    candidate.document.target.tabId,
-    { rootFrameId: frames[0].frameId, frames },
-    signal,
-  );
-  let context: VisualContext = EMPTY_VISUAL_CONTEXT;
-  let parentRead: LiveFrame | undefined;
-  let finalRegion: VisualCandidate["region"] | undefined;
-  let topDpr = 0;
-  for (let i = 0; i < path.length; i++) {
-    const { frame, anchor } = path[i];
-    const live = await readFrame(cdp, frame.document, anchor, signal);
-    if ("code" in live) return live;
-    if (live.top !== (i === 0)) return stale("visual root frame changed");
-    if (i === 0) topDpr = live.dpr;
-    const metrics = await geometry.layoutMetrics(frame.document.target);
-    const viewport = cssViewport(metrics);
-    const projections: GeometryProjection[] = [];
-    if (frame.parent) {
-      const parent = frame.parent.frame.document;
-      const size = parentRead!.rows[0].contentSize;
-      if (![size.width, size.height].every((n) => Number.isFinite(n) && n > 0))
-        return stale("iframe content size unavailable");
-      const parentViewport = await geometry.viewport(parent.target);
-      if (!parentViewport) return stale("parent viewport unavailable");
-      const local = await geometry.snapshotProjection(
-        { target: parent.target, frameId: frame.document.frameId },
-        frame.parent.ownerBackendNodeId,
-        [],
-        parentViewport,
-        size,
-      );
-      const outer = await geometry.targetProjection(parent.frameId);
-      if (local.status !== "available" || !outer)
-        return stale("visual frame projection unavailable");
-      projections.push(local.projection.geometry, outer);
-    } else projections.push({ sourceClips: [], edges: [], topViewport: viewport });
-    const issue = visualProjectionIssue({
-      projections,
-      coordinates: { layoutUnitsPerCssPixel: 1, scrollCss: { x: 0, y: 0 } },
-      pageScale: metrics.cssVisualViewport?.scale ?? metrics.visualViewport?.scale,
-    });
-    if (issue) return stale(issue);
-    for (let j = live.rows.length - 1; j >= 0; j--) {
-      const row = live.rows[j];
-      const isAnchor = j === 0;
-      const node = {
-        document: frame.document,
-        backendNodeId: row.node,
-        styles: row.styles,
-        clientBox: projectVisualBox(row.client, projections),
-      };
-      context = extendVisualContext(
-        context,
-        node,
-        !isAnchor && row.tag !== "iframe" && row.tag !== "frame",
-      );
-    }
-    if (i < path.length - 1) {
-      const owner = live.rows[0];
-      context = {
-        ...context,
-        hidden:
-          context.hidden ||
-          owner.styles.visibility === "hidden" ||
-          owner.styles.visibility === "collapse",
-        transformed: false,
-        localClip: false,
-        unpositionedClip: false,
-      };
-    } else {
-      const row = live.rows[0];
-      if (row.tag !== "canvas") return stale("visual anchor is no longer Canvas");
-      let visible: ViewportRect | null = row.box;
-      for (const projection of projections)
-        visible = visible
-          ? projectRectToViewport(
-              { x: visible.x, y: visible.y, w: visible.width, h: visible.height },
-              projection,
-            )
-          : null;
-      const region = resolveVisualRegion({
-        borderBox: projectVisualBox(row.box, projections),
-        frameVisibleBox: visible,
-        context,
-        visibility: row.styles.visibility,
-      });
-      if (region.status !== "available")
-        return stale(
-          `visual region ${region.status}${region.status === "unavailable" ? `: ${region.reason}` : ""}`,
-        );
-      finalRegion = region;
-    }
-    parentRead = live;
-  }
-  if (
-    !finalRegion ||
-    !closeRect(candidate.region.borderBox, finalRegion.borderBox) ||
-    !closeRect(candidate.region.crop, finalRegion.crop) ||
-    !sameClips(candidate.region.clips, finalRegion.clips)
-  )
-    return stale("visual region changed");
-  const viewport = cssViewport(await geometry.layoutMetrics(frames[0].target));
-  return { crop: finalRegion.crop, viewport, dpr: topDpr };
-}
-
-/** Check identity only: repainting and post-capture layout changes are allowed. */
-async function verifyCapturedTarget(
-  cdp: CdpRunner,
-  candidate: VisualCandidate,
-  signal?: AbortSignal,
-): Promise<RpcError | null> {
-  try {
-    let frame = candidate.framePath;
-    let anchor = candidate.backendNodeId;
-    // The path was validated before capture; never rebuild it from the current page.
-    while (frame) {
-      const verified = await resolveVerifiedNode(cdp, frame.document, anchor, signal);
-      if (verified.status !== "current") return stale(`visual DOM identity ${verified.status}`);
-      await sendToCdpTarget(cdp, frame.document.target, "Runtime.releaseObjectGroup", {
-        objectGroup: verified.objectGroup,
-      }).catch(() => {});
-      throwIfAborted(signal);
-      if (frame.parent) {
-        const owner = await sendToCdpTarget<{ backendNodeId?: number }>(
-          cdp,
-          frame.parent.frame.document.target,
-          "DOM.getFrameOwner",
-          { frameId: frame.document.frameId },
-        );
-        throwIfAborted(signal);
-        if (owner.backendNodeId !== frame.parent.ownerBackendNodeId)
-          return stale("visual frame owner changed");
-        anchor = frame.parent.ownerBackendNodeId;
-      }
-      frame = frame.parent?.frame;
-    }
-    throwIfAborted(signal);
-    return cdp.getAttachmentId?.(candidate.document.target.tabId) ===
-      candidate.document.attachmentId
-      ? null
-      : stale("visual attachment changed");
-  } catch (error) {
-    throwIfAborted(signal);
-    if (isAbortError(error)) throw error;
-    return stale("visual identity unavailable after capture");
-  }
-}
-
 /** One target only. No frame discovery, scrolling, AX, or snapshot recapture. */
 export async function captureVisualScreenshot(
   cdp: CdpRunner,
   candidate: VisualCandidate,
   signal?: AbortSignal,
-): Promise<{ image_base64: string; width: number; height: number } | RpcError> {
+): Promise<
+  | {
+      image_base64: string;
+      width: number;
+      height: number;
+      mapping?: VisualTargetState;
+      capture_unavailable?: string;
+    }
+  | RpcError
+> {
   try {
     let region = await resolveVisualRegionNow(cdp, candidate, signal);
     if ("code" in region) return region;
@@ -410,8 +76,21 @@ export async function captureVisualScreenshot(
         cdp.getAttachmentId?.(candidate.document.target.tabId) !== candidate.document.attachmentId
       )
         return stale("visual attachment changed");
-      const identityError = await verifyCapturedTarget(cdp, candidate, signal);
-      if (identityError) return identityError;
+      let after: VisualTargetState | RpcError;
+      try {
+        after = await resolveVisualRegionNow(cdp, candidate, signal, true);
+      } catch (error) {
+        throwIfAborted(signal);
+        if (isAbortError(error)) throw error;
+        after = stale("post-capture mapping unavailable");
+      }
+      if ("code" in after) {
+        // Preserve PR7 viewing behavior when geometry became unsupported, but never
+        // return an image whose identity could not be confirmed.
+        const identityError = await verifyCapturedTarget(cdp, candidate, signal);
+        if (identityError) return identityError;
+      }
+      const mapping = !("code" in after) && sameVisualMapping(region, after) ? region : undefined;
       const dims = shot.data ? parsePngDimensions(shot.data) : null;
       if (!dims)
         return rpcError(
@@ -420,7 +99,17 @@ export async function captureVisualScreenshot(
           "visual screenshot returned invalid PNG dimensions",
         );
       const correction = visualScreenshotScale(dims.width, dims.height, 1);
-      if (correction === 1) return { image_base64: shot.data!, ...dims };
+      if (correction === 1)
+        return {
+          image_base64: shot.data!,
+          ...dims,
+          ...(mapping
+            ? { mapping }
+            : {
+                capture_unavailable:
+                  "visual mapping changed during capture; observe and screenshot again",
+              }),
+        };
       scale *= correction * 0.99;
     }
     return rpcError(

--- a/apps/extension/src/tools/visual-screenshot.ts
+++ b/apps/extension/src/tools/visual-screenshot.ts
@@ -1,0 +1,382 @@
+import type { CdpFrame } from "@/browser-driver/frame-graph";
+import type { RpcError } from "@/transport/types";
+import { rpcError } from "./errors";
+import {
+  type GeometryProjection,
+  projectRectToViewport,
+  type Size,
+  type ViewportRect,
+} from "./geometry";
+import { type CssViewport, screenshotPageRect } from "./geometry/coordinate-types";
+import { cssViewport, GeometryContext } from "./geometry/frame-context";
+import { parsePngDimensions } from "./png";
+import { type CdpRunner, sendToCdpTarget } from "./shared";
+import { isAbortError, throwIfAborted } from "./vom/capture-abort";
+import { resolveVerifiedNode } from "./vom/document-identity";
+import type { DocumentIdentity } from "./vom/facts";
+import { VISUAL_STYLES } from "./vom/snapshot";
+import type { VisualCandidate, VisualFramePath } from "./vom/visual-discovery";
+import {
+  EMPTY_VISUAL_CONTEXT,
+  extendVisualContext,
+  projectVisualBox,
+  resolveVisualRegion,
+  type VisualClipSource,
+  type VisualContext,
+  visualProjectionIssue,
+} from "./vom/visual-region";
+
+interface LiveRow {
+  node: number;
+  tag: string;
+  box: ViewportRect;
+  client: ViewportRect;
+  contentSize: Size;
+  styles: Record<string, string>;
+}
+interface LiveFrame {
+  top: boolean;
+  dpr: number;
+  rows: LiveRow[]; // Anchor first, root last.
+}
+
+// Read only one current ancestry, including shadow hosts, in the verified isolated world.
+const READ_ANCESTRY = `function(styleNames) {
+  if (!this.isConnected || this.ownerDocument !== document) return null;
+  const rows = [];
+  for (let node = this; node; node = node.parentElement || node.getRootNode().host) {
+    if (!(node instanceof Element)) return null;
+    const s = getComputedStyle(node), r = node.getBoundingClientRect();
+    rows.push({ node, tag: node.localName,
+      box: { x:r.x, y:r.y, width:r.width, height:r.height },
+      client: { x:r.x+node.clientLeft, y:r.y+node.clientTop, width:node.clientWidth, height:node.clientHeight },
+      contentSize: { width:node.clientWidth-parseFloat(s.paddingLeft)-parseFloat(s.paddingRight), height:node.clientHeight-parseFloat(s.paddingTop)-parseFloat(s.paddingBottom) },
+      styles: Object.fromEntries(styleNames.map(key => [key,s.getPropertyValue(key)])) });
+  }
+  return { top: window === window.top, dpr: devicePixelRatio, rows };
+}`;
+
+interface DeepValue {
+  type: string;
+  value?: unknown;
+}
+/** This read returns JSON primitives plus DOM nodes (backend IDs), never remote object handles. */
+function decode(value: DeepValue): unknown {
+  if (value.type === "node") return (value.value as { backendNodeId?: number })?.backendNodeId;
+  if (value.type === "array") return (value.value as DeepValue[]).map(decode);
+  if (value.type === "object")
+    return Object.fromEntries(
+      (value.value as [string, DeepValue][]).map(([key, item]) => [key, decode(item)]),
+    );
+  if (value.type === "null") return null;
+  if (["string", "number", "boolean"].includes(value.type)) return value.value;
+  throw new Error("unexpected live ancestry serialization");
+}
+
+function stale(message: string): RpcError {
+  return rpcError(
+    "not_found",
+    "visual_target_changed",
+    `${message}; observe again before requesting a screenshot`,
+  );
+}
+
+function sameIdentity(a: DocumentIdentity, b: DocumentIdentity): boolean {
+  return (
+    a.attachmentId === b.attachmentId &&
+    a.frameId === b.frameId &&
+    a.target.tabId === b.target.tabId &&
+    a.target.sessionId === b.target.sessionId &&
+    a.documentElementBackendNodeId === b.documentElementBackendNodeId
+  );
+}
+
+function closeRect(a: ViewportRect, b: ViewportRect): boolean {
+  return [
+    a.x - b.x,
+    a.y - b.y,
+    a.x + a.width - b.x - b.width,
+    a.y + a.height - b.y - b.height,
+  ].every((delta) => Number.isFinite(delta) && Math.abs(delta) <= 0.25);
+}
+
+function sameClips(a?: VisualClipSource, b?: VisualClipSource): boolean {
+  while (a && b) {
+    if (
+      !sameIdentity(a.document, b.document) ||
+      a.backendNodeId !== b.backendNodeId ||
+      a.x !== b.x ||
+      a.y !== b.y ||
+      a.overflowX !== b.overflowX ||
+      a.overflowY !== b.overflowY ||
+      !closeRect(a.box, b.box)
+    )
+      return false;
+    a = a.parent;
+    b = b.parent;
+  }
+  return !a && !b;
+}
+
+/** Scale affects raster size only, never the selected CSS region. */
+export function visualScreenshotScale(width: number, height: number, pixelsPerCss: number): number {
+  if (![width, height, pixelsPerCss].every((n) => Number.isFinite(n) && n > 0))
+    throw new Error("invalid screenshot pixel dimensions");
+  return Math.min(
+    1,
+    2048 / (Math.max(width, height) * pixelsPerCss),
+    Math.sqrt(4_000_000 / (width * height * pixelsPerCss * pixelsPerCss)),
+  );
+}
+
+async function readFrame(
+  cdp: CdpRunner,
+  document: DocumentIdentity,
+  anchor: number,
+  signal?: AbortSignal,
+): Promise<LiveFrame | RpcError> {
+  const verified = await resolveVerifiedNode(cdp, document, anchor, signal);
+  if (verified.status !== "current") return stale(`visual DOM identity ${verified.status}`);
+  try {
+    throwIfAborted(signal);
+    const reply = await sendToCdpTarget<{
+      result?: { deepSerializedValue?: DeepValue };
+      exceptionDetails?: unknown;
+    }>(cdp, document.target, "Runtime.callFunctionOn", {
+      objectId: verified.objectId,
+      objectGroup: verified.objectGroup,
+      functionDeclaration: READ_ANCESTRY,
+      arguments: [{ value: VISUAL_STYLES }],
+      serializationOptions: {
+        serialization: "deep",
+        additionalParameters: { maxNodeDepth: 0, includeShadowTree: "none" },
+      },
+    });
+    throwIfAborted(signal);
+    if (reply.exceptionDetails || !reply.result?.deepSerializedValue)
+      return stale("visual ancestry unavailable");
+    const result = decode(reply.result.deepSerializedValue) as LiveFrame | null;
+    if (
+      !result?.rows?.length ||
+      result.rows[0].node !== anchor ||
+      result.rows.at(-1)?.node !== document.documentElementBackendNodeId ||
+      !result.rows.every((row) => Number.isSafeInteger(row.node) && row.node > 0)
+    )
+      return stale("visual ancestry incomplete");
+    if (cdp.getAttachmentId?.(document.target.tabId) !== document.attachmentId)
+      return stale("visual attachment changed");
+    return result;
+  } finally {
+    await sendToCdpTarget(cdp, document.target, "Runtime.releaseObjectGroup", {
+      objectGroup: verified.objectGroup,
+    }).catch(() => {});
+    throwIfAborted(signal);
+  }
+}
+
+/** All live reads for one screenshot use this one measurement context. */
+async function resolveVisualRegionNow(
+  cdp: CdpRunner,
+  candidate: VisualCandidate,
+  signal?: AbortSignal,
+): Promise<{ crop: ViewportRect; viewport: CssViewport; dpr: number } | RpcError> {
+  throwIfAborted(signal);
+  if (!candidate.framePath || !sameIdentity(candidate.document, candidate.framePath.document))
+    return stale("visual frame path unavailable");
+  const path: { frame: VisualFramePath; anchor: number }[] = [];
+  const seen = new Set<string>();
+  let frame: VisualFramePath | undefined = candidate.framePath;
+  let anchor = candidate.backendNodeId;
+  while (frame) {
+    if (
+      seen.has(frame.document.frameId) ||
+      frame.document.target.tabId !== candidate.document.target.tabId ||
+      cdp.getAttachmentId?.(frame.document.target.tabId) !== frame.document.attachmentId
+    )
+      return stale("invalid visual frame path");
+    seen.add(frame.document.frameId);
+    path.push({ frame, anchor });
+    anchor = frame.parent?.ownerBackendNodeId ?? 0;
+    frame = frame.parent?.frame;
+  }
+  path.reverse();
+  const frames: CdpFrame[] = path.map(({ frame }) => ({
+    frameId: frame.document.frameId,
+    target: frame.document.target,
+    ...(frame.parent
+      ? {
+          parentFrameId: frame.parent.frame.document.frameId,
+          ownerBackendNodeId: frame.parent.ownerBackendNodeId,
+        }
+      : {}),
+  }));
+  // Validate each recorded edge instead of asking the driver to fill all page owners.
+  for (const { frame } of path) {
+    if (!frame.parent) continue;
+    throwIfAborted(signal);
+    const owner = await sendToCdpTarget<{ backendNodeId?: number }>(
+      cdp,
+      frame.parent.frame.document.target,
+      "DOM.getFrameOwner",
+      { frameId: frame.document.frameId },
+    );
+    if (owner.backendNodeId !== frame.parent.ownerBackendNodeId)
+      return stale("visual frame owner changed");
+  }
+  const geometry = new GeometryContext(
+    cdp,
+    candidate.document.target.tabId,
+    { rootFrameId: frames[0].frameId, frames },
+    signal,
+  );
+  let context: VisualContext = EMPTY_VISUAL_CONTEXT;
+  let parentRead: LiveFrame | undefined;
+  let finalRegion: VisualCandidate["region"] | undefined;
+  let topDpr = 0;
+  for (let i = 0; i < path.length; i++) {
+    const { frame, anchor } = path[i];
+    const live = await readFrame(cdp, frame.document, anchor, signal);
+    if ("code" in live) return live;
+    if (live.top !== (i === 0)) return stale("visual root frame changed");
+    if (i === 0) topDpr = live.dpr;
+    const metrics = await geometry.layoutMetrics(frame.document.target);
+    const viewport = cssViewport(metrics);
+    const projections: GeometryProjection[] = [];
+    if (frame.parent) {
+      const parent = frame.parent.frame.document;
+      const size = parentRead!.rows[0].contentSize;
+      if (![size.width, size.height].every((n) => Number.isFinite(n) && n > 0))
+        return stale("iframe content size unavailable");
+      const parentViewport = await geometry.viewport(parent.target);
+      if (!parentViewport) return stale("parent viewport unavailable");
+      const local = await geometry.snapshotProjection(
+        { target: parent.target, frameId: frame.document.frameId },
+        frame.parent.ownerBackendNodeId,
+        [],
+        parentViewport,
+        size,
+      );
+      const outer = await geometry.targetProjection(parent.frameId);
+      if (local.status !== "available" || !outer)
+        return stale("visual frame projection unavailable");
+      projections.push(local.projection.geometry, outer);
+    } else projections.push({ sourceClips: [], edges: [], topViewport: viewport });
+    const issue = visualProjectionIssue({
+      projections,
+      coordinates: { layoutUnitsPerCssPixel: 1, scrollCss: { x: 0, y: 0 } },
+      pageScale: metrics.cssVisualViewport?.scale ?? metrics.visualViewport?.scale,
+    });
+    if (issue) return stale(issue);
+    for (let j = live.rows.length - 1; j >= 0; j--) {
+      const row = live.rows[j];
+      const isAnchor = j === 0;
+      const node = {
+        document: frame.document,
+        backendNodeId: row.node,
+        styles: row.styles,
+        clientBox: projectVisualBox(row.client, projections),
+      };
+      context = extendVisualContext(
+        context,
+        node,
+        !isAnchor && row.tag !== "iframe" && row.tag !== "frame",
+      );
+    }
+    if (i < path.length - 1) {
+      const owner = live.rows[0];
+      context = {
+        ...context,
+        hidden:
+          context.hidden ||
+          owner.styles.visibility === "hidden" ||
+          owner.styles.visibility === "collapse",
+        transformed: false,
+        localClip: false,
+        unpositionedClip: false,
+      };
+    } else {
+      const row = live.rows[0];
+      if (row.tag !== "canvas") return stale("visual anchor is no longer Canvas");
+      let visible: ViewportRect | null = row.box;
+      for (const projection of projections)
+        visible = visible
+          ? projectRectToViewport(
+              { x: visible.x, y: visible.y, w: visible.width, h: visible.height },
+              projection,
+            )
+          : null;
+      const region = resolveVisualRegion({
+        borderBox: projectVisualBox(row.box, projections),
+        frameVisibleBox: visible,
+        context,
+        visibility: row.styles.visibility,
+      });
+      if (region.status !== "available")
+        return stale(
+          `visual region ${region.status}${region.status === "unavailable" ? `: ${region.reason}` : ""}`,
+        );
+      finalRegion = region;
+    }
+    parentRead = live;
+  }
+  if (
+    !finalRegion ||
+    !closeRect(candidate.region.borderBox, finalRegion.borderBox) ||
+    !closeRect(candidate.region.crop, finalRegion.crop) ||
+    !sameClips(candidate.region.clips, finalRegion.clips)
+  )
+    return stale("visual region changed");
+  const viewport = cssViewport(await geometry.layoutMetrics(frames[0].target));
+  return { crop: finalRegion.crop, viewport, dpr: topDpr };
+}
+
+/** One target only. No frame discovery, scrolling, AX, or snapshot recapture. */
+export async function captureVisualScreenshot(
+  cdp: CdpRunner,
+  candidate: VisualCandidate,
+  signal?: AbortSignal,
+): Promise<{ image_base64: string; width: number; height: number } | RpcError> {
+  try {
+    const region = await resolveVisualRegionNow(cdp, candidate, signal);
+    if ("code" in region) return region;
+    const clip = screenshotPageRect(region.crop, region.viewport);
+    if (!clip) return stale("invalid screenshot coordinates");
+    let scale = visualScreenshotScale(region.crop.width, region.crop.height, region.dpr);
+    for (let attempt = 0; attempt < 2; attempt++) {
+      throwIfAborted(signal);
+      if (
+        cdp.getAttachmentId?.(candidate.document.target.tabId) !== candidate.document.attachmentId
+      )
+        return stale("visual attachment changed");
+      const shot = await cdp.send<{ data?: string }>(
+        candidate.document.target.tabId,
+        "Page.captureScreenshot",
+        { format: "png", captureBeyondViewport: false, clip: { ...clip.rect, scale } },
+      );
+      throwIfAborted(signal);
+      const dims = shot.data ? parsePngDimensions(shot.data) : null;
+      if (!dims)
+        return rpcError(
+          "cdp_failed",
+          "screenshot_capture_failed",
+          "visual screenshot returned invalid PNG dimensions",
+        );
+      const correction = visualScreenshotScale(dims.width, dims.height, 1);
+      if (correction === 1) return { image_base64: shot.data!, ...dims };
+      scale *= correction * 0.99;
+    }
+    return rpcError(
+      "cdp_failed",
+      "visual_pixel_budget_exceeded",
+      "visual screenshot exceeds the pixel budget",
+    );
+  } catch (error) {
+    if (isAbortError(error) || signal?.aborted)
+      return { code: "cancelled", message: "visual screenshot aborted" };
+    return rpcError(
+      "cdp_failed",
+      "screenshot_capture_failed",
+      error instanceof Error ? error.message : String(error),
+    );
+  }
+}

--- a/apps/extension/src/tools/visual-screenshot.ts
+++ b/apps/extension/src/tools/visual-screenshot.ts
@@ -330,6 +330,49 @@ async function resolveVisualRegionNow(
   return { crop: finalRegion.crop, viewport, dpr: topDpr };
 }
 
+/** Check identity only: repainting and post-capture layout changes are allowed. */
+async function verifyCapturedTarget(
+  cdp: CdpRunner,
+  candidate: VisualCandidate,
+  signal?: AbortSignal,
+): Promise<RpcError | null> {
+  try {
+    let frame = candidate.framePath;
+    let anchor = candidate.backendNodeId;
+    // The path was validated before capture; never rebuild it from the current page.
+    while (frame) {
+      const verified = await resolveVerifiedNode(cdp, frame.document, anchor, signal);
+      if (verified.status !== "current") return stale(`visual DOM identity ${verified.status}`);
+      await sendToCdpTarget(cdp, frame.document.target, "Runtime.releaseObjectGroup", {
+        objectGroup: verified.objectGroup,
+      }).catch(() => {});
+      throwIfAborted(signal);
+      if (frame.parent) {
+        const owner = await sendToCdpTarget<{ backendNodeId?: number }>(
+          cdp,
+          frame.parent.frame.document.target,
+          "DOM.getFrameOwner",
+          { frameId: frame.document.frameId },
+        );
+        throwIfAborted(signal);
+        if (owner.backendNodeId !== frame.parent.ownerBackendNodeId)
+          return stale("visual frame owner changed");
+        anchor = frame.parent.ownerBackendNodeId;
+      }
+      frame = frame.parent?.frame;
+    }
+    throwIfAborted(signal);
+    return cdp.getAttachmentId?.(candidate.document.target.tabId) ===
+      candidate.document.attachmentId
+      ? null
+      : stale("visual attachment changed");
+  } catch (error) {
+    throwIfAborted(signal);
+    if (isAbortError(error)) throw error;
+    return stale("visual identity unavailable after capture");
+  }
+}
+
 /** One target only. No frame discovery, scrolling, AX, or snapshot recapture. */
 export async function captureVisualScreenshot(
   cdp: CdpRunner,
@@ -337,12 +380,21 @@ export async function captureVisualScreenshot(
   signal?: AbortSignal,
 ): Promise<{ image_base64: string; width: number; height: number } | RpcError> {
   try {
-    const region = await resolveVisualRegionNow(cdp, candidate, signal);
+    let region = await resolveVisualRegionNow(cdp, candidate, signal);
     if ("code" in region) return region;
-    const clip = screenshotPageRect(region.crop, region.viewport);
-    if (!clip) return stale("invalid screenshot coordinates");
     let scale = visualScreenshotScale(region.crop.width, region.crop.height, region.dpr);
     for (let attempt = 0; attempt < 2; attempt++) {
+      if (attempt > 0) {
+        // A new raster attempt needs fresh geometry, not the previous crop/cache.
+        region = await resolveVisualRegionNow(cdp, candidate, signal);
+        if ("code" in region) return region;
+        scale = Math.min(
+          scale,
+          visualScreenshotScale(region.crop.width, region.crop.height, region.dpr),
+        );
+      }
+      const clip = screenshotPageRect(region.crop, region.viewport);
+      if (!clip) return stale("invalid screenshot coordinates");
       throwIfAborted(signal);
       if (
         cdp.getAttachmentId?.(candidate.document.target.tabId) !== candidate.document.attachmentId
@@ -354,6 +406,12 @@ export async function captureVisualScreenshot(
         { format: "png", captureBeyondViewport: false, clip: { ...clip.rect, scale } },
       );
       throwIfAborted(signal);
+      if (
+        cdp.getAttachmentId?.(candidate.document.target.tabId) !== candidate.document.attachmentId
+      )
+        return stale("visual attachment changed");
+      const identityError = await verifyCapturedTarget(cdp, candidate, signal);
+      if (identityError) return identityError;
       const dims = shot.data ? parsePngDimensions(shot.data) : null;
       if (!dims)
         return rpcError(

--- a/apps/extension/src/tools/visual-target.ts
+++ b/apps/extension/src/tools/visual-target.ts
@@ -1,0 +1,473 @@
+import type { CdpFrame } from "@/browser-driver/frame-graph";
+import type { RpcError } from "@/transport/types";
+import { rpcError } from "./errors";
+import {
+  type GeometryProjection,
+  projectRectToViewport,
+  type Size,
+  type ViewportRect,
+} from "./geometry";
+import { type CssViewport } from "./geometry/coordinate-types";
+import { cssViewport, GeometryContext } from "./geometry/frame-context";
+import { type CdpRunner, sendToCdpTarget } from "./shared";
+import { isAbortError, throwIfAborted } from "./vom/capture-abort";
+import { resolveVerifiedNode } from "./vom/document-identity";
+import type { DocumentIdentity } from "./vom/facts";
+import { VISUAL_STYLES } from "./vom/snapshot";
+import type { VisualCandidate, VisualFramePath } from "./vom/visual-discovery";
+import {
+  EMPTY_VISUAL_CONTEXT,
+  extendVisualContext,
+  projectVisualBox,
+  resolveVisualRegion,
+  type VisualClipSource,
+  type VisualContext,
+  visualProjectionIssue,
+} from "./vom/visual-region";
+
+interface LiveRow {
+  node: number;
+  tag: string;
+  box: ViewportRect;
+  client: ViewportRect;
+  contentSize: Size;
+  styles: Record<string, string>;
+}
+interface LiveFrame {
+  top: boolean;
+  dpr: number;
+  scrollX?: number;
+  scrollY?: number;
+  width?: number;
+  height?: number;
+  rows: LiveRow[]; // Anchor first, root last.
+}
+
+// Read only one current ancestry, including shadow hosts, in the verified isolated world.
+const READ_ANCESTRY = `function(styleNames) {
+  if (!this.isConnected || this.ownerDocument !== document) return null;
+  const rows = [];
+  for (let node = this; node; node = node.parentElement || node.getRootNode().host) {
+    if (!(node instanceof Element)) return null;
+    const s = getComputedStyle(node), r = node.getBoundingClientRect();
+    rows.push({ node, tag: node.localName,
+      box: { x:r.x, y:r.y, width:r.width, height:r.height },
+      client: { x:r.x+node.clientLeft, y:r.y+node.clientTop, width:node.clientWidth, height:node.clientHeight },
+      contentSize: { width:node.clientWidth-parseFloat(s.paddingLeft)-parseFloat(s.paddingRight), height:node.clientHeight-parseFloat(s.paddingTop)-parseFloat(s.paddingBottom) },
+      styles: Object.fromEntries(styleNames.map(key => [key,s.getPropertyValue(key)])) });
+  }
+  return { top: window === window.top, dpr: devicePixelRatio, scrollX, scrollY, width: innerWidth, height: innerHeight, rows };
+}`;
+
+interface DeepValue {
+  type: string;
+  value?: unknown;
+}
+/** This read returns JSON primitives plus DOM nodes (backend IDs), never remote object handles. */
+function decode(value: DeepValue): unknown {
+  if (value.type === "node") return (value.value as { backendNodeId?: number })?.backendNodeId;
+  if (value.type === "array") return (value.value as DeepValue[]).map(decode);
+  if (value.type === "object")
+    return Object.fromEntries(
+      (value.value as [string, DeepValue][]).map(([key, item]) => [key, decode(item)]),
+    );
+  if (value.type === "null") return null;
+  if (["string", "number", "boolean"].includes(value.type)) return value.value;
+  throw new Error("unexpected live ancestry serialization");
+}
+
+function stale(message: string): RpcError {
+  return rpcError(
+    "not_found",
+    "visual_target_changed",
+    `${message}; observe again before requesting a screenshot`,
+  );
+}
+
+export function sameIdentity(a: DocumentIdentity, b: DocumentIdentity): boolean {
+  return (
+    a.attachmentId === b.attachmentId &&
+    a.frameId === b.frameId &&
+    a.target.tabId === b.target.tabId &&
+    a.target.sessionId === b.target.sessionId &&
+    a.documentElementBackendNodeId === b.documentElementBackendNodeId
+  );
+}
+
+function closeRect(a: ViewportRect, b: ViewportRect): boolean {
+  return [
+    a.x - b.x,
+    a.y - b.y,
+    a.x + a.width - b.x - b.width,
+    a.y + a.height - b.y - b.height,
+  ].every((delta) => Number.isFinite(delta) && Math.abs(delta) <= 0.25);
+}
+
+function sameClips(a?: VisualClipSource, b?: VisualClipSource): boolean {
+  while (a && b) {
+    if (
+      !sameIdentity(a.document, b.document) ||
+      a.backendNodeId !== b.backendNodeId ||
+      a.x !== b.x ||
+      a.y !== b.y ||
+      a.overflowX !== b.overflowX ||
+      a.overflowY !== b.overflowY ||
+      !closeRect(a.box, b.box)
+    )
+      return false;
+    a = a.parent;
+    b = b.parent;
+  }
+  return !a && !b;
+}
+
+async function readFrame(
+  cdp: CdpRunner,
+  document: DocumentIdentity,
+  anchor: number,
+  signal?: AbortSignal,
+): Promise<LiveFrame | RpcError> {
+  const verified = await resolveVerifiedNode(cdp, document, anchor, signal);
+  if (verified.status !== "current") return stale(`visual DOM identity ${verified.status}`);
+  try {
+    throwIfAborted(signal);
+    const reply = await sendToCdpTarget<{
+      result?: { deepSerializedValue?: DeepValue };
+      exceptionDetails?: unknown;
+    }>(cdp, document.target, "Runtime.callFunctionOn", {
+      objectId: verified.objectId,
+      objectGroup: verified.objectGroup,
+      functionDeclaration: READ_ANCESTRY,
+      arguments: [{ value: VISUAL_STYLES }],
+      serializationOptions: {
+        serialization: "deep",
+        additionalParameters: { maxNodeDepth: 0, includeShadowTree: "none" },
+      },
+    });
+    throwIfAborted(signal);
+    if (reply.exceptionDetails || !reply.result?.deepSerializedValue)
+      return stale("visual ancestry unavailable");
+    const result = decode(reply.result.deepSerializedValue) as LiveFrame | null;
+    if (
+      !result?.rows?.length ||
+      result.rows[0].node !== anchor ||
+      result.rows.at(-1)?.node !== document.documentElementBackendNodeId ||
+      !result.rows.every((row) => Number.isSafeInteger(row.node) && row.node > 0)
+    )
+      return stale("visual ancestry incomplete");
+    if (cdp.getAttachmentId?.(document.target.tabId) !== document.attachmentId)
+      return stale("visual attachment changed");
+    return result;
+  } finally {
+    await sendToCdpTarget(cdp, document.target, "Runtime.releaseObjectGroup", {
+      objectGroup: verified.objectGroup,
+    }).catch(() => {});
+    throwIfAborted(signal);
+  }
+}
+
+/** All live reads for one screenshot use this one measurement context. */
+export async function resolveVisualRegionNow(
+  cdp: CdpRunner,
+  candidate: VisualCandidate,
+  signal?: AbortSignal,
+  allowGeometryChange = false,
+): Promise<VisualTargetState | RpcError> {
+  throwIfAborted(signal);
+  if (!candidate.framePath || !sameIdentity(candidate.document, candidate.framePath.document))
+    return stale("visual frame path unavailable");
+  const path: { frame: VisualFramePath; anchor: number }[] = [];
+  const seen = new Set<string>();
+  let frame: VisualFramePath | undefined = candidate.framePath;
+  let anchor = candidate.backendNodeId;
+  while (frame) {
+    if (
+      seen.has(frame.document.frameId) ||
+      frame.document.target.tabId !== candidate.document.target.tabId ||
+      cdp.getAttachmentId?.(frame.document.target.tabId) !== frame.document.attachmentId
+    )
+      return stale("invalid visual frame path");
+    seen.add(frame.document.frameId);
+    path.push({ frame, anchor });
+    anchor = frame.parent?.ownerBackendNodeId ?? 0;
+    frame = frame.parent?.frame;
+  }
+  path.reverse();
+  const frames: CdpFrame[] = path.map(({ frame }) => ({
+    frameId: frame.document.frameId,
+    target: frame.document.target,
+    ...(frame.parent
+      ? {
+          parentFrameId: frame.parent.frame.document.frameId,
+          ownerBackendNodeId: frame.parent.ownerBackendNodeId,
+        }
+      : {}),
+  }));
+  // Validate each recorded edge instead of asking the driver to fill all page owners.
+  for (const { frame } of path) {
+    if (!frame.parent) continue;
+    throwIfAborted(signal);
+    const owner = await sendToCdpTarget<{ backendNodeId?: number }>(
+      cdp,
+      frame.parent.frame.document.target,
+      "DOM.getFrameOwner",
+      { frameId: frame.document.frameId },
+    );
+    if (owner.backendNodeId !== frame.parent.ownerBackendNodeId)
+      return stale("visual frame owner changed");
+  }
+  const geometry = new GeometryContext(
+    cdp,
+    candidate.document.target.tabId,
+    { rootFrameId: frames[0].frameId, frames },
+    signal,
+  );
+  let context: VisualContext = EMPTY_VISUAL_CONTEXT;
+  let parentRead: LiveFrame | undefined;
+  let finalRegion: VisualCandidate["region"] | undefined;
+  let topDpr = 0;
+  const mappings: VisualTargetState["mappings"] = [];
+  for (let i = 0; i < path.length; i++) {
+    const { frame, anchor } = path[i];
+    const live = await readFrame(cdp, frame.document, anchor, signal);
+    if ("code" in live) return live;
+    if (live.top !== (i === 0)) return stale("visual root frame changed");
+    if (i === 0) topDpr = live.dpr;
+    const metrics = await geometry.layoutMetrics(frame.document.target);
+    const viewport = cssViewport(metrics);
+    const projections: GeometryProjection[] = [];
+    if (frame.parent) {
+      const parent = frame.parent.frame.document;
+      const size = parentRead!.rows[0].contentSize;
+      if (![size.width, size.height].every((n) => Number.isFinite(n) && n > 0))
+        return stale("iframe content size unavailable");
+      const parentViewport = await geometry.viewport(parent.target);
+      if (!parentViewport) return stale("parent viewport unavailable");
+      const local = await geometry.snapshotProjection(
+        { target: parent.target, frameId: frame.document.frameId },
+        frame.parent.ownerBackendNodeId,
+        [],
+        parentViewport,
+        size,
+      );
+      const outer = await geometry.targetProjection(parent.frameId);
+      if (local.status !== "available" || !outer)
+        return stale("visual frame projection unavailable");
+      projections.push(local.projection.geometry, outer);
+    } else projections.push({ sourceClips: [], edges: [], topViewport: viewport });
+    const issue = visualProjectionIssue({
+      projections,
+      coordinates: { layoutUnitsPerCssPixel: 1, scrollCss: { x: 0, y: 0 } },
+      pageScale: metrics.cssVisualViewport?.scale ?? metrics.visualViewport?.scale,
+    });
+    if (issue) return stale(issue);
+    const unit = projectVisualBox({ x: 0, y: 0, width: 1, height: 1 }, projections);
+    if (!unit || !(unit.width > 0 && unit.height > 0)) return stale("visual mapping unavailable");
+    mappings.push({
+      document: frame.document,
+      anchor,
+      unit,
+      viewport: {
+        ...viewport,
+        scrollX: live.scrollX ?? viewport.scrollX,
+        scrollY: live.scrollY ?? viewport.scrollY,
+        width: live.width ?? viewport.width,
+        height: live.height ?? viewport.height,
+      },
+    });
+    for (let j = live.rows.length - 1; j >= 0; j--) {
+      const row = live.rows[j];
+      const isAnchor = j === 0;
+      const node = {
+        document: frame.document,
+        backendNodeId: row.node,
+        styles: row.styles,
+        clientBox: projectVisualBox(row.client, projections),
+      };
+      context = extendVisualContext(
+        context,
+        node,
+        !isAnchor && row.tag !== "iframe" && row.tag !== "frame",
+      );
+    }
+    if (i < path.length - 1) {
+      const owner = live.rows[0];
+      context = {
+        ...context,
+        hidden:
+          context.hidden ||
+          owner.styles.visibility === "hidden" ||
+          owner.styles.visibility === "collapse",
+        transformed: false,
+        localClip: false,
+        unpositionedClip: false,
+      };
+    } else {
+      const row = live.rows[0];
+      if (row.tag !== "canvas") return stale("visual anchor is no longer Canvas");
+      let visible: ViewportRect | null = row.box;
+      for (const projection of projections)
+        visible = visible
+          ? projectRectToViewport(
+              { x: visible.x, y: visible.y, w: visible.width, h: visible.height },
+              projection,
+            )
+          : null;
+      const region = resolveVisualRegion({
+        borderBox: projectVisualBox(row.box, projections),
+        frameVisibleBox: visible,
+        context,
+        visibility: row.styles.visibility,
+      });
+      if (region.status !== "available")
+        return stale(
+          `visual region ${region.status}${region.status === "unavailable" ? `: ${region.reason}` : ""}`,
+        );
+      finalRegion = region;
+    }
+    parentRead = live;
+  }
+  if (
+    !finalRegion ||
+    (!allowGeometryChange &&
+      (!closeRect(candidate.region.borderBox, finalRegion.borderBox) ||
+        !closeRect(candidate.region.crop, finalRegion.crop) ||
+        !sameClips(candidate.region.clips, finalRegion.clips)))
+  )
+    return stale("visual region changed");
+  const viewport = cssViewport(await geometry.layoutMetrics(frames[0].target));
+  return { crop: finalRegion.crop, region: finalRegion, viewport, dpr: topDpr, mappings };
+}
+
+/** Check identity only: repainting and post-capture layout changes are allowed. */
+export async function verifyCapturedTarget(
+  cdp: CdpRunner,
+  candidate: VisualCandidate,
+  signal?: AbortSignal,
+): Promise<RpcError | null> {
+  try {
+    let frame = candidate.framePath;
+    let anchor = candidate.backendNodeId;
+    // The path was validated before capture; never rebuild it from the current page.
+    while (frame) {
+      const verified = await resolveVerifiedNode(cdp, frame.document, anchor, signal);
+      if (verified.status !== "current") return stale(`visual DOM identity ${verified.status}`);
+      await sendToCdpTarget(cdp, frame.document.target, "Runtime.releaseObjectGroup", {
+        objectGroup: verified.objectGroup,
+      }).catch(() => {});
+      throwIfAborted(signal);
+      if (frame.parent) {
+        const owner = await sendToCdpTarget<{ backendNodeId?: number }>(
+          cdp,
+          frame.parent.frame.document.target,
+          "DOM.getFrameOwner",
+          { frameId: frame.document.frameId },
+        );
+        throwIfAborted(signal);
+        if (owner.backendNodeId !== frame.parent.ownerBackendNodeId)
+          return stale("visual frame owner changed");
+        anchor = frame.parent.ownerBackendNodeId;
+      }
+      frame = frame.parent?.frame;
+    }
+    throwIfAborted(signal);
+    return cdp.getAttachmentId?.(candidate.document.target.tabId) ===
+      candidate.document.attachmentId
+      ? null
+      : stale("visual attachment changed");
+  } catch (error) {
+    throwIfAborted(signal);
+    if (isAbortError(error)) throw error;
+    return stale("visual identity unavailable after capture");
+  }
+}
+
+export interface VisualTargetState {
+  crop: ViewportRect;
+  region: VisualCandidate["region"];
+  viewport: CssViewport;
+  dpr: number;
+  mappings: {
+    document: DocumentIdentity;
+    anchor: number;
+    unit: ViewportRect;
+    viewport: CssViewport;
+  }[];
+}
+function sameViewport(a: CssViewport, b: CssViewport): boolean {
+  return (
+    a.width === b.width &&
+    a.height === b.height &&
+    a.scrollX === b.scrollX &&
+    a.scrollY === b.scrollY &&
+    a.cssToDip === b.cssToDip
+  );
+}
+export function sameVisualMapping(a: VisualTargetState, b: VisualTargetState): boolean {
+  return (
+    a.dpr === b.dpr &&
+    sameViewport(a.viewport, b.viewport) &&
+    closeRect(a.crop, b.crop) &&
+    closeRect(a.region.borderBox, b.region.borderBox) &&
+    sameClips(a.region.clips, b.region.clips) &&
+    a.mappings.length === b.mappings.length &&
+    a.mappings.every((m, i) => {
+      const n = b.mappings[i];
+      return (
+        m.anchor === n.anchor &&
+        sameIdentity(m.document, n.document) &&
+        closeRect(m.unit, n.unit) &&
+        Math.abs(m.unit.width - n.unit.width) < 1e-6 &&
+        Math.abs(m.unit.height - n.unit.height) < 1e-6 &&
+        sameViewport(m.viewport, n.viewport)
+      );
+    })
+  );
+}
+/** Browser hit testing follows each verified frame, including open shadow roots. */
+export async function verifyVisualHit(
+  cdp: CdpRunner,
+  state: VisualTargetState,
+  point: { x: number; y: number },
+  signal?: AbortSignal,
+): Promise<boolean> {
+  for (const mapping of state.mappings) {
+    throwIfAborted(signal);
+    const { unit, document, anchor } = mapping;
+    if (!(unit.width > 0 && unit.height > 0)) return false;
+    const verified = await resolveVerifiedNode(cdp, document, anchor, signal);
+    if (verified.status !== "current") return false;
+    try {
+      const result = await sendToCdpTarget<{
+        result?: { value?: boolean };
+        exceptionDetails?: unknown;
+      }>(cdp, document.target, "Runtime.callFunctionOn", {
+        objectId: verified.objectId,
+        objectGroup: verified.objectGroup,
+        functionDeclaration: `function(x,y) {
+          if (!this.isConnected || this.ownerDocument !== document) return false;
+          for(let n=this;n;n=n.parentElement || n.getRootNode().host) if(n.inert) return false;
+          let hit=document.elementFromPoint(x,y);
+          while(hit && hit.shadowRoot) {
+            const inner=hit.shadowRoot.elementFromPoint(x,y);
+            if(!inner || inner===hit) break;
+            hit=inner;
+          }
+          return hit===this;
+        }`,
+        arguments: [
+          { value: (point.x - unit.x) / unit.width },
+          { value: (point.y - unit.y) / unit.height },
+        ],
+        returnByValue: true,
+      });
+      if (result.exceptionDetails || result.result?.value !== true) return false;
+    } finally {
+      await sendToCdpTarget(cdp, document.target, "Runtime.releaseObjectGroup", {
+        objectGroup: verified.objectGroup,
+      }).catch(() => {});
+      throwIfAborted(signal);
+    }
+  }
+  return true;
+}

--- a/apps/extension/src/tools/visual-target.ts
+++ b/apps/extension/src/tools/visual-target.ts
@@ -22,11 +22,14 @@ import {
   resolveVisualRegion,
   type VisualClipSource,
   type VisualContext,
+  viewportOverflowSource,
   visualProjectionIssue,
 } from "./vom/visual-region";
 
 interface LiveRow {
   node: number;
+  isBody?: boolean;
+  parentIsElement?: boolean;
   tag: string;
   box: ViewportRect;
   client: ViewportRect;
@@ -43,14 +46,19 @@ interface LiveFrame {
   rows: LiveRow[]; // Anchor first, root last.
 }
 
-// Read only one current ancestry, including shadow hosts, in the verified isolated world.
-const READ_ANCESTRY = `function(styleNames) {
+// Follow the rendered ancestry, including slot distribution, in the verified world.
+// Closed slots supplied by CDP are rechecked here against the current assignment.
+const READ_ANCESTRY = `function(styleNames, ...closedSlots) {
   if (!this.isConnected || this.ownerDocument !== document) return null;
   const rows = [];
-  for (let node = this; node; node = node.parentElement || node.getRootNode().host) {
+  const parent = node => node.assignedSlot ||
+    closedSlots.find(slot => slot.isConnected && slot.ownerDocument === document &&
+      slot.getRootNode().host === node.parentElement && slot.assignedElements().includes(node)) ||
+    node.parentElement || node.getRootNode().host;
+  for (let node = this; node; node = parent(node)) {
     if (!(node instanceof Element)) return null;
     const s = getComputedStyle(node), r = node.getBoundingClientRect();
-    rows.push({ node, tag: node.localName,
+    rows.push({ node, tag: node.localName, isBody: node === document.body, parentIsElement: !!node.parentElement,
       box: { x:r.x, y:r.y, width:r.width, height:r.height },
       client: { x:r.x+node.clientLeft, y:r.y+node.clientTop, width:node.clientWidth, height:node.clientHeight },
       contentSize: { width:node.clientWidth-parseFloat(s.paddingLeft)-parseFloat(s.paddingRight), height:node.clientHeight-parseFloat(s.paddingTop)-parseFloat(s.paddingBottom) },
@@ -64,12 +72,21 @@ interface DeepValue {
   value?: unknown;
 }
 /** This read returns JSON primitives plus DOM nodes (backend IDs), never remote object handles. */
-function decode(value: DeepValue): unknown {
-  if (value.type === "node") return (value.value as { backendNodeId?: number })?.backendNodeId;
-  if (value.type === "array") return (value.value as DeepValue[]).map(decode);
+function decode(value: DeepValue, closedHosts: Set<number>): unknown {
+  if (value.type === "node") {
+    const node = value.value as {
+      backendNodeId?: number;
+      shadowRoot?: { value?: { mode?: string } };
+    };
+    if (node?.backendNodeId && node.shadowRoot?.value?.mode === "closed")
+      closedHosts.add(node.backendNodeId);
+    return node?.backendNodeId;
+  }
+  if (value.type === "array")
+    return (value.value as DeepValue[]).map((item) => decode(item, closedHosts));
   if (value.type === "object")
     return Object.fromEntries(
-      (value.value as [string, DeepValue][]).map(([key, item]) => [key, decode(item)]),
+      (value.value as [string, DeepValue][]).map(([key, item]) => [key, decode(item, closedHosts)]),
     );
   if (value.type === "null") return null;
   if (["string", "number", "boolean"].includes(value.type)) return value.value;
@@ -130,34 +147,69 @@ async function readFrame(
   const verified = await resolveVerifiedNode(cdp, document, anchor, signal);
   if (verified.status !== "current") return stale(`visual DOM identity ${verified.status}`);
   try {
-    throwIfAborted(signal);
-    const reply = await sendToCdpTarget<{
-      result?: { deepSerializedValue?: DeepValue };
-      exceptionDetails?: unknown;
-    }>(cdp, document.target, "Runtime.callFunctionOn", {
-      objectId: verified.objectId,
-      objectGroup: verified.objectGroup,
-      functionDeclaration: READ_ANCESTRY,
-      arguments: [{ value: VISUAL_STYLES }],
-      serializationOptions: {
-        serialization: "deep",
-        additionalParameters: { maxNodeDepth: 0, includeShadowTree: "none" },
-      },
-    });
-    throwIfAborted(signal);
-    if (reply.exceptionDetails || !reply.result?.deepSerializedValue)
-      return stale("visual ancestry unavailable");
-    const result = decode(reply.result.deepSerializedValue) as LiveFrame | null;
-    if (
-      !result?.rows?.length ||
-      result.rows[0].node !== anchor ||
-      result.rows.at(-1)?.node !== document.documentElementBackendNodeId ||
-      !result.rows.every((row) => Number.isSafeInteger(row.node) && row.node > 0)
-    )
-      return stale("visual ancestry incomplete");
-    if (cdp.getAttachmentId?.(document.target.tabId) !== document.attachmentId)
-      return stale("visual attachment changed");
-    return result;
+    const slots = new Map<number, string>();
+    while (true) {
+      throwIfAborted(signal);
+      const reply = await sendToCdpTarget<{
+        result?: { deepSerializedValue?: DeepValue };
+        exceptionDetails?: unknown;
+      }>(cdp, document.target, "Runtime.callFunctionOn", {
+        objectId: verified.objectId,
+        objectGroup: verified.objectGroup,
+        functionDeclaration: READ_ANCESTRY,
+        arguments: [
+          { value: VISUAL_STYLES },
+          ...Array.from(slots.values(), (objectId) => ({ objectId })),
+        ],
+        serializationOptions: {
+          serialization: "deep",
+          // At depth zero only shadow-root metadata is included, never its descendants.
+          additionalParameters: { maxNodeDepth: 0, includeShadowTree: "all" },
+        },
+      });
+      throwIfAborted(signal);
+      if (reply.exceptionDetails || !reply.result?.deepSerializedValue)
+        return stale("visual ancestry unavailable");
+      const closedHosts = new Set<number>();
+      const result = decode(reply.result.deepSerializedValue, closedHosts) as LiveFrame | null;
+      if (
+        !result?.rows?.length ||
+        result.rows[0].node !== anchor ||
+        result.rows.at(-1)?.node !== document.documentElementBackendNodeId ||
+        !result.rows.every((row) => Number.isSafeInteger(row.node) && row.node > 0)
+      )
+        return stale("visual ancestry incomplete");
+      if (cdp.getAttachmentId?.(document.target.tabId) !== document.attachmentId)
+        return stale("visual attachment changed");
+      // assignedSlot is null for light children of a closed shadow host. Query only
+      // these missing edges, then reread geometry and validate the assignment together.
+      const missing = result.rows.filter(
+        (row, i) => row.parentIsElement && closedHosts.has(result.rows[i + 1]?.node),
+      );
+      if (!missing.length) return result;
+      for (const row of missing) {
+        if (slots.has(row.node)) return stale("visual slot assignment changed");
+        throwIfAborted(signal);
+        const described = await sendToCdpTarget<{
+          node?: { assignedSlot?: { backendNodeId?: number } };
+        }>(cdp, document.target, "DOM.describeNode", { backendNodeId: row.node, depth: 0 });
+        const backendNodeId = described.node?.assignedSlot?.backendNodeId;
+        if (!backendNodeId) return stale("visual slot assignment unavailable");
+        throwIfAborted(signal);
+        const resolved = await sendToCdpTarget<{ object?: { objectId?: string } }>(
+          cdp,
+          document.target,
+          "DOM.resolveNode",
+          {
+            backendNodeId,
+            executionContextId: verified.executionContextId,
+            objectGroup: verified.objectGroup,
+          },
+        );
+        if (!resolved.object?.objectId) return stale("visual slot unavailable");
+        slots.set(row.node, resolved.object.objectId);
+      }
+    }
   } finally {
     await sendToCdpTarget(cdp, document.target, "Runtime.releaseObjectGroup", {
       objectGroup: verified.objectGroup,
@@ -275,6 +327,16 @@ export async function resolveVisualRegionNow(
         height: live.height ?? viewport.height,
       },
     });
+    const overflowElement = (row: LiveRow | undefined) =>
+      row && {
+        backendNodeId: row.node,
+        tag: row.tag,
+        styles: row.styles,
+      };
+    const overflowSource = viewportOverflowSource(
+      overflowElement(live.rows.at(-1)),
+      overflowElement(live.rows.find((row) => row.isBody)),
+    );
     for (let j = live.rows.length - 1; j >= 0; j--) {
       const row = live.rows[j];
       const isAnchor = j === 0;
@@ -287,7 +349,7 @@ export async function resolveVisualRegionNow(
       context = extendVisualContext(
         context,
         node,
-        !isAnchor && row.tag !== "iframe" && row.tag !== "frame",
+        !isAnchor && row.tag !== "iframe" && row.tag !== "frame" && row.node !== overflowSource,
       );
     }
     if (i < path.length - 1) {

--- a/apps/extension/src/tools/visual-target.ts
+++ b/apps/extension/src/tools/visual-target.ts
@@ -424,7 +424,7 @@ export function sameVisualMapping(a: VisualTargetState, b: VisualTargetState): b
     })
   );
 }
-/** Browser hit testing follows each verified frame, including open shadow roots. */
+/** Browser hit testing follows each verified frame, including open and closed shadow roots. */
 export async function verifyVisualHit(
   cdp: CdpRunner,
   state: VisualTargetState,
@@ -447,13 +447,17 @@ export async function verifyVisualHit(
         functionDeclaration: `function(x,y) {
           if (!this.isConnected || this.ownerDocument !== document) return false;
           for(let n=this;n;n=n.parentElement || n.getRootNode().host) if(n.inert) return false;
-          let hit=document.elementFromPoint(x,y);
-          while(hit && hit.shadowRoot) {
-            const inner=hit.shadowRoot.elementFromPoint(x,y);
-            if(!inner || inner===hit) break;
-            hit=inner;
+          // Resolve roots from the verified target; closed hosts expose no shadowRoot.
+          const path=[];
+          for(let node=this;node;) {
+            const root=node.getRootNode();
+            path.push({root,node});
+            if(root===document) break;
+            if(!root.host) return false;
+            node=root.host;
           }
-          return hit===this;
+          // Check every outer scope as well, so internal hits cannot bypass an overlay.
+          return path.reverse().every(({root,node}) => root.elementFromPoint(x,y)===node);
         }`,
         arguments: [
           { value: (point.x - unit.x) / unit.width },

--- a/apps/extension/src/tools/vom/__tests__/capture-coordinator.test.ts
+++ b/apps/extension/src/tools/vom/__tests__/capture-coordinator.test.ts
@@ -7,10 +7,12 @@ import type { CdpRunner } from "../../shared";
 import { captureObservationFacts, semanticCapture } from "../capture-coordinator";
 import { buildSemanticGraph } from "../semantic-graph/build";
 import { REQUESTED_STYLES, type SnapshotReply } from "../snapshot";
+import { discoverVisualCandidates } from "../visual-discovery";
 
 function fixture(
   options: {
     frames?: CdpFrame[];
+    canvas?: boolean;
     after?: Record<string, { element?: number; missing?: boolean; unreadable?: boolean }>;
     fail?: string;
     missingIdentity?: boolean;
@@ -78,7 +80,7 @@ function fixture(
       if (method === "Page.getLayoutMetrics")
         result = {
           visualViewport: { clientWidth: 1000 },
-          cssVisualViewport: { clientWidth: 1000 },
+          cssVisualViewport: { clientWidth: 1000, scale: 1 },
           cssLayoutViewport: { clientWidth: 1000, clientHeight: 800 },
         };
       if (method === "DOMSnapshot.captureSnapshot") {
@@ -88,13 +90,16 @@ function fixture(
           strings: [
             "#document",
             "html",
-            "button",
+            options.canvas ? "canvas" : "button",
             OVERLAY_HOST_MARKER_ATTR,
             "",
             "visible",
             "1",
             "static",
             "auto",
+            "block",
+            "none",
+            "0px",
           ],
           documents: frames
             .filter(
@@ -144,9 +149,13 @@ function fixture(
                     [0, 0, 1000, 800],
                     [10, 20, 100, 40],
                   ],
+                  clientRects: [
+                    [0, 0, 1000, 800],
+                    [0, 0, 100, 40],
+                  ],
                   styles: [
-                    [7, 8, 8, 5, 6],
-                    [7, 8, 8, 5, 6],
+                    [7, 8, 8, 5, 6, 9, 5, 5, 10, 6, 10, 10, 10, 10, 10, 8, 10, 11],
+                    [7, 8, 8, 5, 6, 9, 5, 5, 10, 6, 10, 10, 10, 10, 10, 8, 10, 11],
                   ],
                 },
               };
@@ -193,7 +202,7 @@ describe("captureObservationFacts", () => {
       if (method === "Page.getLayoutMetrics")
         return {
           visualViewport: { clientWidth: 2000 },
-          cssVisualViewport: { clientWidth: 1000 },
+          cssVisualViewport: { clientWidth: 1000, scale: 1 },
           cssLayoutViewport: { clientWidth: 1000, clientHeight: 800, pageX: 999, pageY: 999 },
         } as never;
       const reply = await original(target, method, params);
@@ -659,7 +668,7 @@ describe("OOPIF capture", () => {
       if (method === "Page.getLayoutMetrics") {
         return {
           visualViewport: { clientWidth: 1000 },
-          cssVisualViewport: { clientWidth: 1000 },
+          cssVisualViewport: { clientWidth: 1000, scale: 1 },
           cssLayoutViewport: { clientWidth: 300, clientHeight: 200, pageX: 0, pageY: 0 },
         };
       }
@@ -685,7 +694,7 @@ describe("OOPIF capture", () => {
         if (method === "Page.getLayoutMetrics") {
           return {
             visualViewport: { clientWidth: 1000 },
-            cssVisualViewport: { clientWidth: 1000 },
+            cssVisualViewport: { clientWidth: 1000, scale: 1 },
             cssLayoutViewport: { clientWidth: 1000, clientHeight: 800 },
           };
         }
@@ -767,7 +776,7 @@ describe("OOPIF capture", () => {
       if (method === "Page.getLayoutMetrics")
         return {
           visualViewport: { clientWidth: 1000 },
-          cssVisualViewport: { clientWidth: 1000 },
+          cssVisualViewport: { clientWidth: 1000, scale: 1 },
           cssLayoutViewport: { clientWidth: 300, clientHeight: 200 },
         };
       if (method === "DOMSnapshot.captureSnapshot")
@@ -829,7 +838,7 @@ describe("OOPIF capture", () => {
         if (method === "Page.getLayoutMetrics") {
           return {
             visualViewport: { clientWidth: 1000 },
-            cssVisualViewport: { clientWidth: 1000 },
+            cssVisualViewport: { clientWidth: 1000, scale: 1 },
             cssLayoutViewport: { clientWidth: 1000, clientHeight: 800 },
           };
         }
@@ -919,7 +928,7 @@ function siblingCaptureFixture(
       if (method === "Page.getLayoutMetrics")
         return {
           visualViewport: { clientWidth: 1000 },
-          cssVisualViewport: { clientWidth: 1000 },
+          cssVisualViewport: { clientWidth: 1000, scale: 1 },
           cssLayoutViewport: { clientWidth: 1000, clientHeight: 800 },
         };
       if (method === "DOM.getBoxModel")
@@ -1127,7 +1136,7 @@ describe("snapshot document provenance", () => {
           : method === "Page.getLayoutMetrics"
             ? {
                 visualViewport: { clientWidth: 1000 },
-                cssVisualViewport: { clientWidth: 1000 },
+                cssVisualViewport: { clientWidth: 1000, scale: 1 },
                 cssLayoutViewport: { clientWidth: 200, clientHeight: 100 },
               }
             : {}) as T,
@@ -1361,5 +1370,30 @@ describe("AX frame scheduling", () => {
     }
     expect(peak).toBe(4);
     expect(active).toBe(0);
+  });
+});
+
+describe("visual facts integration", () => {
+  it("passes actual snapshot styles, client units, projection and identity to pure discovery without additional CDP", async () => {
+    const { cdp, logs } = fixture({
+      canvas: true,
+      frames: [{ frameId: "main", target: { tabId: 4 } }],
+    });
+    const facts = await captureObservationFacts(cdp, 4);
+    const before = logs.length;
+    const result = await discoverVisualCandidates(facts);
+    expect(logs).toHaveLength(before);
+    expect(logs.filter((call) => call.method === "DOMSnapshot.captureSnapshot")).toHaveLength(1);
+    expect(result.complete).toBe(true);
+    expect(result.candidates).toHaveLength(1);
+    expect(result.candidates[0]).toMatchObject({
+      document: { frameId: "main", documentElementBackendNodeId: 1 },
+      region: { crop: { x: 10, y: 20, width: 100, height: 40 } },
+    });
+    expect(facts.documents[0].index.nodes.get(2)?.layout?.clientRect).toEqual([0, 0, 100, 40]);
+    expect(facts.documents[0].geometry?.pageScale).toBe(1);
+    const baseline = fixture({ frames: [{ frameId: "main", target: { tabId: 4 } }] });
+    await captureObservationFacts(baseline.cdp, 4);
+    expect(logs.map((call) => call.method)).toEqual(baseline.logs.map((call) => call.method));
   });
 });

--- a/apps/extension/src/tools/vom/__tests__/capture-coordinator.test.ts
+++ b/apps/extension/src/tools/vom/__tests__/capture-coordinator.test.ts
@@ -7,6 +7,7 @@ import type { CdpRunner } from "../../shared";
 import { captureObservationFacts, semanticCapture } from "../capture-coordinator";
 import { buildSemanticGraph, buildSemanticVomScene } from "../semantic-graph";
 import { REQUESTED_STYLES, type SnapshotReply, VISUAL_STYLES } from "../snapshot";
+import { deduplicateVisualCandidates } from "../visual-dedup";
 import { discoverVisualCandidates } from "../visual-discovery";
 
 function fixture(
@@ -1459,6 +1460,15 @@ describe("visual facts integration", () => {
       document: { frameId: "main", documentElementBackendNodeId: 1 },
       region: { crop: { x: 10, y: 20, width: 100, height: 40 } },
     });
+    const deduplicated = await deduplicateVisualCandidates(result);
+    expect(deduplicated.candidates).toEqual(result.candidates);
+    expect(deduplicated.candidates[0]).toBe(result.candidates[0]);
+    expect(deduplicated).toMatchObject({
+      candidateCount: 1,
+      deduplicatedCount: 0,
+      dedupDegraded: false,
+    });
+    expect(logs).toHaveLength(before);
     expect(facts.documents[0].index.nodes.get(2)?.layout?.clientRect).toEqual([0, 0, 100, 40]);
     expect(facts.documents[0].geometry?.pageScale).toBe(1);
     const baseline = fixture({ frames: [{ frameId: "main", target: { tabId: 4 } }] });

--- a/apps/extension/src/tools/vom/__tests__/capture-coordinator.test.ts
+++ b/apps/extension/src/tools/vom/__tests__/capture-coordinator.test.ts
@@ -102,6 +102,7 @@ function fixture(
             "block",
             "none",
             "0px",
+            "normal",
           ],
           documents: frames
             .filter(
@@ -158,7 +159,7 @@ function fixture(
                   styles: Array.from({ length: 2 }, () =>
                     requested.map(
                       (name) =>
-                        [7, 8, 8, 5, 6, 9, 5, 5, 10, 6, 10, 10, 10, 10, 10, 8, 10, 11][
+                        [7, 8, 8, 5, 6, 9, 5, 5, 10, 6, 10, 10, 10, 10, 10, 8, 10, 5, 12, 11][
                           VISUAL_STYLES.indexOf(name as (typeof VISUAL_STYLES)[number])
                         ],
                     ),

--- a/apps/extension/src/tools/vom/__tests__/capture-coordinator.test.ts
+++ b/apps/extension/src/tools/vom/__tests__/capture-coordinator.test.ts
@@ -5,8 +5,8 @@ import { OVERLAY_HOST_MARKER_ATTR } from "@/lib/overlay-bridge";
 import { captureVomObservation } from "../../observation";
 import type { CdpRunner } from "../../shared";
 import { captureObservationFacts, semanticCapture } from "../capture-coordinator";
-import { buildSemanticGraph } from "../semantic-graph/build";
-import { REQUESTED_STYLES, type SnapshotReply } from "../snapshot";
+import { buildSemanticGraph, buildSemanticVomScene } from "../semantic-graph";
+import { REQUESTED_STYLES, type SnapshotReply, VISUAL_STYLES } from "../snapshot";
 import { discoverVisualCandidates } from "../visual-discovery";
 
 function fixture(
@@ -85,7 +85,8 @@ function fixture(
         };
       if (method === "DOMSnapshot.captureSnapshot") {
         snapshots++;
-        expect((params as { computedStyles: unknown }).computedStyles).toEqual(REQUESTED_STYLES);
+        const requested = (params as { computedStyles: readonly string[] }).computedStyles;
+        expect([REQUESTED_STYLES, VISUAL_STYLES]).toContainEqual(requested);
         result = {
           strings: [
             "#document",
@@ -153,10 +154,14 @@ function fixture(
                     [0, 0, 1000, 800],
                     [0, 0, 100, 40],
                   ],
-                  styles: [
-                    [7, 8, 8, 5, 6, 9, 5, 5, 10, 6, 10, 10, 10, 10, 10, 8, 10, 11],
-                    [7, 8, 8, 5, 6, 9, 5, 5, 10, 6, 10, 10, 10, 10, 10, 8, 10, 11],
-                  ],
+                  styles: Array.from({ length: 2 }, () =>
+                    requested.map(
+                      (name) =>
+                        [7, 8, 8, 5, 6, 9, 5, 5, 10, 6, 10, 10, 10, 10, 10, 8, 10, 11][
+                          VISUAL_STYLES.indexOf(name as (typeof VISUAL_STYLES)[number])
+                        ],
+                    ),
+                  ),
                 },
               };
             }),
@@ -1374,12 +1379,76 @@ describe("AX frame scheduling", () => {
 });
 
 describe("visual facts integration", () => {
+  it("defaults to base facts across targets and shares semantic behavior with visual capture", async () => {
+    const base = fixture({ canvas: true });
+    const visual = fixture({ canvas: true });
+    const baseFacts = await captureObservationFacts(base.cdp, 4);
+    const visualFacts = await captureObservationFacts(visual.cdp, 4, undefined, undefined, {
+      includeVisualFacts: true,
+    });
+    expect(baseFacts.visualFactsCollected).toBe(false);
+    expect(visualFacts.visualFactsCollected).toBe(true);
+    expect(baseFacts.documents).toHaveLength(4);
+    expect(visualFacts.documents).toHaveLength(4);
+    for (const doc of baseFacts.documents) {
+      expect(doc.geometry).toBeUndefined();
+      expect(doc.index.ancestryComplete).toBeUndefined();
+      for (const node of doc.index.nodes.values()) {
+        expect(node.parentMissing).toBeUndefined();
+        expect(node.layout?.clientRect).toBeUndefined();
+        if (node.layout) expect(Object.keys(node.layout.styles)).toEqual([...REQUESTED_STYLES]);
+      }
+    }
+    // This fixture has no child frame projection measurements. Enabling visual
+    // collection must preserve that missing evidence, not invent geometry.
+    expect(
+      visualFacts.documents.find((doc) => doc.frame.frameId === "main")?.geometry,
+    ).toBeDefined();
+    expect(visualFacts.documents.filter((doc) => doc.geometry)).toHaveLength(1);
+    for (const doc of visualFacts.documents) {
+      expect(doc.index.ancestryComplete).toBeDefined();
+      for (const node of doc.index.nodes.values())
+        if (node.layout) {
+          expect(Object.keys(node.layout.styles)).toEqual([...VISUAL_STYLES]);
+          expect(Object.keys(node.layout.styles).some((key) => key.includes("radius"))).toBe(false);
+        }
+    }
+    for (const [capture, expected] of [
+      [base, REQUESTED_STYLES],
+      [visual, VISUAL_STYLES],
+    ] as const) {
+      const calls = capture.logs.filter((c) => c.method === "DOMSnapshot.captureSnapshot");
+      expect(calls).toHaveLength(2);
+      for (const call of calls) expect(call.params.computedStyles).toEqual(expected);
+    }
+    expect(base.logs.map((c) => [c.target, c.method])).toEqual(
+      visual.logs.map((c) => [c.target, c.method]),
+    );
+    const scene = (input: typeof baseFacts) =>
+      buildSemanticVomScene({
+        documents: semanticCapture(input).documents,
+        viewport: input.viewport,
+        rootFrameId: input.rootFrameId,
+        excludedBackendNodeIds: semanticCapture(input).captured.excludedBackendNodeIds,
+      });
+    expect(scene(baseFacts)).toEqual(scene(visualFacts));
+    const before = base.logs.length;
+    expect(await discoverVisualCandidates(baseFacts)).toMatchObject({
+      complete: false,
+      candidates: [],
+      issues: [{ reason: "visual-facts-not-collected" }],
+    });
+    expect(base.logs).toHaveLength(before);
+  });
+
   it("passes actual snapshot styles, client units, projection and identity to pure discovery without additional CDP", async () => {
     const { cdp, logs } = fixture({
       canvas: true,
       frames: [{ frameId: "main", target: { tabId: 4 } }],
     });
-    const facts = await captureObservationFacts(cdp, 4);
+    const facts = await captureObservationFacts(cdp, 4, undefined, undefined, {
+      includeVisualFacts: true,
+    });
     const before = logs.length;
     const result = await discoverVisualCandidates(facts);
     expect(logs).toHaveLength(before);

--- a/apps/extension/src/tools/vom/__tests__/document-identity.test.ts
+++ b/apps/extension/src/tools/vom/__tests__/document-identity.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it, vi } from "vitest";
+import type { CdpRunner } from "../../shared";
+import { verifyDocumentIdentity, verifyVisualTargetIdentity } from "../document-identity";
+import type { VisualCandidate } from "../visual-discovery";
+
+const candidate: VisualCandidate = {
+  document: {
+    attachmentId: "attached",
+    target: { tabId: 4, sessionId: "child-session" },
+    frameId: "child-frame",
+    documentElementBackendNodeId: 10,
+  },
+  backendNodeId: 20,
+  parentBackendNodeId: 10,
+  region: {
+    status: "available",
+    borderBox: { x: 0, y: 0, width: 10, height: 10 },
+    crop: { x: 0, y: 0, width: 10, height: 10 },
+  },
+};
+
+function fixture(
+  options: {
+    connected?: boolean;
+    sameDocument?: boolean;
+    root?: number;
+    missing?: boolean;
+    fail?: string;
+    abortAt?: string;
+    detachAt?: string;
+  } = {},
+) {
+  const controller = new AbortController();
+  let attachment = "attached";
+  const send = vi.fn(
+    async (_tab: number, _session: string, method: string, params: Record<string, unknown>) => {
+      if (options.abortAt === method) controller.abort();
+      if (options.detachAt === method) attachment = "new-attachment";
+      if (options.fail === method) throw new Error("CDP failed");
+      if (method === "Page.createIsolatedWorld") return { executionContextId: 7 };
+      if (method === "DOM.resolveNode")
+        return options.missing ? {} : { object: { objectId: "anchor" } };
+      if (method === "Runtime.evaluate" || method === "Runtime.callFunctionOn") {
+        let root: unknown = {};
+        if (method === "Runtime.callFunctionOn") {
+          const document = { documentElement: {} };
+          // Exercise the actual predicate, including connection and owner checks.
+          root = new Function("document", `return (${params.functionDeclaration}).call(this)`).call(
+            {
+              isConnected: options.connected ?? true,
+              ownerDocument: options.sameDocument === false ? {} : document,
+            },
+            document,
+          );
+        }
+        return {
+          result: {
+            deepSerializedValue:
+              root === null
+                ? { type: "null" }
+                : { type: "node", value: { backendNodeId: options.root ?? 10 } },
+          },
+        };
+      }
+      if (method === "Runtime.releaseObjectGroup") return {};
+      throw new Error(`unexpected ${method}`);
+    },
+  );
+  const cdp = {
+    send: vi.fn(),
+    sendToTarget: (
+      target: { tabId: number; sessionId?: string },
+      method: string,
+      params: Record<string, unknown>,
+    ) => send(target.tabId, target.sessionId!, method, params),
+    getAttachmentId: () => attachment,
+  } as unknown as CdpRunner;
+  return { cdp, send, controller };
+}
+
+describe("visual target identity", () => {
+  it("uses the exact frame and target with bounded local reads and releases objects", async () => {
+    const { cdp, send } = fixture();
+    expect(await verifyVisualTargetIdentity(cdp, candidate)).toBe("current");
+    expect(send.mock.calls.map((c) => c[2])).toEqual([
+      "Page.createIsolatedWorld",
+      "DOM.resolveNode",
+      "Runtime.callFunctionOn",
+      "Runtime.releaseObjectGroup",
+    ]);
+    expect(
+      send.mock.calls.every(([tab, session]) => tab === 4 && session === "child-session"),
+    ).toBe(true);
+    expect(send.mock.calls[0][3]).toMatchObject({ frameId: "child-frame" });
+    expect(send.mock.calls[1][3]).toMatchObject({ backendNodeId: 20, executionContextId: 7 });
+    expect(send.mock.calls[2][3]).toMatchObject({ objectId: "anchor" });
+    expect(send.mock.calls[3][3].objectGroup).toBe(send.mock.calls[1][3].objectGroup);
+  });
+
+  it.each([
+    { connected: false },
+    { sameDocument: false },
+    { root: 11 },
+  ])("rejects detached/adopted/replaced DOM: %j", async (options) => {
+    const { cdp } = fixture(options);
+    expect(await verifyVisualTargetIdentity(cdp, candidate)).toBe("changed");
+  });
+
+  it("does not add anchor reads to existing capture identity verification", async () => {
+    const { cdp, send } = fixture();
+    expect(await verifyDocumentIdentity(cdp, candidate.document)).toBe("current");
+    expect(send.mock.calls.map((c) => c[2])).toEqual([
+      "Page.createIsolatedWorld",
+      "Runtime.evaluate",
+      "Runtime.releaseObjectGroup",
+    ]);
+  });
+
+  it.each([
+    "Page.createIsolatedWorld",
+    "DOM.resolveNode",
+    "Runtime.callFunctionOn",
+  ])("fails closed and cleans up when %s fails", async (fail) => {
+    const { cdp, send } = fixture({ fail });
+    expect(await verifyVisualTargetIdentity(cdp, candidate)).toBe("unavailable");
+    expect(send.mock.calls.at(-1)?.[2]).toBe("Runtime.releaseObjectGroup");
+  });
+
+  it("rejects attachment changes before and during verification", async () => {
+    const first = fixture();
+    expect(
+      await verifyVisualTargetIdentity({ ...first.cdp, getAttachmentId: () => "other" }, candidate),
+    ).toBe("changed");
+    expect(first.send).not.toHaveBeenCalled();
+    const second = fixture({ detachAt: "Runtime.callFunctionOn" });
+    expect(await verifyVisualTargetIdentity(second.cdp, candidate)).toBe("changed");
+    const missing = fixture({ missing: true });
+    expect(await verifyVisualTargetIdentity(missing.cdp, candidate)).toBe("unavailable");
+  });
+
+  it.each([
+    "DOM.resolveNode",
+    "Runtime.callFunctionOn",
+  ])("propagates cancellation at %s after releasing the object group", async (abortAt) => {
+    const { cdp, send, controller } = fixture({ abortAt });
+    await expect(
+      verifyVisualTargetIdentity(cdp, candidate, controller.signal),
+    ).rejects.toMatchObject({ name: "AbortError" });
+    expect(send.mock.calls.at(-1)?.[2]).toBe("Runtime.releaseObjectGroup");
+  });
+});

--- a/apps/extension/src/tools/vom/__tests__/facts.test.ts
+++ b/apps/extension/src/tools/vom/__tests__/facts.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import { OVERLAY_HOST_MARKER_ATTR } from "@/lib/overlay-bridge";
 import { createCaptureCheckpoint } from "../capture-abort";
 import { buildDocumentIndex, type DecodedNode } from "../facts";
-import { decodeDocument, REQUESTED_STYLES } from "../snapshot";
+import { decodeDocument, REQUESTED_STYLES, VISUAL_SNAPSHOT } from "../snapshot";
 
 function node(id: number, parent: number | null): DecodedNode {
   return {
@@ -80,19 +80,6 @@ describe("document facts", () => {
       boundsSpace: "snapshot-document-layout",
       bounds: [10, 20, 120, 40],
       styles: {
-        rotate: "auto",
-        scale: "auto",
-        perspective: "auto",
-        clip: "auto",
-        contain: "auto",
-        "overflow-clip-margin": "auto",
-        display: "auto",
-        "overflow-x": "auto",
-        "overflow-y": "auto",
-        transform: "auto",
-        zoom: "auto",
-        "clip-path": "auto",
-        "mask-image": "auto",
         position: "static",
         "pointer-events": "auto",
         cursor: "auto",
@@ -153,9 +140,9 @@ describe("visual ancestry facts", () => {
       { ...node(8, null), nodeType: 1 },
       { ...node(9, null), nodeType: 9, parentMissing: true },
     ];
-    const index = await buildDocumentIndex(input.reverse());
-    for (const id of [0, 1, 2, 3]) expect(index.ancestryComplete.get(id)).toBe(true);
-    for (const id of [4, 5, 6, 7, 8, 9]) expect(index.ancestryComplete.get(id)).toBe(false);
+    const index = await buildDocumentIndex(input.reverse(), undefined, true);
+    for (const id of [0, 1, 2, 3]) expect(index.ancestryComplete!.get(id)).toBe(true);
+    for (const id of [4, 5, 6, 7, 8, 9]) expect(index.ancestryComplete!.get(id)).toBe(false);
   });
 
   it("retains client offsets in their source units and does not disguise missing parent indices", async () => {
@@ -169,11 +156,13 @@ describe("visual ancestry facts", () => {
         },
       },
       ["div"],
+      undefined,
+      VISUAL_SNAPSHOT,
     );
     expect(decoded.nodes[0].layout?.clientRect).toEqual([5, 5, 68, 38]);
     expect(decoded.nodes[0].layout?.bounds).toEqual([745, 455.625, 97, 59.5]);
     expect(decoded.nodes.every((node) => node.parentMissing)).toBe(true);
-    const index = await buildDocumentIndex(decoded.nodes);
-    expect([...index.ancestryComplete.values()]).toEqual([false, false]);
+    const index = await buildDocumentIndex(decoded.nodes, undefined, true);
+    expect([...index.ancestryComplete!.values()]).toEqual([false, false]);
   });
 });

--- a/apps/extension/src/tools/vom/__tests__/facts.test.ts
+++ b/apps/extension/src/tools/vom/__tests__/facts.test.ts
@@ -80,6 +80,19 @@ describe("document facts", () => {
       boundsSpace: "snapshot-document-layout",
       bounds: [10, 20, 120, 40],
       styles: {
+        rotate: "auto",
+        scale: "auto",
+        perspective: "auto",
+        clip: "auto",
+        contain: "auto",
+        "overflow-clip-margin": "auto",
+        display: "auto",
+        "overflow-x": "auto",
+        "overflow-y": "auto",
+        transform: "auto",
+        zoom: "auto",
+        "clip-path": "auto",
+        "mask-image": "auto",
         position: "static",
         "pointer-events": "auto",
         cursor: "auto",
@@ -123,5 +136,44 @@ describe("document facts", () => {
       name: "AbortError",
     });
     expect(reads).toBeLessThanOrEqual(356);
+  });
+});
+
+describe("visual ancestry facts", () => {
+  it("distinguishes document roots, malformed roots, missing parents and cycles", async () => {
+    const input = [
+      { ...node(0, null), nodeType: 9 },
+      { ...node(1, 0), nodeType: 1 },
+      { ...node(2, 1), nodeType: 11 },
+      node(3, 2),
+      node(4, 99),
+      node(5, 6),
+      node(6, 5),
+      node(7, 5),
+      { ...node(8, null), nodeType: 1 },
+      { ...node(9, null), nodeType: 9, parentMissing: true },
+    ];
+    const index = await buildDocumentIndex(input.reverse());
+    for (const id of [0, 1, 2, 3]) expect(index.ancestryComplete.get(id)).toBe(true);
+    for (const id of [4, 5, 6, 7, 8, 9]) expect(index.ancestryComplete.get(id)).toBe(false);
+  });
+
+  it("retains client offsets in their source units and does not disguise missing parent indices", async () => {
+    const decoded = await decodeDocument(
+      {
+        nodes: { backendNodeId: [1, 2], nodeType: [1, 1], nodeName: [0, 0], parentIndex: [99] },
+        layout: {
+          nodeIndex: [0],
+          bounds: [[745, 455.625, 97, 59.5]],
+          clientRects: [[5, 5, 68, 38]],
+        },
+      },
+      ["div"],
+    );
+    expect(decoded.nodes[0].layout?.clientRect).toEqual([5, 5, 68, 38]);
+    expect(decoded.nodes[0].layout?.bounds).toEqual([745, 455.625, 97, 59.5]);
+    expect(decoded.nodes.every((node) => node.parentMissing)).toBe(true);
+    const index = await buildDocumentIndex(decoded.nodes);
+    expect([...index.ancestryComplete.values()]).toEqual([false, false]);
   });
 });

--- a/apps/extension/src/tools/vom/__tests__/visual-dedup.test.ts
+++ b/apps/extension/src/tools/vom/__tests__/visual-dedup.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from "vitest";
+import { deduplicateVisualCandidates, MAX_VISUAL_DEDUP_KEYS } from "../visual-dedup";
+import type { VisualCandidate, VisualDiscoveryResult } from "../visual-discovery";
+
+function candidate(id: number, width = 100, parent = 1): VisualCandidate {
+  const crop = { x: 0, y: 0, width, height: 100 };
+  return {
+    document: {
+      attachmentId: "a",
+      target: { tabId: 1 },
+      frameId: "main",
+      documentElementBackendNodeId: 1,
+    },
+    backendNodeId: id,
+    parentBackendNodeId: parent,
+    region: { status: "available", borderBox: crop, crop },
+  };
+}
+function discovery(candidates: VisualCandidate[]): VisualDiscoveryResult {
+  return { candidates, complete: true, issues: [], captureIssues: [] };
+}
+
+describe("visual candidate deduplication", () => {
+  it("preserves small, unnamed and labelled candidates and their original evidence", async () => {
+    const small = { ...candidate(3, 1), label: '  A "label"\n😀' };
+    const large = candidate(2, 1000);
+    const input = discovery([small, large]);
+    Object.freeze(input.candidates);
+    Object.freeze(small);
+    Object.freeze(large);
+    for (let i = 0; i < 2; i++) {
+      const result = await deduplicateVisualCandidates(input);
+      expect(result.candidates).toEqual([small, large]);
+      expect(result.candidates[0]).toBe(small);
+      expect(result.candidates[1]).toBe(large);
+      expect(result).toMatchObject({
+        candidateCount: 2,
+        deduplicatedCount: 0,
+        dedupDegraded: false,
+      });
+    }
+  });
+
+  it("only deduplicates exact crops within the same full DOM identity and direct parent", async () => {
+    const base = candidate(20);
+    const variants = [
+      candidate(30, 100, 2),
+      { ...candidate(40), parentBackendNodeId: null },
+      ...["x", "y", "width", "height"].map((axis) => ({
+        ...base,
+        region: {
+          ...base.region,
+          crop: {
+            ...base.region.crop,
+            [axis]: base.region.crop[axis as keyof typeof base.region.crop] + 0.001,
+          },
+        },
+      })),
+      ...[
+        { frameId: "child" },
+        { target: { tabId: 2 } },
+        { target: { tabId: 1, sessionId: "remote" } },
+        { documentElementBackendNodeId: 9 },
+        { attachmentId: "b" },
+      ].map((identity) => ({ ...base, document: { ...base.document, ...identity } })),
+    ];
+    const duplicate = { ...candidate(10), label: "Not a new target" };
+    const result = await deduplicateVisualCandidates(discovery([base, ...variants, duplicate]));
+    expect(result.candidates).toEqual([base, ...variants]);
+    expect(result.candidates[0]).toBe(base);
+    expect(result.deduplicatedCount).toBe(1);
+  });
+
+  it.each([
+    50_001, 100_000,
+  ])("keeps all %s distinct candidates including the last tiny Canvas", async (count) => {
+    const input = Array.from({ length: count }, (_, i) => candidate(i + 1, 100, i + 1));
+    input[count - 1] = candidate(count, 1, count);
+    // A remembered key still deduplicates; an unremembered key passes through.
+    input.push({ ...input[0] }, { ...input[count - 1] });
+    const result = await deduplicateVisualCandidates(discovery(input));
+    expect(result.candidates).toEqual([...input.slice(0, count), input[count + 1]]);
+    expect(result.candidates[count - 1]).toBe(input[count - 1]);
+    expect(result).toMatchObject({
+      candidateCount: count + 2,
+      deduplicatedCount: 1,
+      dedupDegraded: true,
+    });
+  });
+
+  it("does not report degradation when every key fits", async () => {
+    const input = Array.from({ length: MAX_VISUAL_DEDUP_KEYS }, (_, i) => candidate(i, 1, i));
+    input.push({ ...input[0] });
+    const result = await deduplicateVisualCandidates(discovery(input));
+    expect(result.candidates).toHaveLength(MAX_VISUAL_DEDUP_KEYS);
+    expect(result.dedupDegraded).toBe(false);
+    expect(result.deduplicatedCount).toBe(1);
+  });
+
+  it("preserves upstream unknowns without counting issues as Canvas nodes", async () => {
+    const input: VisualDiscoveryResult = {
+      ...discovery([candidate(2)]),
+      complete: false,
+      issues: [{ reason: "geometry-unavailable", target: { tabId: 1 }, frameId: "missing" }],
+      captureIssues: [{ stage: "ax", reason: "capture-unavailable", target: { tabId: 1 } }],
+    };
+    const result = await deduplicateVisualCandidates(input);
+    expect(result.complete).toBe(false);
+    expect(result.candidateCount).toBe(1);
+    expect(result.issues).toBe(input.issues);
+    expect(result.captureIssues).toBe(input.captureIssues);
+    const absent = await deduplicateVisualCandidates({
+      ...input,
+      candidates: [],
+      issues: [{ reason: "visual-facts-not-collected" }],
+    });
+    expect(absent).toMatchObject({
+      complete: false,
+      candidateCount: 0,
+      issues: [{ reason: "visual-facts-not-collected" }],
+    });
+    expect(await deduplicateVisualCandidates(discovery([]))).toMatchObject({
+      complete: true,
+      candidates: [],
+      candidateCount: 0,
+      dedupDegraded: false,
+    });
+  });
+
+  it("drains cancellation through the shared checkpoint", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    await expect(
+      deduplicateVisualCandidates(discovery([]), controller.signal),
+    ).rejects.toMatchObject({ name: "AbortError" });
+    const during = new AbortController();
+    const input = discovery(Array.from({ length: 100_000 }, (_, i) => candidate(i, 100, i)));
+    const timer = setTimeout(() => during.abort(), 0);
+    try {
+      await expect(deduplicateVisualCandidates(input, during.signal)).rejects.toMatchObject({
+        name: "AbortError",
+      });
+    } finally {
+      clearTimeout(timer);
+    }
+  });
+});

--- a/apps/extension/src/tools/vom/__tests__/visual-dedup.test.ts
+++ b/apps/extension/src/tools/vom/__tests__/visual-dedup.test.ts
@@ -41,11 +41,11 @@ describe("visual candidate deduplication", () => {
     }
   });
 
-  it("only deduplicates exact crops within the same full DOM identity and direct parent", async () => {
+  it("only deduplicates the same Canvas identity, direct parent and exact crop", async () => {
     const base = candidate(20);
     const variants = [
-      candidate(30, 100, 2),
-      { ...candidate(40), parentBackendNodeId: null },
+      candidate(20, 100, 2),
+      { ...base, parentBackendNodeId: null },
       ...["x", "y", "width", "height"].map((axis) => ({
         ...base,
         region: {
@@ -64,11 +64,26 @@ describe("visual candidate deduplication", () => {
         { attachmentId: "b" },
       ].map((identity) => ({ ...base, document: { ...base.document, ...identity } })),
     ];
-    const duplicate = { ...candidate(10), label: "Not a new target" };
+    const duplicate = { ...base, label: "Repeated record" };
     const result = await deduplicateVisualCandidates(discovery([base, ...variants, duplicate]));
     expect(result.candidates).toEqual([base, ...variants]);
     expect(result.candidates[0]).toBe(base);
     expect(result.deduplicatedCount).toBe(1);
+  });
+
+  it("preserves distinct overlapping Canvas anchors in either encounter order", async () => {
+    const first = candidate(20);
+    const second = candidate(30);
+    for (const ordered of [
+      [first, second],
+      [second, first],
+    ]) {
+      const result = await deduplicateVisualCandidates(discovery([...ordered, { ...ordered[0] }]));
+      expect(result.candidates).toEqual(ordered);
+      expect(result.candidates[0]).toBe(ordered[0]);
+      expect(result.candidates[1]).toBe(ordered[1]);
+      expect(result).toMatchObject({ candidateCount: 3, deduplicatedCount: 1 });
+    }
   });
 
   it.each([

--- a/apps/extension/src/tools/vom/__tests__/visual-discovery.test.ts
+++ b/apps/extension/src/tools/vom/__tests__/visual-discovery.test.ts
@@ -141,6 +141,32 @@ function facts(
 }
 
 describe("Canvas discovery", () => {
+  it("shares frame address paths from existing Facts without changing candidate evidence", async () => {
+    const parent = await document([{ id: 2, parent: 1, tag: "iframe" }]);
+    const child = await document(
+      [
+        { id: 3, parent: 1 },
+        { id: 4, parent: 1 },
+      ],
+      {
+        frame: {
+          frameId: "child",
+          parentFrameId: "main",
+          ownerBackendNodeId: 2,
+          target: { tabId: 1 },
+        },
+      },
+    );
+    const result = await discoverVisualCandidates(facts([child, parent]));
+    expect(result.candidates).toHaveLength(2);
+    const path = result.candidates[0].framePath;
+    expect(path).toBe(result.candidates[1].framePath);
+    expect(path?.document).toBe(child.identity);
+    expect(path?.parent?.ownerBackendNodeId).toBe(2);
+    expect(path?.parent?.frame.document).toBe(parent.identity);
+    expect(path?.parent?.frame.parent).toBeUndefined();
+  });
+
   it("distinguishes visual facts not collected from complete empty discovery and honors cancellation", async () => {
     const empty = facts([]);
     expect(await discoverVisualCandidates(empty)).toMatchObject({

--- a/apps/extension/src/tools/vom/__tests__/visual-discovery.test.ts
+++ b/apps/extension/src/tools/vom/__tests__/visual-discovery.test.ts
@@ -5,7 +5,7 @@ import type { GeometryProjection } from "../../geometry";
 import { buildDocumentIndex, type DocumentFacts, type ObservationFacts } from "../facts";
 import type { FrameOwnedAxNode } from "../frame-document";
 import { normalizeDocument } from "../normalize";
-import { REQUESTED_STYLES } from "../snapshot";
+import { VISUAL_SNAPSHOT, VISUAL_STYLES } from "../snapshot";
 import { discoverVisualCandidates } from "../visual-discovery";
 
 const defaults: Record<string, string> = {
@@ -86,7 +86,7 @@ async function document(
         bounds: layouts.map((n) => n.bounds ?? [10, 20, 120, 40]),
         clientRects: layouts.map((n) => n.client ?? [0, 0, 1000, 800]),
         styles: layouts.map((n) =>
-          REQUESTED_STYLES.map((key) => str({ ...defaults, ...n.styles }[key])),
+          VISUAL_STYLES.map((key) => str({ ...defaults, ...n.styles }[key])),
         ),
       },
     },
@@ -108,6 +108,8 @@ async function document(
       },
       pageScale: options.pageScale ?? 1,
     },
+    undefined,
+    VISUAL_SNAPSHOT,
   );
   return {
     frame,
@@ -128,6 +130,7 @@ function facts(
   issues: ObservationFacts<FrameOwnedAxNode>["issues"] = [],
 ): ObservationFacts<FrameOwnedAxNode> {
   return {
+    visualFactsCollected: true,
     rootFrameId: "main",
     documents,
     viewport: { width: 1000, height: 800 },
@@ -138,6 +141,46 @@ function facts(
 }
 
 describe("Canvas discovery", () => {
+  it("distinguishes visual facts not collected from complete empty discovery and honors cancellation", async () => {
+    const empty = facts([]);
+    expect(await discoverVisualCandidates(empty)).toMatchObject({
+      complete: true,
+      candidates: [],
+      issues: [],
+    });
+    expect(await discoverVisualCandidates({ ...empty, visualFactsCollected: false })).toMatchObject(
+      { complete: false, candidates: [], issues: [{ reason: "visual-facts-not-collected" }] },
+    );
+    const controller = new AbortController();
+    controller.abort();
+    await expect(
+      discoverVisualCandidates({ ...empty, visualFactsCollected: false }, controller.signal),
+    ).rejects.toMatchObject({ name: "AbortError" });
+  });
+
+  it("discovers Canvas and frame contents without corner radius facts", async () => {
+    const own = await document([{ id: 2, parent: 1, styles: {} }]);
+    expect(await discoverVisualCandidates(facts([own]))).toMatchObject({
+      candidates: [{ backendNodeId: 2 }],
+      complete: true,
+      issues: [],
+    });
+    const parent = await document([{ id: 2, parent: 1, tag: "iframe", styles: {} }]);
+    const child = await document([{ id: 3, parent: 1 }], {
+      frame: {
+        frameId: "child",
+        parentFrameId: "main",
+        ownerBackendNodeId: 2,
+        target: { tabId: 1 },
+      },
+    });
+    expect(await discoverVisualCandidates(facts([parent, child]))).toMatchObject({
+      candidates: [{ backendNodeId: 3 }],
+      complete: true,
+      issues: [],
+    });
+  });
+
   it.each([
     0.8, 1, 1.25, 2,
   ])("combines layout-unit bounds with CSS client clips at scale %s", async (scale) => {
@@ -383,7 +426,7 @@ describe("Canvas discovery", () => {
     ]);
     for (const parent of [99, 3]) {
       doc.index.nodes.get(2)!.parentBackendNodeId = parent;
-      const index = await buildDocumentIndex([...doc.index.nodes.values()]);
+      const index = await buildDocumentIndex([...doc.index.nodes.values()], undefined, true);
       const result = await discoverVisualCandidates(facts([{ ...doc, index }]));
       expect(result.candidates).toHaveLength(0);
       expect(result.issues[0].reason).toBe("ancestry-incomplete");
@@ -445,7 +488,7 @@ describe("Canvas discovery", () => {
       });
       input.push(node);
     }
-    const index = await buildDocumentIndex(input);
+    const index = await buildDocumentIndex(input, undefined, true);
     reads = 0;
     const result = await discoverVisualCandidates(facts([{ ...doc, index }]));
     expect(result.candidates).toHaveLength(count / 2 + 2);

--- a/apps/extension/src/tools/vom/__tests__/visual-discovery.test.ts
+++ b/apps/extension/src/tools/vom/__tests__/visual-discovery.test.ts
@@ -1,0 +1,459 @@
+import { describe, expect, it } from "vitest";
+import type { CdpFrame } from "@/browser-driver/frame-graph";
+import { OVERLAY_HOST_MARKER_ATTR } from "@/lib/overlay-bridge";
+import type { GeometryProjection } from "../../geometry";
+import { buildDocumentIndex, type DocumentFacts, type ObservationFacts } from "../facts";
+import type { FrameOwnedAxNode } from "../frame-document";
+import { normalizeDocument } from "../normalize";
+import { REQUESTED_STYLES } from "../snapshot";
+import { discoverVisualCandidates } from "../visual-discovery";
+
+const defaults: Record<string, string> = {
+  position: "static",
+  "pointer-events": "auto",
+  cursor: "auto",
+  visibility: "visible",
+  opacity: "1",
+  display: "block",
+  "overflow-x": "visible",
+  "overflow-y": "visible",
+  transform: "none",
+  zoom: "1",
+  "clip-path": "none",
+  "mask-image": "none",
+  rotate: "none",
+  scale: "none",
+  perspective: "none",
+  clip: "auto",
+  contain: "none",
+  "overflow-clip-margin": "0px",
+};
+const projection: GeometryProjection = {
+  sourceClips: [],
+  edges: [],
+  topViewport: { width: 1000, height: 800 },
+};
+interface Spec {
+  id: number;
+  parent?: number;
+  tag?: string;
+  styles?: Record<string, string>;
+  bounds?: number[] | null;
+  client?: number[];
+  attrs?: Record<string, string>;
+}
+async function document(
+  nodes: Spec[],
+  options: {
+    frame?: CdpFrame;
+    projection?: GeometryProjection;
+    pageScale?: number;
+    scrollY?: number;
+    layoutScale?: number;
+  } = {},
+): Promise<DocumentFacts<FrameOwnedAxNode>> {
+  const frame = options.frame ?? { frameId: "main", target: { tabId: 1 } };
+  const strings: string[] = [];
+  const str = (value: string) => {
+    const index = strings.indexOf(value);
+    if (index >= 0) return index;
+    strings.push(value);
+    return strings.length - 1;
+  };
+  const input: Spec[] = [
+    { id: 0, tag: "#document", bounds: null },
+    { id: 1, parent: 0, tag: "html", bounds: [0, 0, 1000, 800] },
+    ...nodes,
+  ];
+  const layouts = input.filter((node) => node.bounds !== null);
+  const normalized = await normalizeDocument(
+    {
+      nodes: {
+        backendNodeId: input.map((n) => n.id),
+        nodeType: input.map((n) =>
+          n.tag === "#document" ? 9 : n.tag === "#document-fragment" ? 11 : 1,
+        ),
+        parentIndex: input.map((n) =>
+          n.parent === undefined ? -1 : input.findIndex((p) => p.id === n.parent),
+        ),
+        nodeName: input.map((n) => str(n.tag ?? "canvas")),
+        attributes: input.map((n) =>
+          Object.entries(n.attrs ?? {}).flatMap(([k, v]) => [str(k), str(v)]),
+        ),
+      },
+      layout: {
+        nodeIndex: layouts.map((n) => input.indexOf(n)),
+        bounds: layouts.map((n) => n.bounds ?? [10, 20, 120, 40]),
+        clientRects: layouts.map((n) => n.client ?? [0, 0, 1000, 800]),
+        styles: layouts.map((n) =>
+          REQUESTED_STYLES.map((key) => str({ ...defaults, ...n.styles }[key])),
+        ),
+      },
+    },
+    strings,
+    {
+      frameId: frame.frameId,
+      ownerFrameBackendNodeId: frame.ownerBackendNodeId ?? null,
+      target: frame.target,
+      projection: {
+        status: "available",
+        projection: {
+          source: { target: frame.target, frameId: frame.frameId },
+          geometry: options.projection ?? projection,
+        },
+      },
+      coordinates: {
+        layoutUnitsPerCssPixel: options.layoutScale ?? 1,
+        scrollCss: { x: 0, y: options.scrollY ?? 0 },
+      },
+      pageScale: options.pageScale ?? 1,
+    },
+  );
+  return {
+    frame,
+    identity: {
+      attachmentId: "attached",
+      target: frame.target,
+      frameId: frame.frameId,
+      documentElementBackendNodeId: 1,
+    },
+    index: normalized.index,
+    geometry: normalized.geometry,
+    domNodes: normalized.nodes,
+    axNodes: [],
+  };
+}
+function facts(
+  documents: DocumentFacts<FrameOwnedAxNode>[],
+  issues: ObservationFacts<FrameOwnedAxNode>["issues"] = [],
+): ObservationFacts<FrameOwnedAxNode> {
+  return {
+    rootFrameId: "main",
+    documents,
+    viewport: { width: 1000, height: 800 },
+    issues,
+    startedAt: 1,
+    finishedAt: 2,
+  };
+}
+
+describe("Canvas discovery", () => {
+  it.each([
+    0.8, 1, 1.25, 2,
+  ])("combines layout-unit bounds with CSS client clips at scale %s", async (scale) => {
+    const doc = await document(
+      [
+        {
+          id: 2,
+          parent: 1,
+          tag: "div",
+          bounds: [100, 200, 64, 34].map((n) => n * scale),
+          client: [2, 2, 60, 30],
+          styles: { "overflow-x": "hidden", "overflow-y": "hidden" },
+        },
+        { id: 3, parent: 2, bounds: [102, 202, 120, 40].map((n) => n * scale) },
+      ],
+      { layoutScale: scale, scrollY: 75 },
+    );
+    const result = await discoverVisualCandidates(facts([doc]));
+    expect(result.issues).toEqual([]);
+    const expected = {
+      borderBox: { x: 102, y: 127, width: 120, height: 40 },
+      crop: { x: 102, y: 127, width: 60, height: 30 },
+    };
+    for (const box of ["borderBox", "crop"] as const)
+      for (const key of ["x", "y", "width", "height"] as const)
+        expect(result.candidates[0].region[box][key]).toBeCloseTo(expected[box][key], 8);
+  });
+
+  it("normalizes a zero-width ancestor origin before one-axis clipping", async () => {
+    const doc = await document(
+      [
+        {
+          id: 2,
+          parent: 1,
+          tag: "div",
+          bounds: [200, 400, 0, 60],
+          client: [0, 0, 0, 30],
+          styles: { "overflow-y": "hidden" },
+        },
+        { id: 3, parent: 2, bounds: [200, 400, 240, 80] },
+      ],
+      { layoutScale: 2, scrollY: 75 },
+    );
+    const result = await discoverVisualCandidates(facts([doc]));
+    expect(result.issues).toEqual([]);
+    expect(result.candidates[0].region.crop).toEqual({ x: 100, y: 125, width: 120, height: 30 });
+  });
+
+  it("keeps unnamed, semantic, aria-hidden, inert, pointer-none and visibility override Canvas", async () => {
+    const doc = await document([
+      { id: 2, parent: 1 },
+      { id: 3, parent: 1, attrs: { "aria-label": "Chart" } },
+      {
+        id: 4,
+        parent: 1,
+        attrs: { "aria-hidden": "true", inert: "" },
+        styles: { "pointer-events": "none" },
+      },
+      { id: 5, parent: 1, tag: "div", styles: { visibility: "hidden" } },
+      { id: 6, parent: 5, styles: { visibility: "visible" } },
+      { id: 7, parent: 1, attrs: { hidden: "" }, styles: { display: "block" } },
+    ]);
+    doc.axNodes.push({ nodeId: "canvas", backendDOMNodeId: 2 } as FrameOwnedAxNode);
+    const result = await discoverVisualCandidates(facts([doc]));
+    expect(result.candidates.map((c) => c.backendNodeId)).toEqual([2, 3, 4, 6, 7]);
+    expect(result.candidates[1].label).toBe("Chart");
+    expect(result.complete).toBe(true);
+  });
+
+  it("excludes CSS transparent subtrees, hidden/zero/no-layout/fully clipped nodes and overlays", async () => {
+    const doc = await document([
+      { id: 2, parent: 1, tag: "div", styles: { opacity: "0" } },
+      { id: 3, parent: 2 },
+      { id: 4, parent: 1, styles: { visibility: "hidden" } },
+      { id: 5, parent: 1, bounds: [0, 0, 0, 40] },
+      { id: 6, parent: 1, bounds: null },
+      { id: 7, parent: 1, bounds: [1200, 0, 100, 50] },
+      { id: 8, parent: 1, tag: "div", attrs: { [OVERLAY_HOST_MARKER_ATTR]: "" } },
+      { id: 9, parent: 8, tag: "#document-fragment", bounds: null },
+      { id: 10, parent: 9 },
+    ]);
+    expect(await discoverVisualCandidates(facts([doc]))).toMatchObject({
+      candidates: [],
+      issues: [],
+      complete: true,
+    });
+  });
+
+  it.each([
+    ["both", "hidden", "hidden", [0, 0, 60, 30], [60, 30]],
+    ["x", "clip", "visible", [0, 0, 60, 20], [60, 40]],
+    ["border", "hidden", "hidden", [5, 5, 68, 38], [64, 34]],
+  ])("uses client box for %s clipping", async (_name, x, y, client, expected) => {
+    const doc = await document([
+      {
+        id: 2,
+        parent: 1,
+        tag: "div",
+        bounds: [0, 0, 78, 48],
+        client: client as number[],
+        styles: { "overflow-x": x as string, "overflow-y": y as string },
+      },
+      {
+        id: 3,
+        parent: 2,
+        bounds: x === "clip" || _name === "both" ? [0, 0, 120, 40] : [9, 9, 120, 40],
+      },
+    ]);
+    const [candidate] = (await discoverVisualCandidates(facts([doc]))).candidates;
+    expect([candidate.region.crop.width, candidate.region.crop.height]).toEqual(expected);
+    expect(candidate.region.clips?.backendNodeId).toBe(2);
+  });
+
+  it("keeps Canvas border-box and clips partial viewport intersections", async () => {
+    const doc = await document([{ id: 2, parent: 1, bounds: [950, 20, 130, 50] }]);
+    const [candidate] = (await discoverVisualCandidates(facts([doc]))).candidates;
+    expect(candidate.region.borderBox.width).toBe(130);
+    expect(candidate.region.crop).toEqual({ x: 950, y: 20, width: 50, height: 50 });
+  });
+
+  it("propagates owner ancestry across targets, without depending on semantic parents", async () => {
+    const parent = await document([
+      {
+        id: 2,
+        parent: 1,
+        tag: "div",
+        bounds: [0, 0, 200, 100],
+        client: [0, 0, 200, 100],
+        styles: { "overflow-x": "hidden", "overflow-y": "hidden" },
+      },
+      { id: 3, parent: 2, tag: "iframe", bounds: [100, 0, 200, 200] },
+    ]);
+    parent.domNodes.splice(0); // Visual discovery never reads the semantic subset.
+    const child = await document([{ id: 2, parent: 1, bounds: [0, 0, 200, 200] }], {
+      frame: {
+        frameId: "child",
+        parentFrameId: "main",
+        ownerBackendNodeId: 3,
+        target: { tabId: 1, sessionId: "remote" },
+      },
+      projection: {
+        ...projection,
+        edges: [
+          {
+            sourceViewport: { width: 200, height: 200 },
+            destinationQuad: [
+              { x: 100, y: 0 },
+              { x: 300, y: 0 },
+              { x: 300, y: 200 },
+              { x: 100, y: 200 },
+            ],
+          },
+        ],
+      },
+    });
+    const result = await discoverVisualCandidates(facts([child, parent]));
+    expect(result.complete).toBe(true);
+    expect(result.candidates[0]).toMatchObject({
+      document: { frameId: "child", target: { sessionId: "remote" } },
+      region: { crop: { x: 100, y: 0, width: 100, height: 100 } },
+    });
+    const owner = parent.index.nodes.get(3)!;
+    owner.layout!.styles = { ...owner.layout!.styles, visibility: "hidden" };
+    expect((await discoverVisualCandidates(facts([parent, child]))).candidates).toHaveLength(0);
+  });
+
+  it.each<Record<string, string>>([
+    { transform: "matrix(0,1,-1,0,0,0)" },
+    { "clip-path": "circle(50%)" },
+    { "mask-image": "url(mask)" },
+    { zoom: "1.25", "overflow-x": "hidden" },
+  ])("reports unsupported ancestor geometry: %o", async (styles) => {
+    const doc = await document([
+      { id: 2, parent: 1, tag: "div", styles },
+      { id: 3, parent: 2 },
+    ]);
+    const result = await discoverVisualCandidates(facts([doc]));
+    expect(result.candidates).toHaveLength(0);
+    expect(result.issues[0].reason).toBe("geometry-unsupported");
+  });
+
+  it("supports positive scale without overflow, rejects pinch and non-rectangular frame projection", async () => {
+    const nodes = [
+      {
+        id: 2,
+        parent: 1,
+        styles: { transform: "matrix(1.25,0,0,1.25,0,0)" },
+        bounds: [10, 20, 150, 50],
+      },
+    ];
+    expect(
+      (await discoverVisualCandidates(facts([await document(nodes)]))).candidates,
+    ).toHaveLength(1);
+    expect(
+      (await discoverVisualCandidates(facts([await document(nodes, { pageScale: 1.5 })]))).issues[0]
+        .reason,
+    ).toBe("geometry-unsupported");
+    const rotated = {
+      ...projection,
+      edges: [
+        {
+          sourceViewport: { width: 200, height: 200 },
+          destinationQuad: [
+            { x: 10, y: 0 },
+            { x: 200, y: 10 },
+            { x: 190, y: 200 },
+            { x: 0, y: 190 },
+          ] as [
+            { x: number; y: number },
+            { x: number; y: number },
+            { x: number; y: number },
+            { x: number; y: number },
+          ],
+        },
+      ],
+    };
+    expect(
+      (await discoverVisualCandidates(facts([await document(nodes, { projection: rotated })])))
+        .issues[0].reason,
+    ).toBe("geometry-unsupported");
+  });
+
+  it("keeps partial capture separate from valid geometry, rejects unverified identities", async () => {
+    const doc = await document([{ id: 2, parent: 1 }]);
+    const partial = facts(
+      [doc],
+      [{ target: doc.frame.target, frameId: "main", stage: "ax", reason: "capture-unavailable" }],
+    );
+    const result = await discoverVisualCandidates(partial);
+    expect(result.candidates).toHaveLength(1);
+    expect(result.captureIssues).toBe(partial.issues);
+    expect(result.complete).toBe(false);
+    const unverified = { ...doc, identity: undefined };
+    const failed = await discoverVisualCandidates(facts([unverified]));
+    expect(failed.candidates).toHaveLength(0);
+    expect(failed.issues[0].reason).toBe("identity-unverified");
+  });
+
+  it("does not trust orphan, cyclic, boxless or missing frame-owner ancestry", async () => {
+    const doc = await document([
+      { id: 2, parent: 1, tag: "div" },
+      { id: 3, parent: 2 },
+    ]);
+    for (const parent of [99, 3]) {
+      doc.index.nodes.get(2)!.parentBackendNodeId = parent;
+      const index = await buildDocumentIndex([...doc.index.nodes.values()]);
+      const result = await discoverVisualCandidates(facts([{ ...doc, index }]));
+      expect(result.candidates).toHaveLength(0);
+      expect(result.issues[0].reason).toBe("ancestry-incomplete");
+    }
+    const boxless = await document([
+      { id: 2, parent: 1, tag: "div", bounds: null },
+      { id: 3, parent: 2 },
+    ]);
+    expect((await discoverVisualCandidates(facts([boxless]))).issues[0].reason).toBe(
+      "facts-unavailable",
+    );
+    const child = {
+      ...doc,
+      frame: { ...doc.frame, frameId: "child", parentFrameId: "absent", ownerBackendNodeId: 2 },
+    };
+    expect((await discoverVisualCandidates(facts([child]))).issues[0].reason).toBe(
+      "ownership-unresolved",
+    );
+  });
+
+  it("is deterministic, does not deduplicate or mutate inputs", async () => {
+    const input = facts([
+      await document([
+        { id: 2, parent: 1 },
+        { id: 3, parent: 1 },
+      ]),
+    ]);
+    const freeze = (value: unknown): void => {
+      if (!value || typeof value !== "object" || Object.isFrozen(value)) return;
+      if (value instanceof Map) for (const item of value.values()) freeze(item);
+      for (const item of Object.values(value)) freeze(item);
+      Object.freeze(value);
+    };
+    freeze(input);
+    const first = await discoverVisualCandidates(input);
+    expect(await discoverVisualCandidates(input)).toEqual(first);
+    expect(first.candidates).toHaveLength(2);
+  });
+
+  it.each([
+    1000, 10000, 100000,
+  ])("memoizes deep ancestry across %i nodes and checks cancellation", async (count) => {
+    const doc = await document([{ id: 2, parent: 1 }]);
+    const template = doc.index.nodes.get(2)!;
+    let reads = 0;
+    const input = [doc.index.nodes.get(0)!, doc.index.nodes.get(1)!];
+    for (let id = 2; id < count + 2; id++) {
+      const node = {
+        ...template,
+        backendNodeId: id,
+        tag: id < count / 2 ? "div" : "canvas",
+        parentBackendNodeId: id < count / 2 ? id - 1 : count / 2 - 1,
+      };
+      Object.defineProperty(node, "parentBackendNodeId", {
+        get: () => {
+          reads++;
+          return id < count / 2 ? id - 1 : count / 2 - 1;
+        },
+      });
+      input.push(node);
+    }
+    const index = await buildDocumentIndex(input);
+    reads = 0;
+    const result = await discoverVisualCandidates(facts([{ ...doc, index }]));
+    expect(result.candidates).toHaveLength(count / 2 + 2);
+    expect(reads).toBeLessThan(count * 5);
+    const controller = new AbortController();
+    controller.abort();
+    await expect(discoverVisualCandidates(facts([doc]), controller.signal)).rejects.toMatchObject({
+      name: "AbortError",
+    });
+  });
+});

--- a/apps/extension/src/tools/vom/__tests__/visual-observation.test.ts
+++ b/apps/extension/src/tools/vom/__tests__/visual-observation.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, it, vi } from "vitest";
 import { SessionManager } from "@/session-manager/manager";
 import { RefStore } from "@/session-manager/ref-store";
 import type { ObserveResult } from "@/transport/types";
+import { auditContext } from "../../audit-context";
 import { handleObserve, handleSnapshot } from "../../observation";
 import type { CdpRunner } from "../../shared";
 import type { DocumentIdentity } from "../facts";
@@ -164,6 +165,7 @@ describe("visual observation output", () => {
     let r = success(await publishObservationPage(f.store, f.cdp, 4, { output: f.output }));
     const seen = new Set<string>();
     let pages = 0;
+    let retriedFinalPage = false;
     while (true) {
       expect(
         r.text.split("\n").reduce((n, line) => n + Math.ceil(line.length / 4), 0),
@@ -177,9 +179,13 @@ describe("visual observation output", () => {
       const old = [...f.store.entries()].map(([ref]) => ref);
       r = success(await publishObservationPage(f.store, f.cdp, 4, { cursor }));
       for (const ref of old) expect(f.store.resolveEntry(ref)).toBeNull();
+      const revision = f.store.revision;
       expect(await publishObservationPage(f.store, f.cdp, 4, { cursor })).toEqual(r);
+      expect(f.store.revision).toBe(revision);
+      if (!r.next_cursor) retriedFinalPage = true;
       expect(++pages).toBeLessThan(35);
     }
+    expect(retriedFinalPage).toBe(true);
     expect(seen.size).toBe(35);
     expect(
       f.send.mock.calls.every((c) =>
@@ -845,4 +851,85 @@ it("can retry a cancelled final page with a smaller budget without losing buffer
     cursor = result.next_cursor;
   }
   expect(seen.size).toBe(20);
+});
+
+it("preserves DOM labels for audit on the first and continuation pages", async () => {
+  const f = fixture(0, 110);
+  f.scene.nodes.push(
+    ...Array.from({ length: 12 }, (_, i) => ({
+      ...node(i + 2, 1, "button", `Action ${i}`),
+      rect: { x: 0, y: i * 35, w: 100, h: 30 },
+    })),
+  );
+  f.output.render = prepareObservationRender(f.scene);
+  const manager = new SessionManager({
+    agentWindow: {
+      create: async () => 100,
+      remove: async () => {},
+      ensureActiveTab: async () => 4,
+    },
+  });
+  const ctx = await manager.start("audit-test");
+  ctx.agentCreatedTabs.add(4);
+  const originalChrome = globalThis.chrome;
+  vi.stubGlobal("chrome", {
+    tabs: { get: vi.fn(async () => ({ id: 4, url: "https://fixture.test/page" })) },
+  });
+  try {
+    let result = success(
+      await publishObservationPage(ctx.refStore, f.cdp, 4, { output: f.output }),
+    );
+    let pages = 0;
+    const labels: string[] = [];
+    while (true) {
+      for (const [ref, entry] of ctx.refStore.entries()) {
+        expect(entry.kind).toBe("dom");
+        if (entry.kind !== "dom") throw new Error("expected DOM ref");
+        expect(entry.name).toBe(`Action ${labels.length}`);
+        const audit = await auditContext(
+          {
+            id: "audit-click",
+            method: "tool.click",
+            params: {
+              session_id: ctx.sessionId,
+              tab_id: 4,
+              ref,
+              _audit_id: "operation-test",
+            },
+          },
+          manager,
+        );
+        expect(audit).toMatchObject({ target: entry.name, tab_id: 4 });
+        labels.push(entry.name!);
+      }
+      pages++;
+      if (!result.next_cursor) break;
+      result = success(
+        await publishObservationPage(ctx.refStore, f.cdp, 4, { cursor: result.next_cursor }),
+      );
+    }
+    expect(pages).toBeGreaterThan(1);
+    expect(labels).toHaveLength(12);
+    // A visual ref has no DOM audit label, even when its candidate has a label.
+    ctx.refStore.replace([
+      ["e1", { kind: "visual-region", candidate: { ...candidate(100), label: "Canvas" } }],
+    ]);
+    expect(
+      await auditContext(
+        {
+          id: "audit-visual",
+          method: "tool.click",
+          params: {
+            session_id: ctx.sessionId,
+            tab_id: 4,
+            ref: "e1",
+            _audit_id: "operation-test",
+          },
+        },
+        manager,
+      ),
+    ).not.toHaveProperty("target");
+  } finally {
+    vi.stubGlobal("chrome", originalChrome);
+  }
 });

--- a/apps/extension/src/tools/vom/__tests__/visual-observation.test.ts
+++ b/apps/extension/src/tools/vom/__tests__/visual-observation.test.ts
@@ -1,0 +1,541 @@
+import {
+  prepareObservationRender,
+  renderVom,
+  type VomNode,
+  type VomScene,
+} from "@browser-skill/vom";
+import { describe, expect, it, vi } from "vitest";
+import { SessionManager } from "@/session-manager/manager";
+import { RefStore } from "@/session-manager/ref-store";
+import type { ObserveResult } from "@/transport/types";
+import { handleObserve, handleSnapshot } from "../../observation";
+import type { CdpRunner } from "../../shared";
+import type { DocumentIdentity } from "../facts";
+import {
+  buildSemanticGraph,
+  normalizeSemanticStructure,
+  projectSemanticGraph,
+  resolveSemanticGraph,
+} from "../semantic-graph";
+import type { VisualCandidate } from "../visual-discovery";
+import {
+  attachVisualEntries,
+  type ObservationOutput,
+  prepareVisualObservation,
+  publishObservationPage,
+} from "../visual-observation";
+
+const identity: DocumentIdentity = {
+  attachmentId: "a",
+  target: { tabId: 4 },
+  frameId: "top",
+  documentElementBackendNodeId: 1,
+};
+const candidate = (id: number): VisualCandidate => ({
+  document: identity,
+  backendNodeId: id,
+  parentBackendNodeId: 1,
+  framePath: { document: identity },
+  region: {
+    status: "available",
+    borderBox: { x: 0, y: 0, width: 100, height: 100 },
+    crop: { x: 0, y: 0, width: 100, height: 100 },
+  },
+});
+const node = (id: number, parentId: number | null, role: string, name?: string): VomNode => ({
+  id,
+  parentId,
+  backendNodeId: id,
+  frameId: "top",
+  tag: role,
+  role,
+  name,
+  rect: { x: 0, y: 0, w: 100, h: 30 },
+  paintOrder: id,
+  position: "static",
+  pointerEvents: "auto",
+});
+function fixture(count = 20, maxTokens?: number) {
+  const candidates = Array.from({ length: count }, (_, i) => candidate(i + 100));
+  const scene: VomScene = {
+    viewport: { width: 1200, height: 800 },
+    nodes: [node(1, null, "rootwebarea")],
+    visuals: candidates.map((_, key) => ({ key, parentId: 1, frameId: "top" })),
+  };
+  const output: ObservationOutput = {
+    candidates,
+    identities: new Map([["top", identity]]),
+    rootIdentity: identity,
+    frames: new Map([["top", { target: identity.target }]]),
+    render: prepareObservationRender(scene),
+    notices: [],
+    maxTokens,
+  };
+  let changed = false;
+  const send = vi.fn(async (_tab: number, method: string) => {
+    if (method === "Page.createIsolatedWorld") return { executionContextId: 1 };
+    if (method === "Runtime.evaluate")
+      return {
+        result: {
+          deepSerializedValue: { type: "node", value: { backendNodeId: changed ? 999 : 1 } },
+        },
+      };
+    if (method === "Runtime.releaseObjectGroup") return {};
+    throw new Error(`unexpected ${method}`);
+  });
+  const cdp = { send, getAttachmentId: () => "a" } as unknown as CdpRunner;
+  return {
+    output,
+    scene,
+    store: new RefStore(),
+    cdp,
+    send,
+    change: () => {
+      changed = true;
+    },
+  };
+}
+const success = (r: Awaited<ReturnType<typeof publishObservationPage>>): ObserveResult => {
+  expect(r).not.toHaveProperty("code");
+  return r as ObserveResult;
+};
+
+describe("visual observation output", () => {
+  it("publishes all unnamed Canvas refs by default without live reads or screenshots", async () => {
+    const f = fixture(120);
+    const r = success(await publishObservationPage(f.store, f.cdp, 4, { output: f.output }));
+    expect(r.ref_count).toBe(120);
+    expect(r.next_cursor).toBeUndefined();
+    expect(r.text.match(/\[visual:screenshot\]/g)).toHaveLength(120);
+    expect(f.store.resolveEntry("e1")?.kind).toBe("visual-region");
+    expect(f.send).not.toHaveBeenCalled();
+  });
+  it("continues all candidates, replaces refs and retries the latest cursor without skipping", async () => {
+    const f = fixture(35, 100);
+    let r = success(await publishObservationPage(f.store, f.cdp, 4, { output: f.output }));
+    const seen = new Set<string>();
+    let pages = 0;
+    while (true) {
+      expect(
+        r.text.split("\n").reduce((n, line) => n + Math.ceil(line.length / 4), 0),
+      ).toBeLessThanOrEqual(100);
+      for (const [ref] of f.store.entries()) {
+        expect(seen.has(ref)).toBe(false);
+        seen.add(ref);
+      }
+      if (!r.next_cursor) break;
+      const cursor = r.next_cursor;
+      const old = [...f.store.entries()].map(([ref]) => ref);
+      r = success(await publishObservationPage(f.store, f.cdp, 4, { cursor }));
+      for (const ref of old) expect(f.store.resolveEntry(ref)).toBeNull();
+      expect(await publishObservationPage(f.store, f.cdp, 4, { cursor })).toEqual(r);
+      expect(++pages).toBeLessThan(35);
+    }
+    expect(seen.size).toBe(35);
+    expect(
+      f.send.mock.calls.every((c) =>
+        ["Page.createIsolatedWorld", "Runtime.evaluate", "Runtime.releaseObjectGroup"].includes(
+          c[1],
+        ),
+      ),
+    ).toBe(true);
+  });
+  it.each(["DOM", "replace", "clear", "tab"])("rejects a cursor after %s changes", async (kind) => {
+    const f = fixture(20, 100);
+    const first = success(await publishObservationPage(f.store, f.cdp, 4, { output: f.output }));
+    if (kind === "DOM") f.change();
+    if (kind === "replace") f.store.replace([]);
+    if (kind === "clear") f.store.clear();
+    expect(
+      await publishObservationPage(f.store, f.cdp, kind === "tab" ? 5 : 4, {
+        cursor: first.next_cursor,
+      }),
+    ).toHaveProperty("code");
+  });
+  it("does not consume an entry when a continuation budget is too small", async () => {
+    const f = fixture(20, 100);
+    const first = success(await publishObservationPage(f.store, f.cdp, 4, { output: f.output }));
+    const cursor = first.next_cursor!;
+    expect(
+      await publishObservationPage(f.store, f.cdp, 4, { cursor, maxTokens: 1 }),
+    ).toHaveProperty("code");
+    const next = success(
+      await publishObservationPage(f.store, f.cdp, 4, { cursor, maxTokens: 100 }),
+    );
+    expect(next.ref_count).toBeGreaterThan(0);
+  });
+  it("shrinks a long visual label, preserving its complete capability marker", async () => {
+    const f = fixture(1, 45);
+    f.scene.visuals![0].label = 'bad\n" ' + "x".repeat(1000);
+    f.output.render = prepareObservationRender(f.scene);
+    const r = success(await publishObservationPage(f.store, f.cdp, 4, { output: f.output }));
+    expect(r.text).toContain("@e1 canvas [visual:screenshot]");
+    expect(r.next_cursor).toBeUndefined();
+  });
+  it("keeps Canvas reachable below a depth limit", async () => {
+    const f = fixture(1);
+    f.scene.nodes.push(node(2, 1, "group", "deep"));
+    f.scene.visuals![0].parentId = 2;
+    f.output.render = prepareObservationRender(f.scene, { maxDepth: 1 });
+    const r = success(await publishObservationPage(f.store, f.cdp, 4, { output: f.output }));
+    expect(r.ref_count).toBe(1);
+    expect(r.truncated).toBe(true);
+  });
+  it("preserves the original semantic output when there are no Canvas entries", () => {
+    const scene: VomScene = {
+      viewport: { width: 1000, height: 800 },
+      nodes: [
+        node(1, null, "rootwebarea"),
+        node(2, 1, "button", "Save"),
+        node(3, 2, "statictext", "Save"),
+      ],
+    };
+    const original = renderVom(scene);
+    const prepared = prepareObservationRender(scene);
+    expect(
+      [
+        ...prepared.headers,
+        ...Array.from({ [Symbol.iterator]: () => prepared.rows }).map((r) => r.text),
+      ].join("\n"),
+    ).toBe(original.text);
+  });
+  it("joins through a dropped wrapper using source order without naming Canvas from nearby buttons", () => {
+    const docs: Parameters<typeof buildSemanticGraph>[0]["documents"] = [
+      {
+        frameId: "top",
+        target: { tabId: 4 },
+        contextScopeId: "top",
+        domNodes: [
+          {
+            backendNodeId: 1,
+            parentBackendNodeId: null,
+            tag: "main",
+            attrs: {},
+            rect: { x: 0, y: 0, w: 300, h: 300 },
+            paintOrder: 1,
+            position: "static",
+            pointerEvents: "auto",
+          },
+          {
+            backendNodeId: 2,
+            parentBackendNodeId: 1,
+            tag: "button",
+            attrs: { "aria-label": "Before" },
+            rect: { x: 0, y: 0, w: 100, h: 30 },
+            paintOrder: 2,
+            position: "static",
+            pointerEvents: "auto",
+          },
+          {
+            backendNodeId: 3,
+            parentBackendNodeId: 1,
+            tag: "div",
+            attrs: {},
+            rect: { x: 0, y: 30, w: 100, h: 100 },
+            paintOrder: 3,
+            position: "static",
+            pointerEvents: "auto",
+          },
+          {
+            backendNodeId: 4,
+            parentBackendNodeId: 3,
+            tag: "canvas",
+            attrs: {},
+            rect: { x: 0, y: 30, w: 100, h: 100 },
+            paintOrder: 4,
+            position: "static",
+            pointerEvents: "auto",
+          },
+          {
+            backendNodeId: 5,
+            parentBackendNodeId: 1,
+            tag: "button",
+            attrs: { "aria-label": "After" },
+            rect: { x: 0, y: 130, w: 100, h: 30 },
+            paintOrder: 5,
+            position: "static",
+            pointerEvents: "auto",
+          },
+        ],
+        axNodes: [],
+      },
+    ];
+    const graph = normalizeSemanticStructure(
+      resolveSemanticGraph(
+        buildSemanticGraph({
+          documents: docs,
+          rootFrameId: "top",
+          viewport: { width: 300, height: 300 },
+        }),
+      ),
+    );
+    const scene = attachVisualEntries(projectSemanticGraph(graph), graph, [candidate(4)]);
+    const prepared = prepareObservationRender(scene);
+    const text = Array.from({ [Symbol.iterator]: () => prepared.rows })
+      .map((r) => r.text)
+      .join("\n");
+    expect(text.indexOf('"Before"')).toBeLessThan(text.indexOf("[visual:screenshot]"));
+    expect(text.indexOf("[visual:screenshot]")).toBeLessThan(text.indexOf('"After"'));
+    expect(text).toMatch(/canvas \[visual:screenshot\]/);
+  });
+  it("keeps unplaced candidates in an explicit supplement", () => {
+    const graph = normalizeSemanticStructure(
+      resolveSemanticGraph(
+        buildSemanticGraph({
+          documents: [],
+          rootFrameId: "top",
+          viewport: { width: 300, height: 300 },
+        }),
+      ),
+    );
+    const prepared = prepareObservationRender(
+      attachVisualEntries({ viewport: { width: 300, height: 300 }, nodes: [] }, graph, [
+        candidate(10),
+      ]),
+    );
+    const text = Array.from({ [Symbol.iterator]: () => prepared.rows })
+      .map((r) => r.text)
+      .join("\n");
+    expect(text).toContain("Unplaced Canvas regions");
+    expect(text).toContain("[visual:screenshot]");
+  });
+  it("places child-frame Canvas under its iframe owner", () => {
+    const graph = normalizeSemanticStructure(
+      resolveSemanticGraph(
+        buildSemanticGraph({
+          rootFrameId: "top",
+          viewport: { width: 300, height: 300 },
+          documents: [
+            {
+              frameId: "top",
+              target: { tabId: 4 },
+              contextScopeId: "top",
+              axNodes: [],
+              domNodes: [
+                {
+                  backendNodeId: 1,
+                  parentBackendNodeId: null,
+                  tag: "main",
+                  attrs: {},
+                  rect: { x: 0, y: 0, w: 300, h: 300 },
+                  paintOrder: 1,
+                  position: "static",
+                  pointerEvents: "auto",
+                },
+                {
+                  backendNodeId: 2,
+                  parentBackendNodeId: 1,
+                  tag: "iframe",
+                  attrs: {},
+                  rect: { x: 0, y: 0, w: 200, h: 200 },
+                  paintOrder: 2,
+                  position: "static",
+                  pointerEvents: "auto",
+                },
+              ],
+            },
+            {
+              frameId: "child",
+              parentFrameId: "top",
+              ownerBackendNodeId: 2,
+              target: { tabId: 4, sessionId: "oopif" },
+              contextScopeId: "child",
+              axNodes: [],
+              domNodes: [
+                {
+                  backendNodeId: 11,
+                  parentBackendNodeId: null,
+                  tag: "canvas",
+                  attrs: {},
+                  rect: { x: 0, y: 0, w: 100, h: 100 },
+                  paintOrder: 1,
+                  position: "static",
+                  pointerEvents: "auto",
+                },
+              ],
+            },
+          ],
+        }),
+      ),
+    );
+    const c = { ...candidate(11), document: { ...identity, frameId: "child" } };
+    const scene = attachVisualEntries(projectSemanticGraph(graph), graph, [c]);
+    const owner = scene.nodes.find((n) => n.backendNodeId === 2)!;
+    expect(scene.visuals![0].parentId).toBe(owner.id);
+    expect(scene.visuals![0].fallbackContext).toBeUndefined();
+  });
+  it("does not register candidates missing screenshot paths", () => {
+    const graph = normalizeSemanticStructure(
+      resolveSemanticGraph(
+        buildSemanticGraph({
+          documents: [],
+          rootFrameId: "top",
+          viewport: { width: 300, height: 300 },
+        }),
+      ),
+    );
+    const c = { ...candidate(4), framePath: undefined };
+    const output = prepareVisualObservation(
+      { viewport: { width: 300, height: 300 }, nodes: [] },
+      graph,
+      { candidates: [c], issues: [], captureIssues: [], complete: true },
+      new Map(),
+      "top",
+      [],
+      {},
+    );
+    expect(output.candidates).toHaveLength(0);
+    expect(output.notices[0]).toContain("no verified screenshot path");
+  });
+});
+
+it("observe discovers and registers visual refs from its single production capture; snapshot stays semantic", async () => {
+  const strings = [
+    "#document",
+    "HTML",
+    "CANVAS",
+    "static",
+    "auto",
+    "visible",
+    "1",
+    "block",
+    "none",
+    "0px",
+    "http://fixture.test",
+  ];
+  const index = (s: string) => strings.indexOf(s);
+  const manager = new SessionManager({
+    agentWindow: {
+      create: async () => 100,
+      remove: async () => {},
+      ensureActiveTab: async () => 4,
+    },
+  });
+  const ctx = await manager.start("test");
+  const send = vi.fn(async (_tab: number, method: string, params: Record<string, unknown> = {}) => {
+    if (method === "Page.getLayoutMetrics")
+      return {
+        visualViewport: { clientWidth: 1000, clientHeight: 800 },
+        cssVisualViewport: { clientWidth: 1000, clientHeight: 800, scale: 1, zoom: 1 },
+        cssLayoutViewport: { clientWidth: 1000, clientHeight: 800, pageX: 0, pageY: 0 },
+      };
+    if (method === "DOMSnapshot.captureSnapshot") {
+      const styles = (params.computedStyles as string[]).map((key) =>
+        index(
+          (
+            {
+              position: "static",
+              "pointer-events": "auto",
+              cursor: "auto",
+              visibility: "visible",
+              opacity: "1",
+              display: "block",
+              "overflow-x": "visible",
+              "overflow-y": "visible",
+              zoom: "1",
+              clip: "auto",
+              "overflow-clip-margin": "0px",
+            } as Record<string, string>
+          )[key] ?? "none",
+        ),
+      );
+      return {
+        strings,
+        documents: [
+          {
+            frameId: "top",
+            documentURL: index("http://fixture.test"),
+            scrollOffsetX: 0,
+            scrollOffsetY: 0,
+            nodes: {
+              parentIndex: [-1, 0, 1],
+              nodeType: [9, 1, 1],
+              nodeName: [0, 1, 2],
+              backendNodeId: [10, 1, 100],
+              attributes: [[], [], []],
+            },
+            layout: {
+              nodeIndex: [1, 2],
+              styles: [styles, styles],
+              bounds: [
+                [0, 0, 1000, 800],
+                [20, 20, 100, 100],
+              ],
+              clientRects: [
+                [0, 0, 1000, 800],
+                [0, 0, 100, 100],
+              ],
+              paintOrders: [0, 1],
+            },
+          },
+        ],
+      };
+    }
+    if (method === "Accessibility.getFullAXTree")
+      return {
+        nodes: [
+          {
+            nodeId: "1",
+            backendDOMNodeId: 1,
+            role: { value: "RootWebArea" },
+            name: { value: "Fixture" },
+          },
+        ],
+      };
+    if (method === "Page.createIsolatedWorld") return { executionContextId: 1 };
+    if (method === "Runtime.evaluate")
+      return { result: { deepSerializedValue: { type: "node", value: { backendNodeId: 1 } } } };
+    if (method === "Runtime.releaseObjectGroup" || method.endsWith(".enable")) return {};
+    throw new Error(`unexpected ${method}`);
+  });
+  const cdp = {
+    send,
+    getAttachmentId: () => "a",
+    getFrameGraph: async () => ({
+      rootFrameId: "top",
+      frames: [{ frameId: "top", target: { tabId: 4 } }],
+    }),
+  } as unknown as CdpRunner;
+  const tab = { id: 4, windowId: 100, active: true, url: "http://fixture.test" } as chrome.tabs.Tab;
+  const deps = { cdp, tabsApi: { get: async () => tab, query: async () => [tab] } };
+  const observed = await handleObserve(manager, { session_id: "test" }, deps);
+  expect(observed).not.toHaveProperty("code");
+  expect((observed as ObserveResult).text).toContain("@e1 canvas [visual:screenshot]");
+  expect(ctx.refStore.resolveEntry("e1")?.kind).toBe("visual-region");
+  expect(send.mock.calls.filter((c) => c[1] === "DOMSnapshot.captureSnapshot")).toHaveLength(1);
+  expect(send.mock.calls.some((c) => c[1] === "Page.captureScreenshot")).toBe(false);
+  await handleSnapshot(manager, { session_id: "test" }, deps);
+  const captures = send.mock.calls.filter((c) => c[1] === "DOMSnapshot.captureSnapshot");
+  expect(captures[0][2]?.computedStyles).toHaveLength(18);
+  expect(captures[1][2]?.computedStyles).toHaveLength(5);
+  expect([...ctx.refStore.entries()].some(([, entry]) => entry.kind === "visual-region")).toBe(
+    false,
+  );
+});
+
+it.each([
+  "same",
+  "different",
+  "action",
+])("only suppresses redundant passive Canvas semantics: %s", (kind) => {
+  const semantic = node(
+    2,
+    1,
+    kind === "action" ? "button" : "canvas",
+    kind === "different" ? "Distinct semantics" : "Canvas title",
+  );
+  semantic.tag = "canvas";
+  const scene: VomScene = {
+    viewport: { width: 1000, height: 800 },
+    nodes: [node(1, null, "rootwebarea"), semantic],
+    visuals: [
+      { key: 0, sourceId: 2, beforeId: 2, parentId: 1, label: "Canvas title", frameId: "top" },
+    ],
+  };
+  const rows = Array.from({ [Symbol.iterator]: () => prepareObservationRender(scene).rows });
+  expect(rows.filter((r) => r.text.includes("Canvas title"))).toHaveLength(
+    kind === "action" ? 2 : 1,
+  );
+  expect(rows.some((r) => r.text.includes("Distinct semantics"))).toBe(kind === "different");
+  if (kind === "action") expect(rows.filter((r) => r.ref)).toHaveLength(2);
+});

--- a/apps/extension/src/tools/vom/__tests__/visual-observation.test.ts
+++ b/apps/extension/src/tools/vom/__tests__/visual-observation.test.ts
@@ -490,6 +490,8 @@ it("observe discovers and registers visual refs from its single production captu
               zoom: "1",
               clip: "auto",
               "overflow-clip-margin": "0px",
+              "content-visibility": "visible",
+              "container-type": "normal",
             } as Record<string, string>
           )[key] ?? "none",
         ),
@@ -561,7 +563,7 @@ it("observe discovers and registers visual refs from its single production captu
   expect(send.mock.calls.some((c) => c[1] === "Page.captureScreenshot")).toBe(false);
   await handleSnapshot(manager, { session_id: "test" }, deps);
   const captures = send.mock.calls.filter((c) => c[1] === "DOMSnapshot.captureSnapshot");
-  expect(captures[0][2]?.computedStyles).toHaveLength(18);
+  expect(captures[0][2]?.computedStyles).toHaveLength(20);
   expect(captures[1][2]?.computedStyles).toHaveLength(5);
   expect([...ctx.refStore.entries()].some(([, entry]) => entry.kind === "visual-region")).toBe(
     false,

--- a/apps/extension/src/tools/vom/__tests__/visual-observation.test.ts
+++ b/apps/extension/src/tools/vom/__tests__/visual-observation.test.ts
@@ -539,3 +539,261 @@ it.each([
   expect(rows.some((r) => r.text.includes("Distinct semantics"))).toBe(kind === "different");
   if (kind === "action") expect(rows.filter((r) => r.ref)).toHaveLength(2);
 });
+
+it.each([
+  "source",
+  "parent",
+  "frame",
+  "unplaced",
+])("does not resurrect modal background Canvas via %s", async (kind) => {
+  const f = fixture(1);
+  f.scene.rootFrameId = "top";
+  f.scene.nodes.push(node(2, 1, kind === "frame" ? "iframe" : "canvas"));
+  f.scene.nodes.push({
+    ...node(10, 1, "dialog", "Login"),
+    position: "fixed",
+    rect: { x: 0, y: 0, w: 800, h: 600 },
+  });
+  f.scene.visuals = [
+    {
+      key: 0,
+      frameId: kind === "frame" ? "child" : "top",
+      parentId: kind === "unplaced" ? null : 2,
+      ...(kind === "source" ? { sourceId: 2 } : {}),
+    },
+  ];
+  f.output.render = prepareObservationRender(f.scene);
+  const result = success(await publishObservationPage(f.store, f.cdp, 4, { output: f.output }));
+  expect(result.text).toContain("focus=L1");
+  expect(result.text).not.toContain("[visual:screenshot]");
+  expect(result.text).not.toContain("Unplaced Canvas");
+  expect([...f.store.entries()].some(([, entry]) => entry.kind === "visual-region")).toBe(false);
+  f.scene.nodes = f.scene.nodes.filter((n) => n.id !== 10);
+  expect(
+    Array.from({ [Symbol.iterator]: () => prepareObservationRender(f.scene).rows }).filter(
+      (r) => r.ref?.visualKey !== undefined,
+    ),
+  ).toHaveLength(1);
+});
+
+it("preserves modal Canvas with omitted semantics and admits proven foreground fallback", () => {
+  const scene: VomScene = {
+    rootFrameId: "top",
+    viewport: { width: 1000, height: 800 },
+    nodes: [
+      node(1, null, "rootwebarea"),
+      {
+        ...node(10, 1, "dialog", "Login"),
+        position: "fixed",
+        rect: { x: 0, y: 0, w: 800, h: 600 },
+      },
+    ],
+    visuals: [
+      { key: 0, parentId: 10, frameId: "top" },
+      {
+        key: 1,
+        parentId: null,
+        frameId: "top",
+        paintOrder: 11,
+        rect: { x: 10, y: 10, w: 40, h: 40 },
+      },
+    ],
+  };
+  const result = Array.from({ [Symbol.iterator]: () => prepareObservationRender(scene).rows });
+  expect(result.filter((r) => r.ref?.visualKey !== undefined).map((r) => r.ref!.visualKey)).toEqual(
+    [0, 1],
+  );
+});
+
+it.each([
+  true,
+  false,
+])("applies the existing active-region policy to Canvas (enabled=%s)", (enabled) => {
+  const scene: VomScene = {
+    rootFrameId: "top",
+    viewport: { width: 1000, height: 800 },
+    nodes: [
+      node(1, null, "rootwebarea"),
+      node(2, 1, "canvas"),
+      {
+        ...node(10, 1, "group", "Popover"),
+        position: "fixed",
+        rect: { x: 0, y: 0, w: 100, h: 100 },
+      },
+    ],
+    visuals: [
+      {
+        key: 0,
+        parentId: 1,
+        sourceId: 2,
+        frameId: "top",
+        rect: { x: 0, y: 0, w: 100, h: 30 },
+        paintOrder: 2,
+      },
+    ],
+  };
+  const rendered = Array.from({
+    [Symbol.iterator]: () => prepareObservationRender(scene, { activeRegionPolicy: enabled }).rows,
+  });
+  expect(rendered.filter((r) => r.ref?.visualKey !== undefined)).toHaveLength(enabled ? 0 : 1);
+});
+
+it.each([
+  "Runtime.evaluate",
+  "Runtime.releaseObjectGroup",
+])("retains a cancelled page through handleObserve during %s", async (method) => {
+  const f = fixture(35, 100);
+  const manager = new SessionManager({
+    agentWindow: {
+      create: async () => 100,
+      remove: async () => {},
+      ensureActiveTab: async () => 4,
+    },
+  });
+  const ctx = await manager.start("cancel-test");
+  const first = success(await publishObservationPage(ctx.refStore, f.cdp, 4, { output: f.output }));
+  const originalRefs = [...ctx.refStore.entries()];
+  const revision = ctx.refStore.revision;
+  const controller = new AbortController();
+  const original = f.send.getMockImplementation()!;
+  f.send.mockImplementation(async (tab, command) => {
+    const result = await original(tab, command);
+    if (command === method) controller.abort();
+    return result;
+  });
+  const tab = { id: 4, windowId: 100, url: "http://fixture.test" } as chrome.tabs.Tab;
+  const cancelled = await handleObserve(
+    manager,
+    { session_id: "cancel-test", cursor: first.next_cursor },
+    { cdp: f.cdp, tabsApi: { get: async () => tab, query: async () => [tab] } },
+    controller.signal,
+  );
+  expect(cancelled).toHaveProperty("code", "cancelled");
+  expect(ctx.refStore.revision).toBe(revision);
+  expect([...ctx.refStore.entries()]).toEqual(originalRefs);
+  f.send.mockImplementation(original);
+  const seen = new Set(originalRefs.map(([ref]) => ref));
+  let cursor = first.next_cursor;
+  while (cursor) {
+    const page = success(await publishObservationPage(ctx.refStore, f.cdp, 4, { cursor }));
+    expect(await publishObservationPage(ctx.refStore, f.cdp, 4, { cursor })).toEqual(page);
+    for (const [ref] of ctx.refStore.entries()) {
+      expect(seen.has(ref)).toBe(false);
+      seen.add(ref);
+    }
+    cursor = page.next_cursor;
+  }
+  expect(seen.size).toBe(35);
+});
+
+it("preserves a Canvas containing an active region rather than treating it as background", () => {
+  const scene: VomScene = {
+    rootFrameId: "top",
+    viewport: { width: 1000, height: 800 },
+    nodes: [
+      node(1, null, "rootwebarea"),
+      { ...node(2, 1, "canvas"), paintOrder: 5 },
+      {
+        ...node(10, 2, "group", "Popover"),
+        paintOrder: 5,
+        position: "fixed",
+        rect: { x: 0, y: 0, w: 100, h: 100 },
+      },
+    ],
+    visuals: [{ key: 0, parentId: 1, sourceId: 2, frameId: "top" }],
+  };
+  const result = prepareObservationRender(scene, { activeRegionPolicy: true });
+  const text = [
+    ...result.headers,
+    ...Array.from({ [Symbol.iterator]: () => result.rows }, (r) => r.text),
+  ].join("\n");
+  expect(text).toContain("[visual:screenshot]");
+  expect(text).toContain('group "Popover"');
+});
+
+it("an old cancelled validation cannot clear a newer observation", async () => {
+  const f = fixture(20, 100);
+  const first = success(await publishObservationPage(f.store, f.cdp, 4, { output: f.output }));
+  const controller = new AbortController();
+  const original = f.send.getMockImplementation()!;
+  let newer: ObserveResult | undefined;
+  f.send.mockImplementation(async (tab, method) => {
+    if (method === "Runtime.evaluate") {
+      newer = success(
+        await publishObservationPage(f.store, f.cdp, 4, { output: fixture(25, 100).output }),
+      );
+      controller.abort();
+    }
+    return original(tab, method);
+  });
+  await expect(
+    publishObservationPage(f.store, f.cdp, 4, { cursor: first.next_cursor }, controller.signal),
+  ).rejects.toThrow();
+  f.send.mockImplementation(original);
+  expect(
+    success(await publishObservationPage(f.store, f.cdp, 4, { cursor: newer!.next_cursor }))
+      .ref_count,
+  ).toBeGreaterThan(0);
+});
+
+it("keeps excluded Canvas out of every continuation page", async () => {
+  const f = fixture(36, 100);
+  f.scene.rootFrameId = "top";
+  f.scene.nodes.push({
+    ...node(10, 1, "dialog", "Login"),
+    position: "fixed",
+    rect: { x: 0, y: 0, w: 800, h: 600 },
+  });
+  f.scene.visuals!.forEach((v, i) => {
+    v.parentId = i === 0 ? 1 : 10;
+  });
+  f.output.render = prepareObservationRender(f.scene);
+  let result = success(await publishObservationPage(f.store, f.cdp, 4, { output: f.output }));
+  let count = 0;
+  while (true) {
+    for (const [, entry] of f.store.entries())
+      if (entry.kind === "visual-region") {
+        expect(entry.candidate.backendNodeId).not.toBe(100);
+        count++;
+      }
+    if (!result.next_cursor) break;
+    result = success(
+      await publishObservationPage(f.store, f.cdp, 4, { cursor: result.next_cursor }),
+    );
+  }
+  expect(count).toBe(35);
+});
+
+it("can retry a cancelled final page with a smaller budget without losing buffered rows", async () => {
+  const f = fixture(20, 100);
+  const first = success(await publishObservationPage(f.store, f.cdp, 4, { output: f.output }));
+  const seen = new Set([...f.store.entries()].map(([ref]) => ref));
+  const controller = new AbortController();
+  const original = f.send.getMockImplementation()!;
+  f.send.mockImplementation(async (tab, method) => {
+    if (method === "Runtime.evaluate") controller.abort();
+    return original(tab, method);
+  });
+  await expect(
+    publishObservationPage(
+      f.store,
+      f.cdp,
+      4,
+      { cursor: first.next_cursor, maxTokens: 10000 },
+      controller.signal,
+    ),
+  ).rejects.toThrow();
+  f.send.mockImplementation(original);
+  let cursor = first.next_cursor;
+  while (cursor) {
+    const result = success(
+      await publishObservationPage(f.store, f.cdp, 4, { cursor, maxTokens: 100 }),
+    );
+    for (const [ref] of f.store.entries()) {
+      expect(seen.has(ref)).toBe(false);
+      seen.add(ref);
+    }
+    cursor = result.next_cursor;
+  }
+  expect(seen.size).toBe(20);
+});

--- a/apps/extension/src/tools/vom/__tests__/visual-observation.test.ts
+++ b/apps/extension/src/tools/vom/__tests__/visual-observation.test.ts
@@ -17,6 +17,7 @@ import {
   projectSemanticGraph,
   resolveSemanticGraph,
 } from "../semantic-graph";
+import { deduplicateVisualCandidates } from "../visual-dedup";
 import type { VisualCandidate } from "../visual-discovery";
 import {
   attachVisualEntries,
@@ -108,6 +109,54 @@ describe("visual observation output", () => {
     expect(r.next_cursor).toBeUndefined();
     expect(r.text.match(/\[visual:screenshot\]/g)).toHaveLength(120);
     expect(f.store.resolveEntry("e1")?.kind).toBe("visual-region");
+    expect(f.send).not.toHaveBeenCalled();
+  });
+  it("publishes distinct refs for overlapping Canvas nodes after candidate deduplication", async () => {
+    const f = fixture(2);
+    const graph = normalizeSemanticStructure(
+      resolveSemanticGraph(
+        buildSemanticGraph({
+          rootFrameId: "top",
+          viewport: { width: 1200, height: 800 },
+          documents: [
+            {
+              frameId: "top",
+              target: identity.target,
+              contextScopeId: "top",
+              axNodes: [],
+              domNodes: [1, 100, 101].map((id) => ({
+                backendNodeId: id,
+                parentBackendNodeId: id === 1 ? null : 1,
+                tag: id === 1 ? "main" : "canvas",
+                attrs: {},
+                rect: { x: 0, y: 0, w: 100, h: 100 },
+                paintOrder: id,
+                position: "static",
+                pointerEvents: "auto",
+              })),
+            },
+          ],
+        }),
+      ),
+    );
+    const discovery = await deduplicateVisualCandidates({
+      candidates: [candidate(100), candidate(101), candidate(100)],
+      complete: true,
+      issues: [],
+      captureIssues: [],
+    });
+    f.output.candidates = discovery.candidates;
+    f.output.render = prepareObservationRender(
+      attachVisualEntries(projectSemanticGraph(graph), graph, discovery.candidates),
+    );
+    const result = success(await publishObservationPage(f.store, f.cdp, 4, { output: f.output }));
+    expect(result.ref_count).toBe(2);
+    expect(result.text.match(/\[visual:screenshot\]/g)).toHaveLength(2);
+    const refs = [...f.store.entries()];
+    expect(refs[0][0]).not.toBe(refs[1][0]);
+    expect(
+      refs.map(([, entry]) => entry.kind === "visual-region" && entry.candidate.backendNodeId),
+    ).toEqual([100, 101]);
     expect(f.send).not.toHaveBeenCalled();
   });
   it("continues all candidates, replaces refs and retries the latest cursor without skipping", async () => {

--- a/apps/extension/src/tools/vom/__tests__/visual-region.test.ts
+++ b/apps/extension/src/tools/vom/__tests__/visual-region.test.ts
@@ -39,6 +39,64 @@ const ancestor: VisualAncestor = {
 const box = { x: 0, y: 0, width: 120, height: 40 };
 
 describe("shared visual region rules", () => {
+  it.each([
+    "visible",
+    "hidden",
+    "auto",
+    "scroll",
+    "clip",
+  ])("keeps %s screenshot bounds independent of rounded styling", (overflow) => {
+    for (const clipContents of [true, false]) {
+      const node = {
+        ...ancestor,
+        styles: { ...styles, "overflow-x": overflow, "overflow-y": overflow },
+      };
+      const baseline = extendVisualContext(EMPTY_VISUAL_CONTEXT, node, clipContents);
+      for (const radius of ["0px", "8px", "50%", "4px 8px"]) {
+        const rounded = extendVisualContext(
+          EMPTY_VISUAL_CONTEXT,
+          {
+            ...node,
+            styles: {
+              ...node.styles,
+              "border-top-left-radius": radius,
+              "border-top-right-radius": radius,
+              "border-bottom-left-radius": radius,
+              "border-bottom-right-radius": radius,
+            },
+          },
+          clipContents,
+        );
+        expect(rounded).toEqual(baseline);
+        expect(
+          resolveVisualRegion({
+            borderBox: box,
+            frameVisibleBox: box,
+            visibility: "visible",
+            context: rounded,
+          }),
+        ).toMatchObject({ status: "available" });
+        expect(
+          resolveVisualRegion({
+            borderBox: box,
+            frameVisibleBox: box,
+            visibility: "hidden",
+            context: rounded,
+          }),
+        ).toEqual({ status: "empty" });
+        if (clipContents && overflow !== "visible")
+          expect(
+            resolveVisualRegion({
+              borderBox: box,
+              frameVisibleBox: { x: 80, y: 0, width: 20, height: 20 },
+              visibility: "visible",
+              context: rounded,
+            }),
+          ).toEqual({ status: "empty" });
+      }
+    }
+  });
+
   it("accepts independently supplied normalized facts and preserves clipping policy", () => {
     const context = extendVisualContext(EMPTY_VISUAL_CONTEXT, {
       ...ancestor,

--- a/apps/extension/src/tools/vom/__tests__/visual-region.test.ts
+++ b/apps/extension/src/tools/vom/__tests__/visual-region.test.ts
@@ -5,6 +5,7 @@ import {
   projectVisualBox,
   resolveVisualRegion,
   type VisualAncestor,
+  viewportOverflowSource,
 } from "../visual-region";
 
 const styles = {
@@ -246,5 +247,60 @@ describe("shared visual region rules", () => {
         false,
       ).issue,
     ).toBe("geometry-unsupported");
+  });
+});
+
+describe("viewport overflow propagation", () => {
+  const root = {
+    backendNodeId: 1,
+    tag: "html",
+    styles: { ...styles, "content-visibility": "visible", "container-type": "normal" },
+  };
+  const body = { ...root, backendNodeId: 2, tag: "body" };
+
+  it("uses the root unless an eligible HTML body supplies viewport overflow", () => {
+    expect(viewportOverflowSource(root, body)).toBe(2);
+    expect(viewportOverflowSource(root)).toBe(1);
+    expect(viewportOverflowSource({ ...root, tag: "svg" }, body)).toBe(1);
+    expect(viewportOverflowSource(root, { ...body, tag: "frameset" })).toBe(1);
+    expect(
+      viewportOverflowSource(root, { ...body, styles: { ...body.styles, display: "none" } }),
+    ).toBe(1);
+    expect(viewportOverflowSource(undefined, body)).toBeUndefined();
+  });
+
+  it.each([
+    { contain: "size" },
+    { contain: "layout" },
+    { contain: "style" },
+    { contain: "paint" },
+    { contain: "strict" },
+    { contain: "content" },
+    { "container-type": "size" },
+    { "container-type": "inline-size scroll-state" },
+    { "content-visibility": "auto" },
+    { "content-visibility": "hidden" },
+    { contain: "" },
+    { "container-type": "" },
+    { "content-visibility": "" },
+  ])("keeps body overflow local with containment or missing evidence: %o", (extra) => {
+    for (const onRoot of [false, true]) {
+      expect(
+        viewportOverflowSource(
+          onRoot ? { ...root, styles: { ...root.styles, ...extra } } : root,
+          onRoot ? body : { ...body, styles: { ...body.styles, ...extra } },
+        ),
+      ).toBe(1);
+    }
+  });
+
+  it("requires both root overflow axes to be visible", () => {
+    for (const axis of ["overflow-x", "overflow-y"]) {
+      for (const value of ["hidden", "auto", "scroll", "clip", ""]) {
+        expect(
+          viewportOverflowSource({ ...root, styles: { ...root.styles, [axis]: value } }, body),
+        ).toBe(1);
+      }
+    }
   });
 });

--- a/apps/extension/src/tools/vom/__tests__/visual-region.test.ts
+++ b/apps/extension/src/tools/vom/__tests__/visual-region.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it } from "vitest";
+import {
+  EMPTY_VISUAL_CONTEXT,
+  extendVisualContext,
+  projectVisualBox,
+  resolveVisualRegion,
+  type VisualAncestor,
+} from "../visual-region";
+
+const styles = {
+  position: "static",
+  visibility: "visible",
+  opacity: "1",
+  display: "block",
+  transform: "none",
+  zoom: "1",
+  "overflow-x": "visible",
+  "overflow-y": "visible",
+  "clip-path": "none",
+  "mask-image": "none",
+  rotate: "none",
+  scale: "none",
+  perspective: "none",
+  clip: "auto",
+  contain: "none",
+  "overflow-clip-margin": "0px",
+};
+const ancestor: VisualAncestor = {
+  document: {
+    attachmentId: "a",
+    target: { tabId: 1 },
+    frameId: "main",
+    documentElementBackendNodeId: 1,
+  },
+  backendNodeId: 2,
+  styles,
+  clientBox: { x: 5, y: 5, width: 60, height: 30 },
+};
+const box = { x: 0, y: 0, width: 120, height: 40 };
+
+describe("shared visual region rules", () => {
+  it("accepts independently supplied normalized facts and preserves clipping policy", () => {
+    const context = extendVisualContext(EMPTY_VISUAL_CONTEXT, {
+      ...ancestor,
+      styles: { ...styles, "overflow-x": "hidden" },
+    });
+    expect(
+      resolveVisualRegion({ borderBox: box, frameVisibleBox: box, visibility: "visible", context }),
+    ).toMatchObject({
+      status: "available",
+      crop: { x: 5, y: 0, width: 60, height: 40 },
+      clips: { overflowX: "hidden", overflowY: "visible" },
+    });
+    const differentPolicy = extendVisualContext(EMPTY_VISUAL_CONTEXT, {
+      ...ancestor,
+      styles: { ...styles, "overflow-x": "scroll" },
+    });
+    expect(differentPolicy.clip).toEqual(context.clip);
+    expect(differentPolicy.clips).not.toEqual(context.clips);
+  });
+
+  it("distinguishes fully clipped, missing client geometry and invalid rectangles", () => {
+    const clipping = { ...ancestor, styles: { ...styles, "overflow-x": "hidden" } };
+    const context = extendVisualContext(EMPTY_VISUAL_CONTEXT, {
+      ...clipping,
+      clientBox: { x: 0, y: 0, width: 0, height: 20 },
+    });
+    expect(
+      resolveVisualRegion({ borderBox: box, frameVisibleBox: box, visibility: "visible", context })
+        .status,
+    ).toBe("empty");
+    const unavailable = extendVisualContext(EMPTY_VISUAL_CONTEXT, { ...clipping, clientBox: null });
+    expect(
+      resolveVisualRegion({
+        borderBox: box,
+        frameVisibleBox: box,
+        visibility: "visible",
+        context: unavailable,
+      }),
+    ).toEqual({ status: "unavailable", reason: "geometry-unavailable" });
+    expect(
+      resolveVisualRegion({
+        borderBox: { ...box, x: NaN },
+        frameVisibleBox: box,
+        visibility: "visible",
+        context: EMPTY_VISUAL_CONTEXT,
+      }).status,
+    ).toBe("unavailable");
+    expect(projectVisualBox({ x: 5, y: 5, width: 0, height: 20 }, [])).toEqual({
+      x: 5,
+      y: 5,
+      width: 0,
+      height: 20,
+    });
+  });
+
+  it.each<Record<string, string>>([
+    { rotate: "45deg" },
+    { scale: "-1 1" },
+    { perspective: "100px" },
+    { clip: "rect(0px, 20px, 20px, 0px)" },
+    { contain: "paint" },
+    { "overflow-x": "clip", "overflow-clip-margin": "10px" },
+    { transform: "matrix3d(1,0,0,0,0,1,0,0,0,0,1,0.01,0,0,0,1)" },
+  ])("refuses unsupported CSS evidence without changing DOM geometry: %o", (change) => {
+    const context = extendVisualContext(EMPTY_VISUAL_CONTEXT, {
+      ...ancestor,
+      styles: { ...styles, ...change },
+    });
+    expect(context.issue).toBe("geometry-unsupported");
+  });
+
+  it("accepts axis-preserving matrix3d translation and independent positive scale", () => {
+    for (const change of [
+      { transform: "matrix3d(1,0,0,0,0,1,0,0,0,0,1,0,10,20,0,1)" },
+      { scale: "1.25" },
+    ])
+      expect(
+        extendVisualContext(EMPTY_VISUAL_CONTEXT, { ...ancestor, styles: { ...styles, ...change } })
+          .issue,
+      ).toBeUndefined();
+  });
+
+  it.each([
+    "matrix(1,0,0,1,0,0)",
+    "matrix(1,0,0,1,10,20)",
+  ])("accepts unscaled overflow transform %s", (transform) => {
+    const context = extendVisualContext(EMPTY_VISUAL_CONTEXT, {
+      ...ancestor,
+      styles: {
+        ...styles,
+        transform,
+        position: "relative",
+        "overflow-x": "hidden",
+        "overflow-y": "hidden",
+      },
+    });
+    expect(context.issue).toBeUndefined();
+    const child = extendVisualContext(
+      context,
+      {
+        ...ancestor,
+        styles: {
+          ...styles,
+          position: "absolute",
+          "overflow-x": "clip",
+          "overflow-y": "clip",
+          "overflow-clip-margin": "content-box",
+        },
+      },
+      false,
+    );
+    expect(
+      resolveVisualRegion({
+        borderBox: box,
+        frameVisibleBox: box,
+        visibility: "visible",
+        context: child,
+      }),
+    ).toMatchObject({ status: "available", crop: { x: 5, y: 5, width: 60, height: 30 } });
+  });
+
+  it("supports positioned overflow containers but refuses uncertain out-of-flow clipping", () => {
+    const overflow = { ...ancestor, styles: { ...styles, "overflow-x": "hidden" } };
+    const staticParent = extendVisualContext(EMPTY_VISUAL_CONTEXT, overflow);
+    expect(
+      extendVisualContext(
+        staticParent,
+        { ...ancestor, styles: { ...styles, position: "absolute" } },
+        false,
+      ).issue,
+    ).toBe("geometry-unsupported");
+    const positionedParent = extendVisualContext(EMPTY_VISUAL_CONTEXT, {
+      ...overflow,
+      styles: { ...overflow.styles, position: "relative" },
+    });
+    const child = extendVisualContext(
+      positionedParent,
+      { ...ancestor, styles: { ...styles, position: "absolute" } },
+      false,
+    );
+    expect(child.issue).toBeUndefined();
+    expect(child.clip).toEqual(positionedParent.clip);
+    expect(
+      extendVisualContext(
+        positionedParent,
+        { ...ancestor, styles: { ...styles, position: "fixed" } },
+        false,
+      ).issue,
+    ).toBe("geometry-unsupported");
+  });
+});

--- a/apps/extension/src/tools/vom/capture-coordinator.ts
+++ b/apps/extension/src/tools/vom/capture-coordinator.ts
@@ -375,6 +375,7 @@ export async function captureObservationFacts<T extends FrameOwnedAxNode>(
     facts.push({
       frame,
       identity: identities.get(document.frameId),
+      ...(doc?.geometry ? { geometry: doc.geometry } : {}),
       index: fallback?.size ? { ...index, excludedBackendNodeIds: fallback } : index,
       domNodes,
       axNodes,

--- a/apps/extension/src/tools/vom/capture-coordinator.ts
+++ b/apps/extension/src/tools/vom/capture-coordinator.ts
@@ -22,7 +22,12 @@ import {
   type FrameOwnedAxNode,
 } from "./frame-document";
 import { type NormalizedFrameDocument, normalizeSnapshot } from "./normalize";
-import { describeSnapshotFrames, REQUESTED_STYLES, type SnapshotReply } from "./snapshot";
+import {
+  BASIC_SNAPSHOT,
+  describeSnapshotFrames,
+  type SnapshotReply,
+  VISUAL_SNAPSHOT,
+} from "./snapshot";
 
 interface TargetBatch<T extends FrameOwnedAxNode> {
   target: CdpTarget;
@@ -69,7 +74,9 @@ export async function captureObservationFacts<T extends FrameOwnedAxNode>(
   tabId: number,
   signal?: AbortSignal,
   pageUrl?: string,
+  options: { includeVisualFacts?: boolean } = {},
 ): Promise<ObservationFacts<T>> {
+  const profile = options.includeVisualFacts ? VISUAL_SNAPSHOT : BASIC_SNAPSHOT;
   const startedAt = Date.now();
   throwCaptureAborted(signal);
   let graph: CdpFrameGraph | undefined;
@@ -125,7 +132,7 @@ export async function captureObservationFacts<T extends FrameOwnedAxNode>(
         throwCaptureAborted(signal);
         batch.snapshotAttachmentId = cdp.getAttachmentId?.(tabId);
         const snapshot = await scoped.send<SnapshotReply>(tabId, "DOMSnapshot.captureSnapshot", {
-          computedStyles: REQUESTED_STYLES,
+          computedStyles: profile.computedStyles,
           includePaintOrder: true,
           includeDOMRects: true,
         });
@@ -146,6 +153,7 @@ export async function captureObservationFacts<T extends FrameOwnedAxNode>(
           issues,
           signal,
           observed.rootFrameId,
+          profile,
         );
         const formsAvailable = await enrichFormControlStates(
           scoped,
@@ -384,7 +392,15 @@ export async function captureObservationFacts<T extends FrameOwnedAxNode>(
   throwCaptureAborted(signal);
   if (firstFailure && facts.every((doc) => !doc.domNodes.length && !doc.axNodes.length))
     throw firstFailure;
-  return { rootFrameId, viewport, documents: facts, issues, startedAt, finishedAt: Date.now() };
+  return {
+    visualFactsCollected: profile.includeVisualFacts,
+    rootFrameId,
+    viewport,
+    documents: facts,
+    issues,
+    startedAt,
+    finishedAt: Date.now(),
+  };
 }
 
 /** Existing semantic consumers get a narrow view; no raw snapshot

--- a/apps/extension/src/tools/vom/document-identity.ts
+++ b/apps/extension/src/tools/vom/document-identity.ts
@@ -25,7 +25,7 @@ export async function verifyVisualTargetIdentity(
 
 export type VerifiedNodeResult =
   | { status: "changed" | "unavailable" }
-  | { status: "current"; objectId: string; objectGroup: string };
+  | { status: "current"; objectId: string; objectGroup: string; executionContextId: number };
 
 /** Caller must release objectGroup in finally after its local read. */
 export async function resolveVerifiedNode(
@@ -35,8 +35,16 @@ export async function resolveVerifiedNode(
   signal?: AbortSignal,
 ): Promise<VerifiedNodeResult> {
   const result = await verifyIdentity(cdp, identity, signal, backendNodeId, true);
-  return result.status === "current" && result.objectId && result.objectGroup
-    ? { status: "current", objectId: result.objectId, objectGroup: result.objectGroup }
+  return result.status === "current" &&
+    result.objectId &&
+    result.objectGroup &&
+    result.executionContextId !== undefined
+    ? {
+        status: "current",
+        objectId: result.objectId,
+        objectGroup: result.objectGroup,
+        executionContextId: result.executionContextId,
+      }
     : { status: result.status === "changed" ? "changed" : "unavailable" };
 }
 
@@ -50,6 +58,7 @@ async function verifyIdentity(
   status: "current" | "changed" | "unavailable";
   objectId?: string;
   objectGroup?: string;
+  executionContextId?: number;
 }> {
   const attached = () => cdp.getAttachmentId?.(identity.target.tabId) === identity.attachmentId;
   throwIfAborted(signal);
@@ -104,8 +113,11 @@ async function verifyIdentity(
     if (id === undefined) return { status: "unavailable" };
     if (id !== identity.documentElementBackendNodeId) return { status: "changed" };
     throwIfAborted(signal);
-    retained = retain && !!objectId;
-    return { status: "current", ...(retained ? { objectId, objectGroup } : {}) };
+    retained = retain && !!objectId && world.executionContextId !== undefined;
+    return {
+      status: "current",
+      ...(retained ? { objectId, objectGroup, executionContextId: world.executionContextId } : {}),
+    };
   } catch (error) {
     throwIfAborted(signal);
     if (isAbortError(error)) throw error;

--- a/apps/extension/src/tools/vom/document-identity.ts
+++ b/apps/extension/src/tools/vom/document-identity.ts
@@ -2,6 +2,7 @@ import type { CdpRunner } from "../shared";
 import { sendToCdpTarget } from "../shared";
 import { isAbortError, throwIfAborted } from "./capture-abort";
 import type { DocumentIdentity } from "./facts";
+import type { VisualCandidate } from "./visual-discovery";
 
 /** Compare the snapshot root with the current root in that exact frame.
  * Deep serialization supplies the backend ID without a separate describeNode. */
@@ -9,6 +10,24 @@ export async function verifyDocumentIdentity(
   cdp: CdpRunner,
   identity: DocumentIdentity,
   signal?: AbortSignal,
+): Promise<"current" | "changed" | "unavailable"> {
+  return verifyIdentity(cdp, identity, signal);
+}
+
+/** Verify the visual anchor in its original frame; geometry is checked by screenshot execution. */
+export async function verifyVisualTargetIdentity(
+  cdp: CdpRunner,
+  candidate: VisualCandidate,
+  signal?: AbortSignal,
+): Promise<"current" | "changed" | "unavailable"> {
+  return verifyIdentity(cdp, candidate.document, signal, candidate.backendNodeId);
+}
+
+async function verifyIdentity(
+  cdp: CdpRunner,
+  identity: DocumentIdentity,
+  signal?: AbortSignal,
+  anchorBackendNodeId?: number,
 ): Promise<"current" | "changed" | "unavailable"> {
   const attached = () => cdp.getAttachmentId?.(identity.target.tabId) === identity.attachmentId;
   throwIfAborted(signal);
@@ -23,17 +42,36 @@ export async function verifyDocumentIdentity(
       frameId: identity.frameId,
       worldName: "bsk-document-identity",
     });
-    const reply = await send<{
+    const serializationOptions = {
+      serialization: "deep",
+      additionalParameters: { maxNodeDepth: 0, includeShadowTree: "none" },
+    };
+    type RootReply = {
       result?: { deepSerializedValue?: { type: string; value?: { backendNodeId?: number } } };
-    }>("Runtime.evaluate", {
-      expression: "document.documentElement",
-      contextId: world.executionContextId,
-      objectGroup,
-      serializationOptions: {
-        serialization: "deep",
-        additionalParameters: { maxNodeDepth: 0, includeShadowTree: "none" },
-      },
-    });
+    };
+    let reply: RootReply;
+    if (anchorBackendNodeId === undefined) {
+      reply = await send<RootReply>("Runtime.evaluate", {
+        expression: "document.documentElement",
+        contextId: world.executionContextId,
+        objectGroup,
+        serializationOptions,
+      });
+    } else {
+      const anchor = await send<{ object?: { objectId?: string } }>("DOM.resolveNode", {
+        backendNodeId: anchorBackendNodeId,
+        executionContextId: world.executionContextId,
+        objectGroup,
+      });
+      if (!anchor.object?.objectId) return "unavailable";
+      reply = await send<RootReply>("Runtime.callFunctionOn", {
+        objectId: anchor.object.objectId,
+        functionDeclaration:
+          "function() { return this.isConnected && this.ownerDocument === document ? document.documentElement : null; }",
+        objectGroup,
+        serializationOptions,
+      });
+    }
     if (!attached()) return "changed";
     const root = reply.result?.deepSerializedValue;
     if (root?.type === "null") return "changed";

--- a/apps/extension/src/tools/vom/document-identity.ts
+++ b/apps/extension/src/tools/vom/document-identity.ts
@@ -11,7 +11,7 @@ export async function verifyDocumentIdentity(
   identity: DocumentIdentity,
   signal?: AbortSignal,
 ): Promise<"current" | "changed" | "unavailable"> {
-  return verifyIdentity(cdp, identity, signal);
+  return (await verifyIdentity(cdp, identity, signal)).status;
 }
 
 /** Verify the visual anchor in its original frame; geometry is checked by screenshot execution. */
@@ -20,7 +20,24 @@ export async function verifyVisualTargetIdentity(
   candidate: VisualCandidate,
   signal?: AbortSignal,
 ): Promise<"current" | "changed" | "unavailable"> {
-  return verifyIdentity(cdp, candidate.document, signal, candidate.backendNodeId);
+  return (await verifyIdentity(cdp, candidate.document, signal, candidate.backendNodeId)).status;
+}
+
+export type VerifiedNodeResult =
+  | { status: "changed" | "unavailable" }
+  | { status: "current"; objectId: string; objectGroup: string };
+
+/** Caller must release objectGroup in finally after its local read. */
+export async function resolveVerifiedNode(
+  cdp: CdpRunner,
+  identity: DocumentIdentity,
+  backendNodeId: number,
+  signal?: AbortSignal,
+): Promise<VerifiedNodeResult> {
+  const result = await verifyIdentity(cdp, identity, signal, backendNodeId, true);
+  return result.status === "current" && result.objectId && result.objectGroup
+    ? { status: "current", objectId: result.objectId, objectGroup: result.objectGroup }
+    : { status: result.status === "changed" ? "changed" : "unavailable" };
 }
 
 async function verifyIdentity(
@@ -28,15 +45,22 @@ async function verifyIdentity(
   identity: DocumentIdentity,
   signal?: AbortSignal,
   anchorBackendNodeId?: number,
-): Promise<"current" | "changed" | "unavailable"> {
+  retain = false,
+): Promise<{
+  status: "current" | "changed" | "unavailable";
+  objectId?: string;
+  objectGroup?: string;
+}> {
   const attached = () => cdp.getAttachmentId?.(identity.target.tabId) === identity.attachmentId;
   throwIfAborted(signal);
-  if (!attached()) return "changed";
+  if (!attached()) return { status: "changed" };
   const objectGroup = `bsk-document-identity-${crypto.randomUUID()}`;
   const send = <T>(method: string, params: object) => {
     throwIfAborted(signal);
     return sendToCdpTarget<T>(cdp, identity.target, method, params);
   };
+  let objectId: string | undefined;
+  let retained = false;
   try {
     const world = await send<{ executionContextId: number }>("Page.createIsolatedWorld", {
       frameId: identity.frameId,
@@ -63,7 +87,8 @@ async function verifyIdentity(
         executionContextId: world.executionContextId,
         objectGroup,
       });
-      if (!anchor.object?.objectId) return "unavailable";
+      if (!anchor.object?.objectId) return { status: "unavailable" };
+      objectId = anchor.object.objectId;
       reply = await send<RootReply>("Runtime.callFunctionOn", {
         objectId: anchor.object.objectId,
         functionDeclaration:
@@ -72,20 +97,24 @@ async function verifyIdentity(
         serializationOptions,
       });
     }
-    if (!attached()) return "changed";
+    if (!attached()) return { status: "changed" };
     const root = reply.result?.deepSerializedValue;
-    if (root?.type === "null") return "changed";
+    if (root?.type === "null") return { status: "changed" };
     const id = root?.type === "node" ? root.value?.backendNodeId : undefined;
-    if (id === undefined) return "unavailable";
-    return id === identity.documentElementBackendNodeId ? "current" : "changed";
+    if (id === undefined) return { status: "unavailable" };
+    if (id !== identity.documentElementBackendNodeId) return { status: "changed" };
+    throwIfAborted(signal);
+    retained = retain && !!objectId;
+    return { status: "current", ...(retained ? { objectId, objectGroup } : {}) };
   } catch (error) {
     throwIfAborted(signal);
     if (isAbortError(error)) throw error;
-    return attached() ? "unavailable" : "changed";
+    return { status: attached() ? "unavailable" : "changed" };
   } finally {
-    await sendToCdpTarget(cdp, identity.target, "Runtime.releaseObjectGroup", {
-      objectGroup,
-    }).catch(() => {});
+    if (!retained)
+      await sendToCdpTarget(cdp, identity.target, "Runtime.releaseObjectGroup", {
+        objectGroup,
+      }).catch(() => {});
     throwIfAborted(signal);
   }
 }

--- a/apps/extension/src/tools/vom/facts.ts
+++ b/apps/extension/src/tools/vom/facts.ts
@@ -30,7 +30,7 @@ export interface NodeFacts extends CapturedNode {
 
 export interface DocumentIndex<T extends DecodedNode = NodeFacts> {
   readonly nodes: ReadonlyMap<number, T>;
-  readonly ancestryComplete: ReadonlyMap<number, boolean>;
+  readonly ancestryComplete?: ReadonlyMap<number, boolean>;
   readonly excludedBackendNodeIds: ReadonlySet<number>;
 }
 
@@ -43,11 +43,12 @@ export interface DecodedDocument {
 export async function buildDocumentIndex<T extends DecodedNode>(
   input: readonly T[],
   signal?: AbortSignal,
+  includeVisualFacts = false,
 ): Promise<DocumentIndex<T>> {
   const checkpoint = createCaptureCheckpoint(signal);
   const nodes = new Map<number, T>();
   const overlayByNode = new Map<number, boolean>();
-  const ancestryComplete = new Map<number, boolean>();
+  const ancestryComplete = includeVisualFacts ? new Map<number, boolean>() : undefined;
   const excludedBackendNodeIds = new Set<number>();
   for (let i = 0; i < input.length; i++) {
     if (i % 256 === 0) {
@@ -84,7 +85,7 @@ export async function buildDocumentIndex<T extends DecodedNode>(
       visiting.add(current.backendNodeId);
       path.push(current);
       if (current.parentBackendNodeId === null) {
-        complete = !current.parentMissing && current.nodeType === 9;
+        if (ancestryComplete) complete = !current.parentMissing && current.nodeType === 9;
         current = undefined;
         break;
       }
@@ -92,7 +93,7 @@ export async function buildDocumentIndex<T extends DecodedNode>(
     }
     if (current && overlayByNode.has(current.backendNodeId)) {
       overlay = overlayByNode.get(current.backendNodeId)!;
-      complete = ancestryComplete.get(current.backendNodeId) === true;
+      if (ancestryComplete) complete = ancestryComplete.get(current.backendNodeId) === true;
     }
     for (let i = path.length - 1; i >= 0; i--) {
       if (work++ % 256 === 0) {
@@ -102,12 +103,14 @@ export async function buildDocumentIndex<T extends DecodedNode>(
       const item = path[i];
       overlay = overlay || isOverlayHostNode(item.tag, Object.keys(item.attrs));
       overlayByNode.set(item.backendNodeId, overlay);
-      complete = complete && !item.parentMissing;
-      ancestryComplete.set(item.backendNodeId, complete);
+      if (ancestryComplete) {
+        complete = complete && !item.parentMissing;
+        ancestryComplete.set(item.backendNodeId, complete);
+      }
       if (overlay) excludedBackendNodeIds.add(item.backendNodeId);
     }
   }
-  return { nodes, ancestryComplete, excludedBackendNodeIds };
+  return { nodes, ...(ancestryComplete ? { ancestryComplete } : {}), excludedBackendNodeIds };
 }
 
 export interface DocumentIdentity {
@@ -158,6 +161,8 @@ export interface DocumentFacts<T extends FrameOwnedAxNode> {
 }
 
 export interface ObservationFacts<T extends FrameOwnedAxNode> {
+  /** Whether visual collection was enabled; partial capture failures remain in issues. */
+  readonly visualFactsCollected: boolean;
   readonly rootFrameId: string;
   readonly viewport: Viewport;
   readonly documents: readonly DocumentFacts<T>[];

--- a/apps/extension/src/tools/vom/facts.ts
+++ b/apps/extension/src/tools/vom/facts.ts
@@ -1,7 +1,8 @@
 import type { Viewport } from "@browser-skill/vom";
 import type { CdpFrame, CdpTarget } from "@/browser-driver/frame-graph";
 import { isOverlayHostNode } from "@/lib/overlay-bridge";
-import type { FrameProjectionIssue } from "../geometry/coordinate-types";
+import type { GeometryProjection } from "../geometry";
+import type { FrameProjectionIssue, SnapshotCoordinates } from "../geometry/coordinate-types";
 import { createCaptureCheckpoint } from "./capture-abort";
 import type { CapturedNode } from "./capture-types";
 import type { FrameOwnedAxNode } from "./frame-document";
@@ -10,21 +11,26 @@ import type { FrameOwnedAxNode } from "./frame-document";
 export interface SnapshotLayout {
   readonly boundsSpace: "snapshot-document-layout";
   bounds?: number[];
+  /** [clientLeft, clientTop, clientWidth, clientHeight], untransformed local CSS units. */
+  clientRect?: number[];
   styles: Readonly<Record<string, string>>;
 }
 
 export interface DecodedNode extends Omit<CapturedNode, "rect" | "localRect" | "rendered"> {
   nodeType?: number;
+  parentMissing?: boolean;
   layout?: SnapshotLayout;
 }
 
 export interface NodeFacts extends CapturedNode {
   nodeType?: number;
+  parentMissing?: boolean;
   layout?: SnapshotLayout;
 }
 
 export interface DocumentIndex<T extends DecodedNode = NodeFacts> {
   readonly nodes: ReadonlyMap<number, T>;
+  readonly ancestryComplete: ReadonlyMap<number, boolean>;
   readonly excludedBackendNodeIds: ReadonlySet<number>;
 }
 
@@ -41,6 +47,7 @@ export async function buildDocumentIndex<T extends DecodedNode>(
   const checkpoint = createCaptureCheckpoint(signal);
   const nodes = new Map<number, T>();
   const overlayByNode = new Map<number, boolean>();
+  const ancestryComplete = new Map<number, boolean>();
   const excludedBackendNodeIds = new Set<number>();
   for (let i = 0; i < input.length; i++) {
     if (i % 256 === 0) {
@@ -61,6 +68,7 @@ export async function buildDocumentIndex<T extends DecodedNode>(
     const visiting = new Set<number>();
     let current: DecodedNode | undefined = node;
     let overlay = false;
+    let complete = false;
     while (current && !overlayByNode.has(current.backendNodeId)) {
       if (work++ % 256 === 0) {
         const pending = checkpoint();
@@ -76,13 +84,16 @@ export async function buildDocumentIndex<T extends DecodedNode>(
       visiting.add(current.backendNodeId);
       path.push(current);
       if (current.parentBackendNodeId === null) {
+        complete = !current.parentMissing && current.nodeType === 9;
         current = undefined;
         break;
       }
       current = nodes.get(current.parentBackendNodeId);
     }
-    if (current && overlayByNode.has(current.backendNodeId))
+    if (current && overlayByNode.has(current.backendNodeId)) {
       overlay = overlayByNode.get(current.backendNodeId)!;
+      complete = ancestryComplete.get(current.backendNodeId) === true;
+    }
     for (let i = path.length - 1; i >= 0; i--) {
       if (work++ % 256 === 0) {
         const pending = checkpoint();
@@ -91,10 +102,12 @@ export async function buildDocumentIndex<T extends DecodedNode>(
       const item = path[i];
       overlay = overlay || isOverlayHostNode(item.tag, Object.keys(item.attrs));
       overlayByNode.set(item.backendNodeId, overlay);
+      complete = complete && !item.parentMissing;
+      ancestryComplete.set(item.backendNodeId, complete);
       if (overlay) excludedBackendNodeIds.add(item.backendNodeId);
     }
   }
-  return { nodes, excludedBackendNodeIds };
+  return { nodes, ancestryComplete, excludedBackendNodeIds };
 }
 
 export interface DocumentIdentity {
@@ -127,7 +140,16 @@ export interface CaptureIssue {
     | "geometry-unavailable";
 }
 
+/** Shared per document; never retain the live GeometryContext in published facts. */
+export interface DocumentGeometry {
+  readonly projections: readonly GeometryProjection[];
+  readonly coordinates: SnapshotCoordinates;
+  /** Visual viewport scale (pinch), distinct from browser UI zoom. */
+  readonly pageScale?: number;
+}
+
 export interface DocumentFacts<T extends FrameOwnedAxNode> {
+  readonly geometry?: DocumentGeometry;
   readonly frame: CdpFrame;
   readonly identity?: DocumentIdentity;
   readonly index: DocumentIndex;

--- a/apps/extension/src/tools/vom/normalize.ts
+++ b/apps/extension/src/tools/vom/normalize.ts
@@ -18,7 +18,13 @@ import {
   isAbortError as isCaptureAbort,
   throwIfAborted as throwCaptureAborted,
 } from "./capture-abort";
-import { buildDocumentIndex, type CaptureIssue, type DocumentIndex, type NodeFacts } from "./facts";
+import {
+  buildDocumentIndex,
+  type CaptureIssue,
+  type DocumentGeometry,
+  type DocumentIndex,
+  type NodeFacts,
+} from "./facts";
 import {
   decodeDocument,
   type SnapshotDocument,
@@ -33,9 +39,11 @@ export interface FrameContext {
   targetProjection?: GeometryProjection | null;
   target: CdpTarget;
   coordinates: SnapshotCoordinates | null;
+  pageScale?: number;
 }
 
 export interface NormalizedDocument {
+  geometry?: DocumentGeometry;
   nodes: NodeFacts[];
   index: DocumentIndex;
   documentElementBackendNodeId?: number;
@@ -99,6 +107,20 @@ export async function normalizeDocument(
       (node) => !node.tag.startsWith("#") && !index.excludedBackendNodeIds.has(node.backendNodeId),
     ),
     index,
+    ...(context.coordinates &&
+    context.projection?.status === "available" &&
+    context.targetProjection !== null
+      ? {
+          geometry: {
+            projections: [
+              context.projection.projection.geometry,
+              ...(context.targetProjection ? [context.targetProjection] : []),
+            ],
+            coordinates: context.coordinates,
+            pageScale: context.pageScale,
+          },
+        }
+      : {}),
     documentElementBackendNodeId: nodes.find(
       (node) =>
         node.nodeType === 1 &&
@@ -313,6 +335,7 @@ export async function normalizeSnapshot(
         frameId: frame.frameId,
         ownerFrameBackendNodeId: frame.ownerBackendNodeId ?? null,
         projection: state,
+        pageScale: metrics.cssVisualViewport?.scale ?? metrics.visualViewport?.scale,
         target,
         ...(target.sessionId ? { targetProjection } : {}),
         coordinates,

--- a/apps/extension/src/tools/vom/normalize.ts
+++ b/apps/extension/src/tools/vom/normalize.ts
@@ -26,8 +26,10 @@ import {
   type NodeFacts,
 } from "./facts";
 import {
+  BASIC_SNAPSHOT,
   decodeDocument,
   type SnapshotDocument,
+  type SnapshotProfile,
   type SnapshotReply,
   snapshotFrameId,
 } from "./snapshot";
@@ -55,8 +57,9 @@ export async function normalizeDocument(
   strings: string[],
   context: FrameContext,
   signal?: AbortSignal,
+  profile: SnapshotProfile = BASIC_SNAPSHOT,
 ): Promise<NormalizedDocument> {
-  const decoded = await decodeDocument(doc, strings, signal);
+  const decoded = await decodeDocument(doc, strings, signal, profile);
   const checkpoint = createCaptureCheckpoint(signal);
   const nodes: NodeFacts[] = [];
   for (let i = 0; i < decoded.nodes.length; i++) {
@@ -101,13 +104,14 @@ export async function normalizeDocument(
         (Number.parseFloat(opacity) || 0) > 0,
     });
   }
-  const index = await buildDocumentIndex(nodes, signal);
+  const index = await buildDocumentIndex(nodes, signal, profile.includeVisualFacts);
   return {
     nodes: nodes.filter(
       (node) => !node.tag.startsWith("#") && !index.excludedBackendNodeIds.has(node.backendNodeId),
     ),
     index,
-    ...(context.coordinates &&
+    ...(profile.includeVisualFacts &&
+    context.coordinates &&
     context.projection?.status === "available" &&
     context.targetProjection !== null
       ? {
@@ -144,6 +148,7 @@ export async function normalizeSnapshot(
   issues: CaptureIssue[],
   signal?: AbortSignal,
   rootFrameId?: string,
+  profile: SnapshotProfile = BASIC_SNAPSHOT,
 ): Promise<NormalizedFrameDocument[]> {
   const strings = snapshot.strings ?? [];
   const raw = snapshot.documents ?? [];
@@ -335,12 +340,15 @@ export async function normalizeSnapshot(
         frameId: frame.frameId,
         ownerFrameBackendNodeId: frame.ownerBackendNodeId ?? null,
         projection: state,
-        pageScale: metrics.cssVisualViewport?.scale ?? metrics.visualViewport?.scale,
+        ...(profile.includeVisualFacts
+          ? { pageScale: metrics.cssVisualViewport?.scale ?? metrics.visualViewport?.scale }
+          : {}),
         target,
         ...(target.sessionId ? { targetProjection } : {}),
         coordinates,
       },
       signal,
+      profile,
     );
     result.push({ ...normalized, frame });
   }

--- a/apps/extension/src/tools/vom/snapshot.ts
+++ b/apps/extension/src/tools/vom/snapshot.ts
@@ -8,6 +8,19 @@ export const REQUESTED_STYLES = [
   "cursor",
   "visibility",
   "opacity",
+  "display",
+  "overflow-x",
+  "overflow-y",
+  "transform",
+  "zoom",
+  "clip-path",
+  "mask-image",
+  "rotate",
+  "scale",
+  "perspective",
+  "clip",
+  "contain",
+  "overflow-clip-margin",
 ] as const;
 const STYLE_COL = Object.fromEntries(
   REQUESTED_STYLES.map((name, index) => [name, index]),
@@ -49,6 +62,7 @@ export interface SnapshotDocument {
     nodeIndex?: number[];
     styles?: number[][];
     bounds?: number[][];
+    clientRects?: number[][];
     paintOrders?: number[];
   };
 }
@@ -177,6 +191,7 @@ export async function decodeDocument(
         : {
             boundsSpace: "snapshot-document-layout" as const,
             bounds: dl?.bounds?.[li],
+            ...(dl?.clientRects?.[li] ? { clientRect: dl.clientRects[li] } : {}),
             styles,
           };
 
@@ -200,6 +215,9 @@ export async function decodeDocument(
       backendNodeId,
       nodeType: dn.nodeType?.[n],
       parentBackendNodeId,
+      ...(dn.parentIndex?.[n] === undefined || (parentIdx >= 0 && parentBackendNodeId === null)
+        ? { parentMissing: true }
+        : {}),
 
       tag,
       attrs,

--- a/apps/extension/src/tools/vom/snapshot.ts
+++ b/apps/extension/src/tools/vom/snapshot.ts
@@ -23,6 +23,8 @@ export const VISUAL_STYLES = [
   "perspective",
   "clip",
   "contain",
+  "content-visibility",
+  "container-type",
   "overflow-clip-margin",
 ] as const;
 

--- a/apps/extension/src/tools/vom/snapshot.ts
+++ b/apps/extension/src/tools/vom/snapshot.ts
@@ -8,6 +8,9 @@ export const REQUESTED_STYLES = [
   "cursor",
   "visibility",
   "opacity",
+] as const;
+export const VISUAL_STYLES = [
+  ...REQUESTED_STYLES,
   "display",
   "overflow-x",
   "overflow-y",
@@ -22,9 +25,14 @@ export const REQUESTED_STYLES = [
   "contain",
   "overflow-clip-margin",
 ] as const;
-const STYLE_COL = Object.fromEntries(
-  REQUESTED_STYLES.map((name, index) => [name, index]),
-) as Record<(typeof REQUESTED_STYLES)[number], number>;
+
+/** The same profile owns request columns, decoding and visual-only derived facts. */
+export const BASIC_SNAPSHOT = {
+  includeVisualFacts: false,
+  computedStyles: REQUESTED_STYLES,
+} as const;
+export const VISUAL_SNAPSHOT = { includeVisualFacts: true, computedStyles: VISUAL_STYLES } as const;
+export type SnapshotProfile = typeof BASIC_SNAPSHOT | typeof VISUAL_SNAPSHOT;
 /** Sparse array format Chrome uses for infrequently-set per-node fields. */
 interface SparseArray {
   index: number[];
@@ -117,6 +125,7 @@ export async function decodeDocument(
   doc: SnapshotDocument,
   strings: string[],
   signal?: AbortSignal,
+  profile: SnapshotProfile = BASIC_SNAPSHOT,
 ): Promise<DecodedDocument> {
   const checkpoint = createCaptureCheckpoint(signal);
   const dn = doc.nodes;
@@ -184,14 +193,17 @@ export async function decodeDocument(
     const li = layoutByNode.get(n);
     const styleRow = li === undefined ? [] : (dl?.styles?.[li] ?? []);
     const styles: Record<string, string> = {};
-    for (const name of REQUESTED_STYLES) styles[name] = str(strings, styleRow[STYLE_COL[name]]);
+    for (let i = 0; i < profile.computedStyles.length; i++)
+      styles[profile.computedStyles[i]] = str(strings, styleRow[i]);
     const layout =
       li === undefined
         ? undefined
         : {
             boundsSpace: "snapshot-document-layout" as const,
             bounds: dl?.bounds?.[li],
-            ...(dl?.clientRects?.[li] ? { clientRect: dl.clientRects[li] } : {}),
+            ...(profile.includeVisualFacts && dl?.clientRects?.[li]
+              ? { clientRect: dl.clientRects[li] }
+              : {}),
             styles,
           };
 
@@ -215,7 +227,8 @@ export async function decodeDocument(
       backendNodeId,
       nodeType: dn.nodeType?.[n],
       parentBackendNodeId,
-      ...(dn.parentIndex?.[n] === undefined || (parentIdx >= 0 && parentBackendNodeId === null)
+      ...(profile.includeVisualFacts &&
+      (dn.parentIndex?.[n] === undefined || (parentIdx >= 0 && parentBackendNodeId === null))
         ? { parentMissing: true }
         : {}),
 

--- a/apps/extension/src/tools/vom/visual-dedup.ts
+++ b/apps/extension/src/tools/vom/visual-dedup.ts
@@ -6,12 +6,13 @@ export const MAX_VISUAL_DEDUP_KEYS = 50_000;
 export interface VisualDedupResult extends VisualDiscoveryResult {
   /** Known valid candidates in this capture, not the total Canvas count on the page. */
   readonly candidateCount: number;
-  /** Candidates actually removed by exact coverage deduplication. */
+  /** Repeated records removed for the same Canvas identity, parent and crop. */
   readonly deduplicatedCount: number;
   readonly dedupDegraded: boolean;
 }
 
-/** Keep the first real anchor for each exact DOM/parent/crop key, in encounter order.
+/** Deduplicate records of the same Canvas identity, parent and crop, in encounter order.
+ * Equal coverage does not make distinct Canvas nodes interchangeable.
  * Once the key set is full, unknown keys pass through: capacity never drops candidates. */
 export async function deduplicateVisualCandidates(
   discovery: VisualDiscoveryResult,
@@ -38,6 +39,7 @@ export async function deduplicateVisualCandidates(
       document.target.sessionId ?? null,
       document.frameId,
       document.documentElementBackendNodeId,
+      candidate.backendNodeId,
       candidate.parentBackendNodeId,
       crop.x,
       crop.y,

--- a/apps/extension/src/tools/vom/visual-dedup.ts
+++ b/apps/extension/src/tools/vom/visual-dedup.ts
@@ -1,0 +1,64 @@
+import { createCaptureCheckpoint } from "./capture-abort";
+import type { VisualCandidate, VisualDiscoveryResult } from "./visual-discovery";
+
+export const MAX_VISUAL_DEDUP_KEYS = 50_000;
+
+export interface VisualDedupResult extends VisualDiscoveryResult {
+  /** Known valid candidates in this capture, not the total Canvas count on the page. */
+  readonly candidateCount: number;
+  /** Candidates actually removed by exact coverage deduplication. */
+  readonly deduplicatedCount: number;
+  readonly dedupDegraded: boolean;
+}
+
+/** Keep the first real anchor for each exact DOM/parent/crop key, in encounter order.
+ * Once the key set is full, unknown keys pass through: capacity never drops candidates. */
+export async function deduplicateVisualCandidates(
+  discovery: VisualDiscoveryResult,
+  signal?: AbortSignal,
+): Promise<VisualDedupResult> {
+  const checkpoint = createCaptureCheckpoint(signal);
+  const keys = new Set<string>();
+  const candidates: VisualCandidate[] = [];
+  let deduplicatedCount = 0;
+  let dedupDegraded = false;
+  for (let i = 0; i < discovery.candidates.length; i++) {
+    if (i % 256 === 0) {
+      const pending = checkpoint();
+      if (pending) await pending;
+    }
+    const candidate = discovery.candidates[i];
+    const {
+      document,
+      region: { crop },
+    } = candidate;
+    const key = JSON.stringify([
+      document.attachmentId,
+      document.target.tabId,
+      document.target.sessionId ?? null,
+      document.frameId,
+      document.documentElementBackendNodeId,
+      candidate.parentBackendNodeId,
+      crop.x,
+      crop.y,
+      crop.width,
+      crop.height,
+    ]);
+    if (keys.has(key)) {
+      deduplicatedCount++;
+      continue;
+    }
+    if (keys.size < MAX_VISUAL_DEDUP_KEYS) keys.add(key);
+    else dedupDegraded = true;
+    candidates.push(candidate);
+  }
+  const pending = checkpoint();
+  if (pending) await pending;
+  return {
+    ...discovery,
+    candidates,
+    candidateCount: discovery.candidates.length,
+    deduplicatedCount,
+    dedupDegraded,
+  };
+}

--- a/apps/extension/src/tools/vom/visual-discovery.ts
+++ b/apps/extension/src/tools/vom/visual-discovery.ts
@@ -20,11 +20,19 @@ import {
   visualProjectionIssue,
 } from "./visual-region";
 
+/** Shared observation-time addresses, not cached live geometry. */
+export interface VisualFramePath {
+  readonly document: DocumentIdentity;
+  readonly parent?: { readonly ownerBackendNodeId: number; readonly frame: VisualFramePath };
+}
+
 export interface VisualCandidate {
   readonly document: DocumentIdentity;
   readonly backendNodeId: number;
   readonly parentBackendNodeId: number | null;
   readonly label?: string;
+  /** Absent when execution ancestry could not be established; discovery is still retained. */
+  readonly framePath?: VisualFramePath;
   readonly region: Extract<VisualRegionResult, { status: "available" }>;
 }
 
@@ -113,6 +121,7 @@ export async function discoverVisualCandidates(
   const candidates: VisualCandidate[] = [];
   const issues: VisualDiscoveryIssue[] = [];
   const documents = new Map(facts.documents.map((document) => [document.frame.frameId, document]));
+  const framePaths = new Map<string, VisualFramePath>();
   const contexts = new Map<string, Map<number, NodeContext>>();
   const roots = new Map<string, VisualContext>();
 
@@ -248,6 +257,16 @@ export async function discoverVisualCandidates(
           root.issue ??
           (!doc.identity ? "identity-unverified" : visualProjectionIssue(doc.geometry)),
       };
+      if (doc.identity) {
+        const parentPath = frame.parentFrameId ? framePaths.get(frame.parentFrameId) : undefined;
+        if (!frame.parentFrameId && frame.frameId === facts.rootFrameId)
+          framePaths.set(frame.frameId, { document: doc.identity });
+        else if (parentPath && frame.ownerBackendNodeId !== undefined)
+          framePaths.set(frame.frameId, {
+            document: doc.identity,
+            parent: { ownerBackendNodeId: frame.ownerBackendNodeId, frame: parentPath },
+          });
+      }
       roots.set(frame.frameId, root);
       contexts.set(frame.frameId, new Map());
     }
@@ -291,6 +310,7 @@ export async function discoverVisualCandidates(
         const label = node.attrs["aria-label"]?.trim() || node.attrs.title?.trim();
         candidates.push({
           document: document.identity,
+          framePath: framePaths.get(document.frame.frameId),
           backendNodeId: node.backendNodeId,
           parentBackendNodeId: node.parentBackendNodeId,
           ...(label ? { label } : {}),

--- a/apps/extension/src/tools/vom/visual-discovery.ts
+++ b/apps/extension/src/tools/vom/visual-discovery.ts
@@ -1,0 +1,307 @@
+import { type CdpTarget } from "@/browser-driver/frame-graph";
+import type { ViewportRect } from "../geometry";
+import { createCaptureCheckpoint } from "./capture-abort";
+import type {
+  CaptureIssue,
+  DocumentFacts,
+  DocumentIdentity,
+  NodeFacts,
+  ObservationFacts,
+} from "./facts";
+import type { FrameOwnedAxNode } from "./frame-document";
+import {
+  EMPTY_VISUAL_CONTEXT,
+  extendVisualContext,
+  projectVisualBox,
+  resolveVisualRegion,
+  type VisualContext,
+  type VisualIssueReason,
+  type VisualRegionResult,
+  visualProjectionIssue,
+} from "./visual-region";
+
+export interface VisualCandidate {
+  readonly document: DocumentIdentity;
+  readonly backendNodeId: number;
+  readonly parentBackendNodeId: number | null;
+  readonly label?: string;
+  readonly region: Extract<VisualRegionResult, { status: "available" }>;
+}
+
+export interface VisualDiscoveryIssue {
+  readonly target: CdpTarget;
+  readonly frameId: string;
+  readonly backendNodeId?: number;
+  readonly reason: VisualIssueReason;
+}
+
+export interface VisualDiscoveryResult {
+  readonly candidates: readonly VisualCandidate[];
+  readonly issues: readonly VisualDiscoveryIssue[];
+  /** Preserve upstream failures, including those that do not invalidate Canvas geometry. */
+  readonly captureIssues: readonly CaptureIssue[];
+  readonly complete: boolean;
+}
+
+type Document = DocumentFacts<FrameOwnedAxNode>;
+interface NodeContext {
+  self: VisualContext;
+  children: VisualContext;
+}
+
+function viewportRect(
+  rect: { x: number; y: number; w: number; h: number } | null | undefined,
+): ViewportRect | null {
+  return rect ? { x: rect.x, y: rect.y, width: rect.w, height: rect.h } : null;
+}
+
+/** Client offsets are unscaled local CSS units. Only ordinary, untransformed
+ * overflow chains consume this adapter; other combinations are rejected by policy. */
+function clientBox(node: NodeFacts, document: Document): ViewportRect | null {
+  const client = node.layout?.clientRect;
+  const bounds = node.layout?.bounds;
+  const border =
+    node.localRect ??
+    (bounds?.length === 4 && bounds.every(Number.isFinite) && document.geometry
+      ? {
+          x:
+            bounds[0] / document.geometry.coordinates.layoutUnitsPerCssPixel -
+            document.geometry.coordinates.scrollCss.x,
+          y:
+            bounds[1] / document.geometry.coordinates.layoutUnitsPerCssPixel -
+            document.geometry.coordinates.scrollCss.y,
+        }
+      : null);
+  if (
+    !client ||
+    client.length !== 4 ||
+    !client.every(Number.isFinite) ||
+    client[2] < 0 ||
+    client[3] < 0 ||
+    !border ||
+    !document.geometry
+  )
+    return null;
+  return projectVisualBox(
+    { x: border.x + client[0], y: border.y + client[1], width: client[2], height: client[3] },
+    document.geometry.projections,
+  );
+}
+
+/** Pure Facts consumer: no CDP, ref registration, selection, or semantic keep/drop.
+ * Both frame and node ancestry are memoized in this call, using iterative walks. */
+export async function discoverVisualCandidates(
+  facts: ObservationFacts<FrameOwnedAxNode>,
+  signal?: AbortSignal,
+): Promise<VisualDiscoveryResult> {
+  const checkpoint = createCaptureCheckpoint(signal);
+  let work = 0;
+  const candidates: VisualCandidate[] = [];
+  const issues: VisualDiscoveryIssue[] = [];
+  const documents = new Map(facts.documents.map((document) => [document.frame.frameId, document]));
+  const contexts = new Map<string, Map<number, NodeContext>>();
+  const roots = new Map<string, VisualContext>();
+
+  async function nodeContext(document: Document, id: number): Promise<NodeContext> {
+    const cache = contexts.get(document.frame.frameId)!;
+    const path: NodeFacts[] = [];
+    let node = document.index.nodes.get(id);
+    while (node && !cache.has(node.backendNodeId)) {
+      if (work++ % 256 === 0) {
+        const pending = checkpoint();
+        if (pending) await pending;
+      }
+      if (
+        !document.index.ancestryComplete.get(node.backendNodeId) ||
+        path.length >= document.index.nodes.size
+      ) {
+        const incomplete = {
+          ...roots.get(document.frame.frameId)!,
+          issue: roots.get(document.frame.frameId)!.issue ?? ("ancestry-incomplete" as const),
+        };
+        cache.set(node.backendNodeId, { self: incomplete, children: incomplete });
+        break;
+      }
+      path.push(node);
+      node =
+        node.parentBackendNodeId === null
+          ? undefined
+          : document.index.nodes.get(node.parentBackendNodeId);
+    }
+    let parent = node
+      ? cache.get(node.backendNodeId)!.children
+      : roots.get(document.frame.frameId)!;
+    for (let i = path.length - 1; i >= 0; i--) {
+      if (work++ % 256 === 0) {
+        const pending = checkpoint();
+        if (pending) await pending;
+      }
+      const current = path[i];
+      let self = parent;
+      let children = parent;
+      if (document.index.excludedBackendNodeIds.has(current.backendNodeId)) {
+        self = children = { ...parent, hidden: true };
+      } else if (current.nodeType === 1) {
+        if (!current.layout) {
+          // An element without layout is not evidence that descendants are hidden
+          // (e.g. a boxless ancestor). Keep the missing style evidence explicit.
+          self = children = { ...parent, issue: parent.issue ?? "facts-unavailable" };
+        } else if (document.identity) {
+          const ancestor = {
+            document: document.identity,
+            backendNodeId: current.backendNodeId,
+            styles: current.layout.styles,
+            clientBox: clientBox(current, document),
+          };
+          children = extendVisualContext(
+            parent,
+            ancestor,
+            current.tag !== "iframe" && current.tag !== "frame",
+          );
+          self = current.tag === "canvas" ? extendVisualContext(parent, ancestor, false) : children;
+        }
+      }
+      const result = { self, children };
+      cache.set(current.backendNodeId, result);
+      parent = children;
+    }
+    return (
+      cache.get(id) ?? {
+        self: { ...parent, issue: "ancestry-incomplete" },
+        children: { ...parent, issue: "ancestry-incomplete" },
+      }
+    );
+  }
+
+  // Process parent documents first, independent of snapshot/target completion order.
+  for (const document of facts.documents) {
+    const path: Document[] = [];
+    const visiting = new Set<string>();
+    let current: Document | undefined = document;
+    while (current && !roots.has(current.frame.frameId)) {
+      if (work++ % 256 === 0) {
+        const pending = checkpoint();
+        if (pending) await pending;
+      }
+      if (visiting.has(current.frame.frameId)) {
+        roots.set(current.frame.frameId, {
+          ...EMPTY_VISUAL_CONTEXT,
+          issue: "ownership-unresolved",
+        });
+        contexts.set(current.frame.frameId, new Map());
+        break;
+      }
+      visiting.add(current.frame.frameId);
+      path.push(current);
+      current = current.frame.parentFrameId
+        ? documents.get(current.frame.parentFrameId)
+        : undefined;
+    }
+    for (let i = path.length - 1; i >= 0; i--) {
+      const doc = path[i];
+      const { frame } = doc;
+      let root: VisualContext = roots.get(frame.frameId) ?? EMPTY_VISUAL_CONTEXT;
+      if (frame.parentFrameId) {
+        const parent = documents.get(frame.parentFrameId);
+        if (
+          !parent ||
+          !roots.has(parent.frame.frameId) ||
+          frame.ownerBackendNodeId === undefined ||
+          !parent.identity
+        ) {
+          root = { ...root, issue: "ownership-unresolved" };
+        } else {
+          const owner = parent.index.nodes.get(frame.ownerBackendNodeId);
+          const ownerState = await nodeContext(parent, frame.ownerBackendNodeId);
+          root = {
+            ...ownerState.children,
+            // CSS visibility inside a child document cannot override its hidden owner.
+            hidden:
+              ownerState.children.hidden ||
+              owner?.layout?.styles.visibility === "hidden" ||
+              owner?.layout?.styles.visibility === "collapse",
+            // Frame scaling is already interpreted by the shared content-quad projection.
+            transformed: false,
+            localClip: false,
+            unpositionedClip: false,
+          };
+        }
+      } else if (frame.frameId !== facts.rootFrameId)
+        root = { ...root, issue: "ownership-unresolved" };
+      root = {
+        ...root,
+        issue:
+          root.issue ??
+          (!doc.identity ? "identity-unverified" : visualProjectionIssue(doc.geometry)),
+      };
+      roots.set(frame.frameId, root);
+      contexts.set(frame.frameId, new Map());
+    }
+  }
+
+  for (const document of facts.documents) {
+    for (const node of document.index.nodes.values()) {
+      if (work++ % 256 === 0) {
+        const pending = checkpoint();
+        if (pending) await pending;
+      }
+      if (node.tag !== "canvas" || document.index.excludedBackendNodeIds.has(node.backendNodeId))
+        continue;
+      // No layout/zero size is positive evidence of no screenshot area for this node.
+      if (!node.layout) continue;
+      const bounds = node.layout.bounds;
+      if (
+        bounds?.length === 4 &&
+        bounds.every(Number.isFinite) &&
+        (bounds[2] <= 0 || bounds[3] <= 0)
+      )
+        continue;
+      const context = (await nodeContext(document, node.backendNodeId)).self;
+      const local = viewportRect(node.localRect);
+      const borderBox =
+        local && document.geometry ? projectVisualBox(local, document.geometry.projections) : null;
+      const region = resolveVisualRegion({
+        borderBox,
+        frameVisibleBox: viewportRect(node.rect),
+        context,
+        visibility: node.layout.styles.visibility,
+      });
+      if (region.status === "unavailable") {
+        issues.push({
+          target: document.frame.target,
+          frameId: document.frame.frameId,
+          backendNodeId: node.backendNodeId,
+          reason: region.reason,
+        });
+      } else if (region.status === "available" && document.identity) {
+        const label = node.attrs["aria-label"]?.trim() || node.attrs.title?.trim();
+        candidates.push({
+          document: document.identity,
+          backendNodeId: node.backendNodeId,
+          parentBackendNodeId: node.parentBackendNodeId,
+          ...(label ? { label } : {}),
+          region,
+        });
+      }
+    }
+  }
+  // AX-only/missing documents have no Canvas nodes to carry the missing evidence.
+  const reportedFrames = new Set(issues.map((issue) => issue.frameId));
+  for (const document of facts.documents) {
+    const reason = roots.get(document.frame.frameId)?.issue;
+    if (
+      reason &&
+      !reportedFrames.has(document.frame.frameId) &&
+      (!document.identity || !document.index.nodes.size)
+    )
+      issues.push({ target: document.frame.target, frameId: document.frame.frameId, reason });
+  }
+  const pending = checkpoint();
+  if (pending) await pending;
+  return {
+    candidates,
+    issues,
+    captureIssues: facts.issues,
+    complete: issues.length === 0 && facts.issues.length === 0,
+  };
+}

--- a/apps/extension/src/tools/vom/visual-discovery.ts
+++ b/apps/extension/src/tools/vom/visual-discovery.ts
@@ -17,6 +17,7 @@ import {
   type VisualContext,
   type VisualIssueReason,
   type VisualRegionResult,
+  viewportOverflowSource,
   visualProjectionIssue,
 } from "./visual-region";
 
@@ -124,6 +125,7 @@ export async function discoverVisualCandidates(
   const framePaths = new Map<string, VisualFramePath>();
   const contexts = new Map<string, Map<number, NodeContext>>();
   const roots = new Map<string, VisualContext>();
+  const overflowSources = new Map<string, number | undefined>();
 
   async function nodeContext(document: Document, id: number): Promise<NodeContext> {
     const cache = contexts.get(document.frame.frameId)!;
@@ -179,7 +181,9 @@ export async function discoverVisualCandidates(
           children = extendVisualContext(
             parent,
             ancestor,
-            current.tag !== "iframe" && current.tag !== "frame",
+            current.tag !== "iframe" &&
+              current.tag !== "frame" &&
+              current.backendNodeId !== overflowSources.get(document.frame.frameId),
           );
           self = current.tag === "canvas" ? extendVisualContext(parent, ancestor, false) : children;
         }
@@ -223,6 +227,23 @@ export async function discoverVisualCandidates(
     for (let i = path.length - 1; i >= 0; i--) {
       const doc = path[i];
       const { frame } = doc;
+      const documentRoot = doc.identity
+        ? doc.index.nodes.get(doc.identity.documentElementBackendNodeId)
+        : undefined;
+      const body = doc.domNodes.find(
+        (node) => node.tag === "body" && node.parentBackendNodeId === documentRoot?.backendNodeId,
+      );
+      const overflowElement = (node: NodeFacts | undefined) =>
+        node?.layout
+          ? { backendNodeId: node.backendNodeId, tag: node.tag, styles: node.layout.styles }
+          : undefined;
+      overflowSources.set(
+        frame.frameId,
+        viewportOverflowSource(
+          overflowElement(documentRoot),
+          overflowElement(body ? doc.index.nodes.get(body.backendNodeId) : undefined),
+        ),
+      );
       let root: VisualContext = roots.get(frame.frameId) ?? EMPTY_VISUAL_CONTEXT;
       if (frame.parentFrameId) {
         const parent = documents.get(frame.parentFrameId);

--- a/apps/extension/src/tools/vom/visual-discovery.ts
+++ b/apps/extension/src/tools/vom/visual-discovery.ts
@@ -28,12 +28,19 @@ export interface VisualCandidate {
   readonly region: Extract<VisualRegionResult, { status: "available" }>;
 }
 
-export interface VisualDiscoveryIssue {
-  readonly target: CdpTarget;
-  readonly frameId: string;
-  readonly backendNodeId?: number;
-  readonly reason: VisualIssueReason;
-}
+export type VisualDiscoveryIssue =
+  | {
+      readonly reason: "visual-facts-not-collected";
+      readonly target?: never;
+      readonly frameId?: never;
+      readonly backendNodeId?: never;
+    }
+  | {
+      readonly target: CdpTarget;
+      readonly frameId: string;
+      readonly backendNodeId?: number;
+      readonly reason: VisualIssueReason;
+    };
 
 export interface VisualDiscoveryResult {
   readonly candidates: readonly VisualCandidate[];
@@ -95,6 +102,13 @@ export async function discoverVisualCandidates(
   signal?: AbortSignal,
 ): Promise<VisualDiscoveryResult> {
   const checkpoint = createCaptureCheckpoint(signal);
+  if (!facts.visualFactsCollected)
+    return {
+      candidates: [],
+      complete: false,
+      captureIssues: facts.issues,
+      issues: [{ reason: "visual-facts-not-collected" }],
+    };
   let work = 0;
   const candidates: VisualCandidate[] = [];
   const issues: VisualDiscoveryIssue[] = [];
@@ -112,7 +126,7 @@ export async function discoverVisualCandidates(
         if (pending) await pending;
       }
       if (
-        !document.index.ancestryComplete.get(node.backendNodeId) ||
+        !document.index.ancestryComplete?.get(node.backendNodeId) ||
         path.length >= document.index.nodes.size
       ) {
         const incomplete = {

--- a/apps/extension/src/tools/vom/visual-observation.ts
+++ b/apps/extension/src/tools/vom/visual-observation.ts
@@ -95,6 +95,13 @@ export function attachVisualEntries(
           : {}),
         parentId,
         sourceId: own,
+        rect: {
+          x: c.region.crop.x,
+          y: c.region.crop.y,
+          w: c.region.crop.width,
+          h: c.region.crop.height,
+        },
+        paintOrder: source?.vom.paintOrder,
         beforeId: own ?? list[lo]?.id,
         label: c.label,
         frameId: c.document.frameId,
@@ -159,6 +166,7 @@ interface Page {
   refs: RenderedRef[];
   more: boolean;
   frameIds: Set<string>;
+  consumed: number;
 }
 interface Continuation {
   output: ObservationOutput;
@@ -186,6 +194,7 @@ function page(
   state: Continuation,
   budget: number | undefined,
   continued: boolean,
+  nextToken: string,
 ): Page | RpcError {
   const max = budget ?? Infinity;
   if (!(max >= 0) || Number.isNaN(max)) return failure("max_tokens must be nonnegative");
@@ -193,7 +202,7 @@ function page(
     ...state.output.render.headers,
     ...(continued ? ["@continued same observation; only refs in this response are current."] : []),
   ];
-  const footer = `@more observe --cursor ${state.token}; use this page's refs before continuing.`;
+  const footer = `@more observe --cursor ${nextToken}; use this page's refs before continuing.`;
   if (continued && state.buffer[0]?.context) headers.push(state.buffer[0].context);
   const fixed = [...headers, ...state.output.notices];
   let used = fixed.reduce((n, line) => n + cost(line), 0);
@@ -204,14 +213,14 @@ function page(
   let emitted = 0;
   while (true) {
     // One-row lookahead avoids reserving a continuation footer on the final row.
-    while (state.buffer.length < 2 && !state.exhausted) {
+    while (state.buffer.length < emitted + 2 && !state.exhausted) {
       const next = state.output.render.rows.next();
       if (next.done) state.exhausted = true;
       else state.buffer.push(next.value);
     }
-    const row = state.buffer[0];
+    const row = state.buffer[emitted];
     if (!row) break;
-    const reserve = state.buffer.length > 1 || !state.exhausted ? cost(footer) : 0;
+    const reserve = state.buffer.length > emitted + 1 || !state.exhausted ? cost(footer) : 0;
     let text = row.text;
     if (used + cost(text) + reserve > max && row.minimal) text = row.minimal;
     if (used + cost(text) + reserve > max) {
@@ -223,12 +232,11 @@ function page(
     lines.push(text);
     used += cost(text);
     emitted++;
-    state.buffer.shift();
   }
   lines.push(...state.output.notices);
-  const more = state.buffer.length > 0 || !state.exhausted;
+  const more = state.buffer.length > emitted || !state.exhausted;
   if (more) lines.push(footer);
-  return { text: lines.join("\n"), refs, more, frameIds };
+  return { text: lines.join("\n"), refs, more, frameIds, consumed: emitted };
 }
 
 export async function publishObservationPage(
@@ -264,13 +272,9 @@ export async function publishObservationPage(
     return failure("retry this cursor with the same budget, or use next_cursor");
   // Retry retains exactly the latest output; it cannot advance the iterator twice.
   const retry = input.cursor && state.last?.input === input.cursor ? state.last : undefined;
-  const previousToken = state.token;
-  if (input.cursor && !retry) state.token = crypto.randomUUID();
-  const rendered = retry ? undefined : page(state, budget, !!input.cursor);
-  if (rendered && "code" in rendered) {
-    state.token = previousToken;
-    return rendered;
-  }
+  const nextToken = crypto.randomUUID();
+  const rendered = retry ? undefined : page(state, budget, !!input.cursor, nextToken);
+  if (rendered && "code" in rendered) return rendered;
   const identities = new Map<string, DocumentIdentity>(retry?.identities);
   if (state.output.rootIdentity)
     identities.set(state.output.rootIdentity.frameId, state.output.rootIdentity);
@@ -289,12 +293,12 @@ export async function publishObservationPage(
   }
   if (input.cursor) {
     if (!state.output.rootIdentity || missingIdentity) {
-      continuations.delete(store);
+      if (continuations.get(store) === state) continuations.delete(store);
       return failure("observation identity unavailable; observe again");
     }
     for (const identity of identities.values()) {
       if ((await verifyDocumentIdentity(cdp, identity, signal)) !== "current") {
-        continuations.delete(store);
+        if (continuations.get(store) === state) continuations.delete(store);
         return failure("observation DOM changed; observe again");
       }
     }
@@ -320,7 +324,10 @@ export async function publishObservationPage(
       },
     ];
   });
+  // Publish only after validation; cancelled preparation leaves buffered rows and refs intact.
   store.replace(entries);
+  state.buffer.splice(0, rendered!.consumed);
+  state.token = nextToken;
   state.revision = store.revision;
   const result: ObserveResult = {
     text: rendered!.text,

--- a/apps/extension/src/tools/vom/visual-observation.ts
+++ b/apps/extension/src/tools/vom/visual-observation.ts
@@ -317,6 +317,7 @@ export async function publishObservationPage(
     return [
       ref.ref,
       {
+        ...(ref.name ? { name: ref.name } : {}),
         backendNodeId: ref.backendNodeId,
         tabId,
         frameId: ref.frameId,

--- a/apps/extension/src/tools/vom/visual-observation.ts
+++ b/apps/extension/src/tools/vom/visual-observation.ts
@@ -1,0 +1,347 @@
+import {
+  prepareObservationRender,
+  type RenderedRef,
+  type RenderRow,
+  type VomOptions,
+  type VomScene,
+} from "@browser-skill/vom";
+import type { CdpTarget } from "@/browser-driver/frame-graph";
+import type { RefInput, RefStore } from "@/session-manager/ref-store";
+import type { ObserveResult, RpcError } from "@/transport/types";
+import type { CdpRunner } from "../shared";
+import { throwIfAborted } from "./capture-abort";
+import { verifyDocumentIdentity } from "./document-identity";
+import type { DocumentIdentity } from "./facts";
+import { frameBackendKey, type StructuredSemanticGraph } from "./semantic-graph/types";
+import type { VisualCandidate, VisualDiscoveryResult } from "./visual-discovery";
+
+/** Attach by source structure, never by spatial proximity or a guessed label. */
+export function attachVisualEntries(
+  scene: VomScene,
+  graph: StructuredSemanticGraph,
+  candidates: readonly VisualCandidate[],
+): VomScene {
+  const retained = new Map(
+    scene.nodes
+      .filter((n) => n.backendNodeId !== undefined)
+      .map((n) => [frameBackendKey(n.frameId!, n.backendNodeId!), n.id]),
+  );
+  const byId = new Map(scene.nodes.map((n) => [n.id, n]));
+  const parents = new Map<string, number | null>();
+  function parentOf(id: string | undefined): number | null {
+    const path: string[] = [];
+    const seen = new Set<string>();
+    while (id && !parents.has(id)) {
+      const node = graph.nodes.get(id);
+      if (!node) break;
+      const kept =
+        node.backendNodeId === undefined
+          ? undefined
+          : retained.get(frameBackendKey(node.frameId, node.backendNodeId));
+      if (kept !== undefined) {
+        parents.set(id, kept);
+        break;
+      }
+      if (seen.has(id)) break;
+      seen.add(id);
+      path.push(id);
+      id = node.domParentId;
+    }
+    const parent = id ? (parents.get(id) ?? null) : null;
+    for (const key of path) parents.set(key, parent);
+    return parent;
+  }
+  const siblings = new Map<string, { id: number; order: number }[]>();
+  for (const node of scene.nodes) {
+    const sourceId =
+      node.backendNodeId === undefined
+        ? undefined
+        : graph.nodeByFrameBackend.get(frameBackendKey(node.frameId!, node.backendNodeId));
+    const source = sourceId ? graph.nodes.get(sourceId) : undefined;
+    if (!source) continue;
+    const key = `${node.frameId}:${node.parentId}`;
+    const list = siblings.get(key) ?? [];
+    list.push({ id: node.id, order: source.sourceOrder });
+    siblings.set(key, list);
+  }
+  for (const list of siblings.values()) list.sort((a, b) => a.order - b.order);
+  return {
+    ...scene,
+    visuals: candidates.map((c, key) => {
+      const sourceId = graph.nodeByFrameBackend.get(
+        frameBackendKey(c.document.frameId, c.backendNodeId),
+      );
+      const source = sourceId ? graph.nodes.get(sourceId) : undefined;
+      const own = retained.get(frameBackendKey(c.document.frameId, c.backendNodeId));
+      let parentId = own !== undefined ? byId.get(own)!.parentId : parentOf(source?.domParentId);
+      if (parentId === null) {
+        const owner = graph.frames.get(c.document.frameId)?.ownerNodeId;
+        if (owner) parentId = parentOf(owner);
+      }
+      const list = siblings.get(`${c.document.frameId}:${parentId}`) ?? [];
+      let lo = 0,
+        hi = list.length;
+      while (lo < hi) {
+        const mid = (lo + hi) >>> 1;
+        if (list[mid].order < (source?.sourceOrder ?? Infinity)) lo = mid + 1;
+        else hi = mid;
+      }
+      return {
+        key,
+        ...(parentId === null
+          ? {
+              fallbackContext: `Unplaced Canvas regions (frame ${(graph.frames.get(c.document.frameId)?.order ?? 0) + 1})`,
+            }
+          : {}),
+        parentId,
+        sourceId: own,
+        beforeId: own ?? list[lo]?.id,
+        label: c.label,
+        frameId: c.document.frameId,
+      };
+    }),
+  };
+}
+
+export interface ObservationOutput {
+  render: ReturnType<typeof prepareObservationRender>;
+  candidates: readonly VisualCandidate[];
+  identities: Map<string, DocumentIdentity>;
+  rootIdentity?: DocumentIdentity;
+  frames: Map<string, { target: CdpTarget; parentFrameId?: string }>;
+  notices: string[];
+  maxTokens?: number;
+}
+
+export function prepareVisualObservation(
+  scene: VomScene,
+  graph: StructuredSemanticGraph,
+  discovery: VisualDiscoveryResult,
+  identities: Map<string, DocumentIdentity>,
+  rootFrameId: string,
+  notices: string[],
+  options: VomOptions,
+): ObservationOutput {
+  const candidates = discovery.candidates.filter((c) => !!c.framePath);
+  const unavailable = discovery.candidates.length - candidates.length;
+  if (unavailable)
+    notices.push(`@warning ${unavailable} Canvas regions have no verified screenshot path.`);
+  const unsupported = discovery.issues.filter(
+    (issue) => issue.reason === "geometry-unsupported",
+  ).length;
+  const incomplete = discovery.issues.length - unsupported;
+  if (unsupported)
+    notices.push(
+      `@warning visual geometry unsupported (${unsupported} issues); no screenshot refs for those regions.`,
+    );
+  if (incomplete)
+    notices.push(
+      `@warning visual discovery incomplete (${incomplete} issues); some Canvas regions could not be verified.`,
+    );
+  return {
+    render: prepareObservationRender(attachVisualEntries(scene, graph, candidates), options),
+    candidates,
+    identities,
+    rootIdentity: identities.get(rootFrameId),
+    frames: new Map(
+      [...graph.frames].map(([id, frame]) => [
+        id,
+        { target: frame.target, parentFrameId: frame.parentFrameId },
+      ]),
+    ),
+    notices,
+    maxTokens: options.maxTokens,
+  };
+}
+
+interface Page {
+  text: string;
+  refs: RenderedRef[];
+  more: boolean;
+  frameIds: Set<string>;
+}
+interface Continuation {
+  output: ObservationOutput;
+  tabId: number;
+  revision: number;
+  token: string;
+  buffer: RenderRow[];
+  exhausted: boolean;
+  /** Only the latest response is retained for retrying its input cursor. */
+  last?: {
+    input: string;
+    budget?: number;
+    result: ObserveResult;
+    identities: Map<string, DocumentIdentity>;
+  };
+}
+const continuations = new WeakMap<RefStore, Continuation>();
+export function clearObservationContinuation(store: RefStore): void {
+  continuations.delete(store);
+}
+const cost = (line: string) => Math.ceil(line.length / 4);
+const failure = (message: string): RpcError => ({ code: "invalid_params", message });
+
+function page(
+  state: Continuation,
+  budget: number | undefined,
+  continued: boolean,
+): Page | RpcError {
+  const max = budget ?? Infinity;
+  if (!(max >= 0) || Number.isNaN(max)) return failure("max_tokens must be nonnegative");
+  const headers = [
+    ...state.output.render.headers,
+    ...(continued ? ["@continued same observation; only refs in this response are current."] : []),
+  ];
+  const footer = `@more observe --cursor ${state.token}; use this page's refs before continuing.`;
+  if (continued && state.buffer[0]?.context) headers.push(state.buffer[0].context);
+  const fixed = [...headers, ...state.output.notices];
+  let used = fixed.reduce((n, line) => n + cost(line), 0);
+  if (used > max) return failure("max_tokens is too small for observation headers and notices");
+  const lines = [...headers];
+  const refs: RenderedRef[] = [];
+  const frameIds = new Set<string>();
+  let emitted = 0;
+  while (true) {
+    // One-row lookahead avoids reserving a continuation footer on the final row.
+    while (state.buffer.length < 2 && !state.exhausted) {
+      const next = state.output.render.rows.next();
+      if (next.done) state.exhausted = true;
+      else state.buffer.push(next.value);
+    }
+    const row = state.buffer[0];
+    if (!row) break;
+    const reserve = state.buffer.length > 1 || !state.exhausted ? cost(footer) : 0;
+    let text = row.text;
+    if (used + cost(text) + reserve > max && row.minimal) text = row.minimal;
+    if (used + cost(text) + reserve > max) {
+      if (!emitted) return failure("max_tokens is too small to advance; increase the budget");
+      break;
+    }
+    if (row.ref) refs.push({ ...row.ref, line: lines.length });
+    if (row.frameId) frameIds.add(row.frameId);
+    lines.push(text);
+    used += cost(text);
+    emitted++;
+    state.buffer.shift();
+  }
+  lines.push(...state.output.notices);
+  const more = state.buffer.length > 0 || !state.exhausted;
+  if (more) lines.push(footer);
+  return { text: lines.join("\n"), refs, more, frameIds };
+}
+
+export async function publishObservationPage(
+  store: RefStore,
+  cdp: CdpRunner,
+  tabId: number,
+  input: { output?: ObservationOutput; cursor?: string; maxTokens?: number },
+  signal?: AbortSignal,
+): Promise<ObserveResult | RpcError> {
+  let state: Continuation;
+  if (input.output)
+    state = {
+      output: input.output,
+      tabId,
+      revision: store.revision,
+      token: crypto.randomUUID(),
+      exhausted: false,
+      buffer: [],
+    };
+  else {
+    const saved = continuations.get(store);
+    if (
+      !saved ||
+      saved.tabId !== tabId ||
+      saved.revision !== store.revision ||
+      (input.cursor !== saved.token && input.cursor !== saved.last?.input)
+    )
+      return failure("observation cursor expired; observe again");
+    state = saved;
+  }
+  const budget = input.maxTokens ?? state.output.maxTokens;
+  if (input.cursor && state.last?.input === input.cursor && state.last.budget !== budget)
+    return failure("retry this cursor with the same budget, or use next_cursor");
+  // Retry retains exactly the latest output; it cannot advance the iterator twice.
+  const retry = input.cursor && state.last?.input === input.cursor ? state.last : undefined;
+  const previousToken = state.token;
+  if (input.cursor && !retry) state.token = crypto.randomUUID();
+  const rendered = retry ? undefined : page(state, budget, !!input.cursor);
+  if (rendered && "code" in rendered) {
+    state.token = previousToken;
+    return rendered;
+  }
+  const identities = new Map<string, DocumentIdentity>(retry?.identities);
+  if (state.output.rootIdentity)
+    identities.set(state.output.rootIdentity.frameId, state.output.rootIdentity);
+  const refs = rendered?.refs ?? [];
+  const visited = new Set<string>();
+  let missingIdentity = false;
+  for (const frameId of rendered?.frameIds ?? []) {
+    let id: string | undefined = frameId;
+    while (id && !visited.has(id)) {
+      visited.add(id);
+      const identity = state.output.identities.get(id);
+      if (identity) identities.set(id, identity);
+      else missingIdentity = true;
+      id = state.output.frames.get(id)?.parentFrameId;
+    }
+  }
+  if (input.cursor) {
+    if (!state.output.rootIdentity || missingIdentity) {
+      continuations.delete(store);
+      return failure("observation identity unavailable; observe again");
+    }
+    for (const identity of identities.values()) {
+      if ((await verifyDocumentIdentity(cdp, identity, signal)) !== "current") {
+        continuations.delete(store);
+        return failure("observation DOM changed; observe again");
+      }
+    }
+  }
+  throwIfAborted(signal);
+  if (input.cursor && (continuations.get(store) !== state || store.revision !== state.revision))
+    return failure("observation cursor expired during validation; observe again");
+  if (retry) return retry.result;
+  const entries: [string, RefInput][] = refs.map((ref) => {
+    if (ref.visualKey !== undefined)
+      return [
+        ref.ref,
+        { kind: "visual-region", candidate: state.output.candidates[ref.visualKey] },
+      ];
+    const target = ref.frameId ? state.output.frames.get(ref.frameId)?.target : undefined;
+    return [
+      ref.ref,
+      {
+        backendNodeId: ref.backendNodeId,
+        tabId,
+        frameId: ref.frameId,
+        cdpSessionId: target?.sessionId,
+      },
+    ];
+  });
+  store.replace(entries);
+  state.revision = store.revision;
+  const result: ObserveResult = {
+    text: rendered!.text,
+    ref_count: refs.length,
+    tab_id: tabId,
+    truncated: rendered!.more || state.output.render.truncated(),
+    ...(rendered!.more ? { next_cursor: state.token } : {}),
+  };
+  if (input.cursor) state.last = { input: input.cursor, budget, result, identities };
+  if (!rendered!.more) {
+    // Keep only the latest response/identity proof for transport retry, not the full observation.
+    state.output = {
+      ...state.output,
+      candidates: [],
+      identities: new Map(),
+      frames: new Map(),
+      notices: [],
+      render: { headers: [], rows: [][Symbol.iterator](), truncated: () => false },
+    };
+  }
+  if (rendered!.more || input.cursor) continuations.set(store, state);
+  else continuations.delete(store);
+  return result;
+}

--- a/apps/extension/src/tools/vom/visual-region.ts
+++ b/apps/extension/src/tools/vom/visual-region.ts
@@ -260,6 +260,8 @@ export function extendVisualContext(
   };
 }
 
+/** A page screenshot rectangle, not an exact mask of visible Canvas pixels.
+ * Rounded corners are rendered by the browser and do not invalidate this range. */
 export type VisualRegionResult =
   | { status: "available"; borderBox: ViewportRect; crop: ViewportRect; clips?: VisualClipSource }
   | { status: "empty" }

--- a/apps/extension/src/tools/vom/visual-region.ts
+++ b/apps/extension/src/tools/vom/visual-region.ts
@@ -142,6 +142,37 @@ export interface VisualAncestor {
   readonly clientBox?: ViewportRect | null;
 }
 
+interface OverflowElement {
+  readonly backendNodeId: number;
+  readonly tag: string;
+  readonly styles: Readonly<Record<string, string>>;
+}
+
+/** The viewport already clips projected geometry. Its overflow source must not
+ * also clip descendants to its own box (CSS Overflow, viewport propagation).
+ * Adapters supply the document element and its actual first body child. */
+export function viewportOverflowSource(
+  root: OverflowElement | undefined,
+  body?: OverflowElement,
+): number | undefined {
+  if (!root || root.styles.display === "none") return undefined;
+  const permitsPropagation = ({ styles }: OverflowElement) =>
+    styles.contain === "none" &&
+    styles["content-visibility"] === "visible" &&
+    !!styles["container-type"] &&
+    !/(?:^|\s)(size|inline-size)(?:$|\s)/.test(styles["container-type"]);
+  return root.tag === "html" &&
+    root.styles["overflow-x"] === "visible" &&
+    root.styles["overflow-y"] === "visible" &&
+    body?.tag === "body" &&
+    !!body.styles.display &&
+    body.styles.display !== "none" &&
+    permitsPropagation(root) &&
+    permitsPropagation(body)
+    ? body.backendNodeId
+    : root.backendNodeId;
+}
+
 /** One ancestor step, reusable by discovery and the future live local adapter. */
 export function extendVisualContext(
   parent: VisualContext,

--- a/apps/extension/src/tools/vom/visual-region.ts
+++ b/apps/extension/src/tools/vom/visual-region.ts
@@ -1,0 +1,316 @@
+import {
+  type GeometryProjection,
+  type Polygon,
+  projectPolygon,
+  rectPolygon,
+  regionBounds,
+  type ViewportRect,
+} from "../geometry";
+import type { DocumentGeometry, DocumentIdentity } from "./facts";
+
+export type VisualIssueReason =
+  | "ancestry-incomplete"
+  | "facts-unavailable"
+  | "geometry-unavailable"
+  | "geometry-unsupported"
+  | "identity-unverified"
+  | "ownership-unresolved";
+
+/** Top viewport CSS coordinates. Unconstrained axes have infinite bounds. */
+export interface VisualClip {
+  readonly left: number;
+  readonly top: number;
+  readonly right: number;
+  readonly bottom: number;
+}
+
+/** Shared persistent chain: one entry per clipping ancestor, not per Canvas. */
+export interface VisualClipSource {
+  readonly document: DocumentIdentity;
+  readonly backendNodeId: number;
+  readonly x: boolean;
+  readonly y: boolean;
+  readonly overflowX: string;
+  readonly overflowY: string;
+  readonly box: ViewportRect;
+  readonly parent?: VisualClipSource;
+}
+
+export interface VisualContext {
+  readonly clip: VisualClip;
+  readonly clips?: VisualClipSource;
+  readonly hidden: boolean;
+  /** A local CSS scale/zoom makes snapshot client offsets ambiguous. */
+  readonly transformed: boolean;
+  readonly localClip?: boolean;
+  /** Overflow between an absolute target and its nearest positioned ancestor. */
+  readonly unpositionedClip?: boolean;
+  readonly issue?: VisualIssueReason;
+}
+
+export const EMPTY_VISUAL_CONTEXT: VisualContext = {
+  clip: { left: -Infinity, top: -Infinity, right: Infinity, bottom: Infinity },
+  hidden: false,
+  transformed: false,
+};
+
+function axisRect(polygon: Polygon): boolean {
+  if (polygon.length !== 4 || polygon.some((p) => !Number.isFinite(p.x) || !Number.isFinite(p.y)))
+    return false;
+  const [a, b, c, d] = polygon;
+  return a.y === b.y && b.x === c.x && c.y === d.y && d.x === a.x && b.x > a.x && d.y > a.y;
+}
+
+/** Check evidence before projectRectToViewport can reduce a polygon to its bounds. */
+export function visualProjectionIssue(
+  geometry: DocumentGeometry | undefined,
+): VisualIssueReason | undefined {
+  if (!geometry || !geometry.projections.length || geometry.pageScale === undefined)
+    return "geometry-unavailable";
+  if (!Number.isFinite(geometry.pageScale) || geometry.pageScale <= 0)
+    return "geometry-unavailable";
+  if (geometry.pageScale !== 1) return "geometry-unsupported";
+  const { layoutUnitsPerCssPixel, scrollCss } = geometry.coordinates;
+  if (
+    !Number.isFinite(layoutUnitsPerCssPixel) ||
+    layoutUnitsPerCssPixel <= 0 ||
+    ![scrollCss.x, scrollCss.y].every(Number.isFinite)
+  )
+    return "geometry-unavailable";
+  for (const projection of geometry.projections) {
+    if (
+      ![projection.topViewport.width, projection.topViewport.height].every(
+        (n) => Number.isFinite(n) && n > 0,
+      )
+    )
+      return "geometry-unavailable";
+    if (projection.sourceClips.some((clip) => !axisRect(clip))) return "geometry-unsupported";
+    for (const edge of projection.edges) {
+      if (
+        ![edge.sourceViewport.width, edge.sourceViewport.height].every(
+          (n) => Number.isFinite(n) && n > 0,
+        )
+      )
+        return "geometry-unavailable";
+      if (!axisRect(edge.destinationQuad) || edge.destinationClips?.some((clip) => !axisRect(clip)))
+        return "geometry-unsupported";
+    }
+  }
+}
+
+/** Uses the same projection math as DOM geometry, without clipping away box origins. */
+export function projectVisualBox(
+  box: ViewportRect,
+  projections: readonly GeometryProjection[],
+): ViewportRect | null {
+  let polygon: Polygon = rectPolygon({ x: box.x, y: box.y, w: box.width, h: box.height });
+  for (const projection of projections)
+    for (const edge of projection.edges) polygon = projectPolygon(polygon, edge);
+  // Preserve zero-size client boxes: they can prove a fully clipped axis.
+  if (box.width === 0 || box.height === 0) {
+    const [a, , c] = polygon;
+    return { x: a.x, y: a.y, width: c.x - a.x, height: c.y - a.y };
+  }
+  return regionBounds([polygon]);
+}
+
+function axisTransformScale(value: string): [number, number] | null {
+  if (value === "none") return [1, 1];
+  const match = /^matrix(3d)?\(([^)]+)\)$/.exec(value);
+  if (!match) return null;
+  const values = match[2].split(",").map((part) => Number(part.trim()));
+  if (!values.every(Number.isFinite)) return null;
+  if (match[1])
+    return values.length === 16 &&
+      values[0] > 0 &&
+      values[5] > 0 &&
+      values[10] === 1 &&
+      values[15] === 1 &&
+      [1, 2, 3, 4, 6, 7, 8, 9, 11, 14].every((index) => values[index] === 0)
+      ? [values[0], values[5]]
+      : null;
+  return values.length === 6 && values[0] > 0 && values[3] > 0 && values[1] === 0 && values[2] === 0
+    ? [values[0], values[3]]
+    : null;
+}
+
+export interface VisualAncestor {
+  readonly document: DocumentIdentity;
+  readonly backendNodeId: number;
+  readonly styles: Readonly<Record<string, string>>;
+  /** Already in top viewport CSS units, from a source-specific adapter. */
+  readonly clientBox?: ViewportRect | null;
+}
+
+/** One ancestor step, reusable by discovery and the future live local adapter. */
+export function extendVisualContext(
+  parent: VisualContext,
+  node: VisualAncestor,
+  clipContents = true,
+): VisualContext {
+  const styles = node.styles;
+  const opacity = styles.opacity?.trim() ? Number(styles.opacity) : NaN;
+  const zoom = styles.zoom === "normal" ? 1 : styles.zoom?.trim() ? Number(styles.zoom) : NaN;
+  const scale =
+    styles.scale === "none" ? [1] : (styles.scale ?? "").trim().split(/\s+/).map(Number);
+  const scaleSupported =
+    scale.length >= 1 &&
+    scale.length <= 3 &&
+    scale.every((n) => Number.isFinite(n) && n > 0) &&
+    (scale.length < 3 || scale[2] === 1);
+  const transformScale = axisTransformScale(styles.transform ?? "");
+  // Identity/translation changes origins, which bounds already capture, but
+  // leaves client offsets in the same units. Only scaling makes them ambiguous.
+  const transformed =
+    parent.transformed ||
+    transformScale?.some((n) => n !== 1) === true ||
+    zoom !== 1 ||
+    scale.some((n) => n !== 1);
+  const hidden = parent.hidden || opacity === 0 || styles.display === "none";
+  let issue = parent.issue;
+  if (
+    !Number.isFinite(opacity) ||
+    !Number.isFinite(zoom) ||
+    zoom <= 0 ||
+    !styles.display ||
+    !styles.visibility
+  )
+    issue ??= "facts-unavailable";
+  if (!styles.transform || !styles["clip-path"] || !styles["mask-image"])
+    issue ??= "facts-unavailable";
+  else if (!transformScale || styles["clip-path"] !== "none" || styles["mask-image"] !== "none")
+    issue ??= "geometry-unsupported";
+
+  if (
+    !["rotate", "scale", "perspective", "clip", "contain", "overflow-clip-margin"].every(
+      (key) => styles[key],
+    )
+  )
+    issue ??= "facts-unavailable";
+  else if (
+    !scaleSupported ||
+    !["none", "0deg"].includes(styles.rotate) ||
+    styles.perspective !== "none" ||
+    styles.clip !== "auto" ||
+    /(?:^|\s)(paint|strict|content)(?:$|\s)/.test(styles.contain)
+  )
+    issue ??= "geometry-unsupported";
+  // Do not pretend every DOM ancestor clips out-of-flow descendants. Support
+  // the ordinary positioned-container case; other containing-block cases stay explicit.
+  if (
+    (styles.position === "absolute" && parent.unpositionedClip) ||
+    (styles.position === "fixed" && parent.localClip)
+  )
+    issue ??= "geometry-unsupported";
+  const overflow = [styles["overflow-x"], styles["overflow-y"]];
+  if (clipContents && overflow.includes("clip") && styles["overflow-clip-margin"] !== "0px")
+    issue ??= "geometry-unsupported";
+  if (
+    overflow.some(
+      (value) => !["visible", "hidden", "clip", "scroll", "auto", "overlay"].includes(value),
+    )
+  )
+    issue ??= "facts-unavailable";
+  const [x, y] = overflow.map((value) => value !== "visible");
+  let clip = parent.clip;
+  let clips = parent.clips;
+  if (clipContents && (x || y)) {
+    if (transformed) issue ??= "geometry-unsupported";
+    const box = node.clientBox;
+    if (
+      !box ||
+      ![box.x, box.y, box.width, box.height].every(Number.isFinite) ||
+      box.width < 0 ||
+      box.height < 0
+    )
+      issue ??= "geometry-unavailable";
+    else {
+      clip = {
+        left: x ? Math.max(clip.left, box.x) : clip.left,
+        right: x ? Math.min(clip.right, box.x + box.width) : clip.right,
+        top: y ? Math.max(clip.top, box.y) : clip.top,
+        bottom: y ? Math.min(clip.bottom, box.y + box.height) : clip.bottom,
+      };
+      clips = {
+        document: node.document,
+        backendNodeId: node.backendNodeId,
+        x,
+        y,
+        overflowX: styles["overflow-x"],
+        overflowY: styles["overflow-y"],
+        box,
+        parent: clips,
+      };
+    }
+  }
+  const clipsHere = clipContents && (x || y);
+  return {
+    hidden,
+    transformed,
+    issue,
+    clip,
+    clips,
+    localClip: parent.localClip || clipsHere,
+    unpositionedClip:
+      styles.position !== "static" ||
+      styles.transform !== "none" ||
+      /(?:^|\s)layout(?:$|\s)/.test(styles.contain ?? "")
+        ? false
+        : parent.unpositionedClip || clipsHere,
+  };
+}
+
+export type VisualRegionResult =
+  | { status: "available"; borderBox: ViewportRect; crop: ViewportRect; clips?: VisualClipSource }
+  | { status: "empty" }
+  | { status: "unavailable"; reason: VisualIssueReason };
+
+/** Box and frameVisibleBox must come from the same box kind (Canvas border-box).
+ * Frame/viewport clipping is supplied by the shared geometry adapter. */
+export function resolveVisualRegion(input: {
+  borderBox: ViewportRect | null;
+  frameVisibleBox: ViewportRect | null;
+  context: VisualContext;
+  visibility: string;
+}): VisualRegionResult {
+  const { borderBox, frameVisibleBox, context, visibility } = input;
+  if (context.hidden || visibility === "hidden" || visibility === "collapse")
+    return { status: "empty" };
+  if (context.issue) return { status: "unavailable", reason: context.issue };
+  if (visibility !== "visible") return { status: "unavailable", reason: "facts-unavailable" };
+  if (!borderBox) return { status: "unavailable", reason: "geometry-unavailable" };
+  if (!frameVisibleBox) return { status: "empty" };
+  if (
+    ![
+      borderBox.x,
+      borderBox.y,
+      borderBox.width,
+      borderBox.height,
+      frameVisibleBox.x,
+      frameVisibleBox.y,
+      frameVisibleBox.width,
+      frameVisibleBox.height,
+    ].every(Number.isFinite)
+  )
+    return { status: "unavailable", reason: "geometry-unavailable" };
+  if (
+    borderBox.width <= 0 ||
+    borderBox.height <= 0 ||
+    frameVisibleBox.width < 0 ||
+    frameVisibleBox.height < 0 ||
+    Object.values(context.clip).some(Number.isNaN)
+  )
+    return { status: "unavailable", reason: "geometry-unavailable" };
+  const x = Math.max(frameVisibleBox.x, context.clip.left);
+  const y = Math.max(frameVisibleBox.y, context.clip.top);
+  const right = Math.min(frameVisibleBox.x + frameVisibleBox.width, context.clip.right);
+  const bottom = Math.min(frameVisibleBox.y + frameVisibleBox.height, context.clip.bottom);
+  return right > x && bottom > y
+    ? {
+        status: "available",
+        borderBox,
+        crop: { x, y, width: right - x, height: bottom - y },
+        clips: context.clips,
+      }
+    : { status: "empty" };
+}

--- a/apps/extension/src/transport/types.ts
+++ b/apps/extension/src/transport/types.ts
@@ -25,6 +25,8 @@ export type RpcErrorReason =
   | "element_not_visible"
   | "ref_not_found"
   | "ref_kind_unsupported"
+  | "visual_target_changed"
+  | "visual_pixel_budget_exceeded"
   | "selector_not_found"
   | "target_not_fillable"
   | "fill_value_invalid"

--- a/apps/extension/src/transport/types.ts
+++ b/apps/extension/src/transport/types.ts
@@ -24,6 +24,7 @@ export type RpcErrorReason =
   | "agent_window_scope"
   | "element_not_visible"
   | "ref_not_found"
+  | "ref_kind_unsupported"
   | "selector_not_found"
   | "target_not_fillable"
   | "fill_value_invalid"

--- a/apps/extension/src/transport/types.ts
+++ b/apps/extension/src/transport/types.ts
@@ -25,6 +25,9 @@ export type RpcErrorReason =
   | "element_not_visible"
   | "ref_not_found"
   | "ref_kind_unsupported"
+  | "visual_capture_stale"
+  | "visual_capture_invalid"
+  | "visual_coordinate_invalid"
   | "visual_target_changed"
   | "visual_pixel_budget_exceeded"
   | "selector_not_found"
@@ -320,6 +323,8 @@ export interface ScreenshotParams {
 }
 
 export interface ScreenshotResult {
+  capture_id?: string;
+  capture_unavailable?: string;
   image_base64: string;
   width: number;
   height: number;
@@ -440,6 +445,9 @@ export type MouseButton = "left" | "middle" | "right";
 export type KeyModifier = "alt" | "ctrl" | "meta" | "shift";
 
 export interface ClickParams {
+  capture_id?: string;
+  image_x?: number;
+  image_y?: number;
   session_id: string;
   ref?: string;
   selector?: string;

--- a/apps/extension/src/transport/types.ts
+++ b/apps/extension/src/transport/types.ts
@@ -344,11 +344,13 @@ export interface SnapshotResult {
 }
 
 export interface ObserveParams extends SnapshotParams {
+  cursor?: string;
   debug_surfaces?: boolean;
   probe_hover?: boolean;
 }
 
 export interface ObserveResult extends SnapshotResult {
+  next_cursor?: string;
   hover_probe?: {
     performed: boolean;
     revealed_content: boolean;

--- a/crates/bsk-cli/skill/SKILL.md
+++ b/crates/bsk-cli/skill/SKILL.md
@@ -120,7 +120,8 @@ needed, obtain a fresh observation before acting on screenshot or HTML findings.
 
 `observe` may place `@eN canvas [visual:screenshot]` near related page controls. Names are
 optional: do not infer a table title or controls inside Canvas from adjacent labels. Visual refs
-support `screenshot --ref`, not click/fill/hover or HTML extraction. First observe returns text,
+support `screenshot --ref`; point clicks additionally require its `capture_id` and image coordinates.
+They do not support fill/hover or HTML extraction. First observe returns text,
 not an image. Use the surrounding semantics to decide whether a Canvas screenshot is needed.
 If you cannot receive and understand images in this session, tell the user the Canvas contents
 cannot be interpreted and ask them to switch to an image-capable model; continue with available
@@ -135,6 +136,17 @@ Continuation reads the same captured observation; it does not refresh or hover t
 combine it with depth changes or hover probing. A new observe/snapshot replaces the continuation;
 if the page identity changed, observe again. Screenshot execution checks current target identity
 and geometry, but permits Canvas repainting and does not freeze pixels.
+
+A Canvas screenshot can return `capture_id`. To click a point you identified in that image, use
+`bsk click eN --capture <id> --image-x <x> --image-y <y> --session <id>`.
+Use original PNG pixels (returned width/height), not resized display or viewport coordinates.
+Captures are single-use, expire after two minutes, and are invalidated by a newer screenshot of
+that ref or observation/continuation. With `capture_unavailable`, view the image but observe and
+screenshot again before clicking. Click counts 1/2, buttons and modifiers are supported.
+After clicking, observe or screenshot to verify the result; use DOM refs for revealed controls.
+A completed click does not prove business success. Canvas repainting is allowed; changed identity,
+geometry or hit target is rejected. If `effect_state=unknown`, inspect before retrying with a new
+capture. Do not infer cell-editing, IME, drag or hover support from point-click capability.
 
 ## Respect the Agent Window boundary
 

--- a/crates/bsk-cli/skill/SKILL.md
+++ b/crates/bsk-cli/skill/SKILL.md
@@ -116,6 +116,26 @@ Escalate page reading only as needed:
 Do not start with raw HTML or screenshots merely to discover ordinary controls. When interaction is
 needed, obtain a fresh observation before acting on screenshot or HTML findings.
 
+## Canvas and observation continuation
+
+`observe` may place `@eN canvas [visual:screenshot]` near related page controls. Names are
+optional: do not infer a table title or controls inside Canvas from adjacent labels. Visual refs
+support `screenshot --ref`, not click/fill/hover or HTML extraction. First observe returns text,
+not an image. Use the surrounding semantics to decide whether a Canvas screenshot is needed.
+If you cannot receive and understand images in this session, tell the user the Canvas contents
+cannot be interpreted and ask them to switch to an image-capable model; continue with available
+semantic information. BrowserSkill does not detect the model's capabilities.
+
+There is no default token cap. With an explicit `--max-tokens` limit, an observation may return
+`next_cursor` and an `@more` instruction. Use current refs before calling
+`bsk observe --cursor <token> --session <id>`: each response replaces the ref map, so refs from
+previous pages must not be reused. A response can contain many Canvas entries. Follow cursors
+when relevant content remains, rather than repeatedly reading the same prefix.
+Continuation reads the same captured observation; it does not refresh or hover the page. Do not
+combine it with depth changes or hover probing. A new observe/snapshot replaces the continuation;
+if the page identity changed, observe again. Screenshot execution checks current target identity
+and geometry, but permits Canvas repainting and does not freeze pixels.
+
 ## Respect the Agent Window boundary
 
 Normal page writes affect only Agent Window tabs. To operate a user tab, first list it with

--- a/crates/bsk-cli/src/cli/error.rs
+++ b/crates/bsk-cli/src/cli/error.rs
@@ -451,7 +451,7 @@ mod tests {
     }
 
     #[test]
-    fn not_found_ref_uses_snapshot_hint_in_json() {
+    fn not_found_ref_uses_observe_hint_in_json() {
         let cli = CliError::from_rpc(RpcError {
             code: ErrorCode::NotFound,
             message: "ref @e99 unknown for tab 7".into(),
@@ -467,7 +467,7 @@ mod tests {
                 .get("hint")
                 .and_then(|v| v.as_str())
                 .unwrap()
-                .contains("bsk snapshot")
+                .contains("bsk observe")
         );
         assert!(
             !parsed

--- a/crates/bsk-cli/src/cli/interaction.rs
+++ b/crates/bsk-cli/src/cli/interaction.rs
@@ -103,6 +103,15 @@ pub(crate) fn split_target(
 
 #[derive(Debug, Clone, Args)]
 pub struct ClickArgs {
+    /// Bind a Canvas point click to the image returned by screenshot --ref.
+    #[arg(long = "capture", requires_all = ["image_x", "image_y"], conflicts_with = "selector")]
+    pub capture_id: Option<String>,
+    /// X coordinate in the original screenshot PNG, not viewport CSS pixels.
+    #[arg(long, requires = "capture_id")]
+    pub image_x: Option<f64>,
+    /// Y coordinate in the original screenshot PNG.
+    #[arg(long, requires = "capture_id")]
+    pub image_y: Option<f64>,
     /// Snapshot ref (`@e3`, `e3`) or CSS selector. Optional when `--ref`/`--selector` is used.
     pub target: Option<String>,
 
@@ -150,6 +159,9 @@ pub fn dispatch_click(args: ClickArgs, format: Format) -> Result<(), CliError> {
     let modifiers = parse_modifiers(&args.modifiers)
         .map_err(|e| CliError::Local(anyhow::anyhow!("--modifiers: {e}")))?;
     let params = ClickParams {
+        capture_id: args.capture_id.clone(),
+        image_x: args.image_x,
+        image_y: args.image_y,
         session_id: args.session.clone(),
         ref_,
         selector,

--- a/crates/bsk-cli/src/cli/mod.rs
+++ b/crates/bsk-cli/src/cli/mod.rs
@@ -140,7 +140,7 @@ pub enum Command {
     /// Emulate a mobile device environment (viewport, UA, touch) on a tab.
     Emulate(EmulateArgs),
 
-    /// Capture a PNG of the active tab or a snapshot ref element.
+    /// Capture a PNG of the active tab, a DOM element or a Canvas region.
     Screenshot(ScreenshotArgs),
 
     /// Produce an indented aria-snapshot with @eN refs.

--- a/crates/bsk-cli/src/cli/observe.rs
+++ b/crates/bsk-cli/src/cli/observe.rs
@@ -14,6 +14,9 @@ use crate::cli::error::{CliError, Format};
 
 #[derive(Debug, Clone, Args)]
 pub struct ObserveArgs {
+    /// Continue the same observation. Use current refs before continuing.
+    #[arg(long, conflicts_with_all = ["max_depth", "probe_hover", "debug_surfaces"])]
+    pub cursor: Option<String>,
     /// Session id (must be active).
     #[arg(long)]
     pub session: String,
@@ -48,6 +51,7 @@ pub fn dispatch(args: ObserveArgs, format: Format) -> Result<(), CliError> {
 
 fn run(sock: PathBuf, args: ObserveArgs, format: Format) -> Result<(), CliError> {
     let params = ObserveParams {
+        cursor: args.cursor,
         session_id: args.session.clone(),
         tab_id: args.tab_id,
         max_depth: args.max_depth,
@@ -68,7 +72,7 @@ fn run(sock: PathBuf, args: ObserveArgs, format: Format) -> Result<(), CliError>
             } else {
                 println!("{}", reply.text);
             }
-            if reply.truncated {
+            if reply.truncated && reply.next_cursor.is_none() {
                 eprintln!(
                     "warning: observation truncated (refs={}, tab={}). Increase --max-depth / --max-tokens if needed.",
                     reply.ref_count, reply.tab_id
@@ -88,4 +92,61 @@ fn call(sock: PathBuf, params: ObserveParams) -> Result<ObserveResult, CliError>
         Some(params),
         TOOL_IPC_TIMEOUT,
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ObserveArgs;
+    use clap::Parser;
+
+    #[derive(Parser)]
+    struct Command {
+        #[command(flatten)]
+        observe: ObserveArgs,
+    }
+
+    #[test]
+    fn cursor_accepts_a_page_budget() {
+        let parsed = Command::try_parse_from([
+            "observe",
+            "--session",
+            "s1",
+            "--cursor",
+            "page-two",
+            "--max-tokens",
+            "100",
+        ])
+        .unwrap();
+        assert_eq!(parsed.observe.cursor.as_deref(), Some("page-two"));
+        assert_eq!(parsed.observe.max_tokens, Some(100));
+    }
+
+    #[test]
+    fn cursor_cannot_change_capture_options() {
+        for option in ["--probe-hover", "--debug-surfaces"] {
+            assert!(
+                Command::try_parse_from([
+                    "observe",
+                    "--session",
+                    "s1",
+                    "--cursor",
+                    "page-two",
+                    option,
+                ])
+                .is_err()
+            );
+        }
+        assert!(
+            Command::try_parse_from([
+                "observe",
+                "--session",
+                "s1",
+                "--cursor",
+                "page-two",
+                "--max-depth",
+                "2",
+            ])
+            .is_err()
+        );
+    }
 }

--- a/crates/bsk-cli/src/cli/render_error.rs
+++ b/crates/bsk-cli/src/cli/render_error.rs
@@ -270,8 +270,8 @@ pub fn info_for_error(code: ErrorCode, data: Option<&serde_json::Value>) -> Rend
             exit_code: base.exit_code,
         },
         (ErrorCode::NotFound, reason::REF_NOT_FOUND) => RenderInfo {
-            summary: "snapshot ref was not found for this tab",
-            hint: Some("rerun `bsk snapshot` for the current tab and use one of the returned refs"),
+            summary: "observation ref was not found for this tab",
+            hint: Some("rerun `bsk observe` for the current tab and use one of the returned refs"),
             exit_code: base.exit_code,
         },
         (ErrorCode::NotFound, reason::SELECTOR_NOT_FOUND) => RenderInfo {
@@ -709,8 +709,8 @@ mod tests {
     fn ref_not_found_overrides_not_found_copy() {
         let data = serde_json::json!({ "reason": reason::REF_NOT_FOUND });
         let info = info_for_error(ErrorCode::NotFound, Some(&data));
-        assert_eq!(info.summary, "snapshot ref was not found for this tab");
-        assert!(info.hint.unwrap().contains("bsk snapshot"));
+        assert_eq!(info.summary, "observation ref was not found for this tab");
+        assert!(info.hint.unwrap().contains("bsk observe"));
     }
 
     #[test]

--- a/crates/bsk-cli/src/cli/render_error.rs
+++ b/crates/bsk-cli/src/cli/render_error.rs
@@ -40,6 +40,7 @@ use bsk_protocol::ErrorCode;
 pub mod reason {
     pub const AGENT_WINDOW_SCOPE: &str = "agent_window_scope";
     pub const ELEMENT_NOT_VISIBLE: &str = "element_not_visible";
+    pub const REF_KIND_UNSUPPORTED: &str = "ref_kind_unsupported";
     pub const REF_NOT_FOUND: &str = "ref_not_found";
     pub const SELECTOR_NOT_FOUND: &str = "selector_not_found";
     pub const TARGET_NOT_FILLABLE: &str = "target_not_fillable";
@@ -244,6 +245,13 @@ pub fn info_for_error(code: ErrorCode, data: Option<&serde_json::Value>) -> Rend
             summary: "tab is borrowed by another session",
             hint: Some(
                 "return the tab from the borrowing session via `bsk tab return <tab-id> --session <id>` or stop that session",
+            ),
+            exit_code: base.exit_code,
+        },
+        (ErrorCode::Unsupported, reason::REF_KIND_UNSUPPORTED) => RenderInfo {
+            summary: "this tool does not support the ref target type",
+            hint: Some(
+                "use a DOM ref for DOM operations; visual-region refs require an available visual screenshot path",
             ),
             exit_code: base.exit_code,
         },
@@ -662,6 +670,15 @@ mod tests {
         let timeout = serde_json::json!({ "reason": reason::TRANSFER_TIMEOUT });
         let info = info_for_error(ErrorCode::Timeout, Some(&timeout));
         assert!(info.summary.contains("timed out after browser dispatch"));
+    }
+
+    #[test]
+    fn visual_ref_type_error_has_specific_guidance() {
+        let data = serde_json::json!({ "reason": reason::REF_KIND_UNSUPPORTED });
+        let info = info_for_error(ErrorCode::Unsupported, Some(&data));
+        assert!(info.summary.contains("ref target type"));
+        assert!(info.hint.unwrap().contains("DOM ref"));
+        assert_eq!(info.exit_code, info_for(ErrorCode::Unsupported).exit_code);
     }
 
     #[test]

--- a/crates/bsk-cli/src/cli/render_error.rs
+++ b/crates/bsk-cli/src/cli/render_error.rs
@@ -250,6 +250,22 @@ pub fn info_for_error(code: ErrorCode, data: Option<&serde_json::Value>) -> Rend
             ),
             exit_code: base.exit_code,
         },
+        (ErrorCode::NotFound, "visual_capture_stale") => RenderInfo {
+            summary: "Canvas screenshot capture is no longer usable",
+            hint: Some(
+                "run `bsk observe`, screenshot the current Canvas ref, and use its new capture_id",
+            ),
+            exit_code: base.exit_code,
+        },
+        (ErrorCode::InvalidParams, "visual_capture_invalid" | "visual_coordinate_invalid") => {
+            RenderInfo {
+                summary: "invalid screenshot-bound Canvas click",
+                hint: Some(
+                    "provide a visual ref, --capture, --image-x and --image-y in the original PNG dimensions",
+                ),
+                exit_code: base.exit_code,
+            }
+        }
         (ErrorCode::NotFound, reason::VISUAL_TARGET_CHANGED) => RenderInfo {
             summary: "visual target needs a fresh observation",
             hint: Some(

--- a/crates/bsk-cli/src/cli/render_error.rs
+++ b/crates/bsk-cli/src/cli/render_error.rs
@@ -40,6 +40,8 @@ use bsk_protocol::ErrorCode;
 pub mod reason {
     pub const AGENT_WINDOW_SCOPE: &str = "agent_window_scope";
     pub const ELEMENT_NOT_VISIBLE: &str = "element_not_visible";
+    pub const VISUAL_TARGET_CHANGED: &str = "visual_target_changed";
+    pub const VISUAL_PIXEL_BUDGET_EXCEEDED: &str = "visual_pixel_budget_exceeded";
     pub const REF_KIND_UNSUPPORTED: &str = "ref_kind_unsupported";
     pub const REF_NOT_FOUND: &str = "ref_not_found";
     pub const SELECTOR_NOT_FOUND: &str = "selector_not_found";
@@ -246,6 +248,18 @@ pub fn info_for_error(code: ErrorCode, data: Option<&serde_json::Value>) -> Rend
             hint: Some(
                 "return the tab from the borrowing session via `bsk tab return <tab-id> --session <id>` or stop that session",
             ),
+            exit_code: base.exit_code,
+        },
+        (ErrorCode::NotFound, reason::VISUAL_TARGET_CHANGED) => RenderInfo {
+            summary: "visual target needs a fresh observation",
+            hint: Some(
+                "observe the page again and use the current visual ref; the previous identity or region cannot be used",
+            ),
+            exit_code: base.exit_code,
+        },
+        (ErrorCode::CdpFailed, reason::VISUAL_PIXEL_BUDGET_EXCEEDED) => RenderInfo {
+            summary: "visual screenshot exceeds the image size limit",
+            hint: Some("the screenshot could not be reduced within the pixel budget"),
             exit_code: base.exit_code,
         },
         (ErrorCode::Unsupported, reason::REF_KIND_UNSUPPORTED) => RenderInfo {
@@ -670,6 +684,16 @@ mod tests {
         let timeout = serde_json::json!({ "reason": reason::TRANSFER_TIMEOUT });
         let info = info_for_error(ErrorCode::Timeout, Some(&timeout));
         assert!(info.summary.contains("timed out after browser dispatch"));
+    }
+
+    #[test]
+    fn visual_screenshot_failures_have_specific_guidance() {
+        let changed = serde_json::json!({ "reason": reason::VISUAL_TARGET_CHANGED });
+        let info = info_for_error(ErrorCode::NotFound, Some(&changed));
+        assert!(info.hint.unwrap().contains("observe"));
+        let budget = serde_json::json!({ "reason": reason::VISUAL_PIXEL_BUDGET_EXCEEDED });
+        let info = info_for_error(ErrorCode::CdpFailed, Some(&budget));
+        assert!(info.summary.contains("image size limit"));
     }
 
     #[test]

--- a/crates/bsk-cli/src/cli/screenshot.rs
+++ b/crates/bsk-cli/src/cli/screenshot.rs
@@ -60,7 +60,7 @@ fn run(sock: PathBuf, args: ScreenshotArgs, format: Format) -> Result<(), CliErr
         .map_err(CliError::Local)?;
     match format {
         Format::Json => {
-            let json = serde_json::json!({
+            let mut json = serde_json::json!({
                 "tab_id": reply.tab_id,
                 "width": reply.width,
                 "height": reply.height,
@@ -68,6 +68,12 @@ fn run(sock: PathBuf, args: ScreenshotArgs, format: Format) -> Result<(), CliErr
                 "path": out_path.to_string_lossy(),
                 "byte_size": bytes.len(),
             });
+            if let Some(id) = &reply.capture_id {
+                json["capture_id"] = serde_json::json!(id);
+            }
+            if let Some(reason) = &reply.capture_unavailable {
+                json["capture_unavailable"] = serde_json::json!(reason);
+            }
             println!(
                 "{}",
                 serde_json::to_string_pretty(&json)
@@ -76,6 +82,15 @@ fn run(sock: PathBuf, args: ScreenshotArgs, format: Format) -> Result<(), CliErr
         }
         Format::Human => {
             println!("{}", out_path.display());
+            if let Some(id) = &reply.capture_id {
+                println!(
+                    "capture: {id} ({}x{} original PNG pixels; single use)",
+                    reply.width, reply.height
+                );
+            }
+            if let Some(reason) = &reply.capture_unavailable {
+                println!("capture unavailable: {reason}");
+            }
             print_dialog_summaries(&reply.dialogs);
         }
     }

--- a/crates/bsk-cli/src/cli/screenshot.rs
+++ b/crates/bsk-cli/src/cli/screenshot.rs
@@ -1,5 +1,6 @@
 //! `bsk screenshot` — capture a PNG of the Agent Window's active tab
-//! or a snapshot ref subtree (M6.2). CLI is responsible for decoding
+//! or a DOM element / Canvas region identified by an observation ref.
+//! CLI is responsible for decoding
 //! the base64 returned by the extension and writing the binary to
 //! disk; the wire payload stays human-readable.
 
@@ -26,8 +27,8 @@ pub struct ScreenshotArgs {
     #[arg(long = "tab-id")]
     pub tab_id: Option<i64>,
 
-    /// Optional `@eN` ref from the last `bsk snapshot`. Crops the
-    /// capture to the matching element.
+    /// Optional `@eN` ref from the latest `bsk observe` or `bsk snapshot`.
+    /// Crops the capture to the referenced DOM element or Canvas region.
     #[arg(long = "ref")]
     pub ref_: Option<String>,
 

--- a/crates/bsk-cli/src/skill_install/storage.rs
+++ b/crates/bsk-cli/src/skill_install/storage.rs
@@ -10,9 +10,16 @@ use tempfile::NamedTempFile;
 
 /// All readers that may replace a skill hold this lock until their writes finish.
 /// Keep the lock file in place: deleting it could let two processes lock different
-/// files at the same path. Closing the handle releases the OS lock.
+/// files at the same path. Explicitly unlock on drop: a concurrently spawned
+/// child may still hold an inherited handle until exec, delaying close-only release.
 pub(super) struct SkillLock {
     _file: File,
+}
+
+impl Drop for SkillLock {
+    fn drop(&mut self) {
+        let _ = FileExt::unlock(&self._file);
+    }
 }
 
 impl SkillLock {
@@ -152,5 +159,19 @@ mod tests {
         drop(lock);
         assert!(dir.path().join(".bsk.lock").exists());
         assert!(SkillLock::try_acquire(dir.path()).unwrap().is_some());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn dropping_guard_releases_lock_with_a_duplicate_handle_alive() {
+        let dir = tempfile::tempdir().unwrap();
+        let lock = SkillLock::acquire(dir.path()).unwrap();
+        // dup shares the open file description, as an inherited fd does between
+        // fork and exec in a concurrently spawned child process.
+        let duplicate = lock._file.try_clone().unwrap();
+        assert!(SkillLock::try_acquire(dir.path()).unwrap().is_none());
+        drop(lock);
+        assert!(SkillLock::try_acquire(dir.path()).unwrap().is_some());
+        drop(duplicate);
     }
 }

--- a/crates/bsk-cli/tests/cli_parse.rs
+++ b/crates/bsk-cli/tests/cli_parse.rs
@@ -715,3 +715,35 @@ fn rejects_invalid_wheel_numbers_and_timeouts() {
         assert!(Cli::try_parse_from(argv).is_err());
     }
 }
+
+#[test]
+fn canvas_click_requires_complete_capture_coordinates() {
+    let cli = parse(&[
+        "bsk",
+        "click",
+        "e1",
+        "--session",
+        "test",
+        "--capture",
+        "image",
+        "--image-x",
+        "12.5",
+        "--image-y",
+        "20",
+    ]);
+    let Command::Click(args) = cli.command else {
+        panic!("expected click")
+    };
+    assert_eq!(args.capture_id.as_deref(), Some("image"));
+    assert_eq!(args.image_x, Some(12.5));
+    assert_eq!(args.image_y, Some(20.0));
+    for extra in [
+        vec!["--capture", "image"],
+        vec!["--image-x", "12"],
+        vec!["--capture", "image", "--image-x", "12"],
+    ] {
+        let mut argv = vec!["bsk", "click", "e1", "--session", "test"];
+        argv.extend(extra);
+        assert!(Cli::try_parse_from(argv).is_err());
+    }
+}

--- a/crates/bsk-cli/tests/tools_ipc.rs
+++ b/crates/bsk-cli/tests/tools_ipc.rs
@@ -233,6 +233,8 @@ async fn screenshot_returns_image_base64_with_dimensions() {
         let _: ScreenshotParams = serde_json::from_value(req.params.clone().unwrap()).unwrap();
         ResponseBody::Ok(
             serde_json::to_value(ScreenshotResult {
+                capture_id: None,
+                capture_unavailable: None,
                 image_base64: "iVBORw0KGgo=".into(),
                 width: 800,
                 height: 600,
@@ -281,6 +283,8 @@ async fn screenshot_forwards_ref_to_extension() {
         assert_eq!(params.ref_.as_deref(), Some("@e5"));
         ResponseBody::Ok(
             serde_json::to_value(ScreenshotResult {
+                capture_id: Some("capture-test".into()),
+                capture_unavailable: None,
                 image_base64: "iVBORw0KGgo=".into(),
                 width: 100,
                 height: 60,
@@ -304,6 +308,7 @@ async fn screenshot_forwards_ref_to_extension() {
     )
     .await
     .expect("screenshot with ref ok");
+    assert_eq!(result.capture_id.as_deref(), Some("capture-test"));
     assert_eq!(result.width, 100);
     assert_eq!(result.height, 60);
     handle.shutdown().await;

--- a/crates/bsk-cli/tests/tools_ipc.rs
+++ b/crates/bsk-cli/tests/tools_ipc.rs
@@ -473,6 +473,7 @@ async fn observe_returns_semantic_text_and_ref_count() {
         let _: ObserveParams = serde_json::from_value(req.params.clone().unwrap()).unwrap();
         ResponseBody::Ok(
             serde_json::to_value(ObserveResult {
+                next_cursor: None,
                 text: "@vom 1\n  @e1 button \"Products\" [hover: Shoes]\n".into(),
                 ref_count: 1,
                 tab_id: 13,
@@ -490,6 +491,7 @@ async fn observe_returns_semantic_text_and_ref_count() {
         &sock,
         Method::ToolObserve,
         ObserveParams {
+            cursor: None,
             session_id,
             tab_id: None,
             max_depth: None,

--- a/crates/bsk-cli/tests/tools_m7_ipc.rs
+++ b/crates/bsk-cli/tests/tools_m7_ipc.rs
@@ -343,6 +343,9 @@ async fn click_round_trips_ref_and_modifiers() {
         }
         let p: ClickParams = serde_json::from_value(params).unwrap();
         assert_eq!(p.ref_.as_deref(), Some("@e3"));
+        assert_eq!(p.capture_id.as_deref(), Some("capture-test"));
+        assert_eq!(p.image_x, Some(12.5));
+        assert_eq!(p.image_y, Some(34.0));
         assert_eq!(p.button, Some(MouseButton::Right));
         assert_eq!(
             p.modifiers,
@@ -366,6 +369,9 @@ async fn click_round_trips_ref_and_modifiers() {
         &sock,
         Method::ToolClick,
         ClickParams {
+            capture_id: Some("capture-test".into()),
+            image_x: Some(12.5),
+            image_y: Some(34.0),
             session_id,
             ref_: Some("@e3".into()),
             selector: None,
@@ -734,6 +740,9 @@ async fn m7_tools_propagate_extension_errors() {
         &sock,
         Method::ToolClick,
         ClickParams {
+            capture_id: None,
+            image_x: None,
+            image_y: None,
             session_id: session_id.clone(),
             ref_: Some("@e1".into()),
             selector: None,

--- a/crates/bsk-protocol/schema/tool_click_params.json
+++ b/crates/bsk-protocol/schema/tool_click_params.json
@@ -16,6 +16,13 @@
         }
       ]
     },
+    "capture_id": {
+      "description": "Single-use capture returned by a visual-ref screenshot; requires image coordinates.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "click_count": {
       "description": "Number of consecutive mouse presses (double-click = 2).",
       "type": [
@@ -24,6 +31,20 @@
       ],
       "format": "uint32",
       "minimum": 1.0
+    },
+    "image_x": {
+      "type": [
+        "number",
+        "null"
+      ],
+      "format": "double"
+    },
+    "image_y": {
+      "type": [
+        "number",
+        "null"
+      ],
+      "format": "double"
     },
     "modifiers": {
       "type": [

--- a/crates/bsk-protocol/schema/tool_observe_params.json
+++ b/crates/bsk-protocol/schema/tool_observe_params.json
@@ -7,6 +7,13 @@
     "session_id"
   ],
   "properties": {
+    "cursor": {
+      "description": "Continue a retained observation; does not recapture the page.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "debug_surfaces": {
       "description": "Include implementation diagnostics for conditional surface probes.",
       "default": false,

--- a/crates/bsk-protocol/schema/tool_observe_result.json
+++ b/crates/bsk-protocol/schema/tool_observe_result.json
@@ -35,6 +35,13 @@
         }
       ]
     },
+    "next_cursor": {
+      "description": "Continue omitted content from this same observation.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "ref_count": {
       "description": "Number of `@e<N>` refs registered for this session by this observation. Equivalent to the size of the new ref-store map.",
       "type": "integer",

--- a/crates/bsk-protocol/schema/tool_screenshot_result.json
+++ b/crates/bsk-protocol/schema/tool_screenshot_result.json
@@ -8,6 +8,20 @@
     "tab_id"
   ],
   "properties": {
+    "capture_id": {
+      "description": "Single-use visual point-click capture, in the original PNG coordinate space.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "capture_unavailable": {
+      "description": "Image remains viewable but cannot authorize a point click.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "dialogs": {
       "type": "array",
       "items": {

--- a/crates/bsk-protocol/src/tools/interaction.rs
+++ b/crates/bsk-protocol/src/tools/interaction.rs
@@ -40,6 +40,13 @@ pub enum MouseButton {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 pub struct ClickParams {
+    /// Single-use capture returned by a visual-ref screenshot; requires image coordinates.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub capture_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub image_x: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub image_y: Option<f64>,
     pub session_id: String,
     /// Optional `@e<N>` ref allocated by the last `tool.snapshot`.
     /// Mutually exclusive with `selector` (caller must supply exactly
@@ -356,6 +363,9 @@ mod tests {
     #[test]
     fn click_params_serialise_ref_field_name() {
         let p = ClickParams {
+            capture_id: None,
+            image_x: None,
+            image_y: None,
             session_id: "abcd".into(),
             ref_: Some("@e3".into()),
             selector: None,

--- a/crates/bsk-protocol/src/tools/observation.rs
+++ b/crates/bsk-protocol/src/tools/observation.rs
@@ -63,6 +63,9 @@ pub struct SnapshotResult {
 /// page state.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 pub struct ObserveParams {
+    /// Continue a retained observation; does not recapture the page.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cursor: Option<String>,
     pub session_id: String,
     /// Optional target tab. Defaults to the Agent Window's currently
     /// active tab.
@@ -126,6 +129,9 @@ pub struct HoverProbeReport {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 pub struct ObserveResult {
+    /// Continue omitted content from this same observation.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub next_cursor: Option<String>,
     /// Semantic VOM observation text. Refs are rendered as `@e<N>` so
     /// the agent can copy them into subsequent interaction tools.
     pub text: String,
@@ -328,6 +334,7 @@ mod tests {
     #[test]
     fn observe_result_round_trips_with_ref_count() {
         let r = ObserveResult {
+            next_cursor: None,
             text: "@vom 1\n  @e1 button \"submit\"\n".into(),
             ref_count: 1,
             tab_id: 42,
@@ -343,6 +350,25 @@ mod tests {
     }
 
     #[test]
+    fn observe_cursor_round_trips_without_changing_snapshot() {
+        let params: ObserveParams = serde_json::from_value(json!({
+            "session_id": "s1", "cursor": "next-page", "max_tokens": 100
+        }))
+        .unwrap();
+        assert_eq!(params.cursor.as_deref(), Some("next-page"));
+        assert_eq!(serde_json::to_value(params).unwrap()["cursor"], "next-page");
+        let result: ObserveResult = serde_json::from_value(json!({
+            "text": "@more", "ref_count": 0, "tab_id": 4,
+            "truncated": true, "next_cursor": "next-page"
+        }))
+        .unwrap();
+        assert_eq!(
+            serde_json::to_value(result).unwrap()["next_cursor"],
+            "next-page"
+        );
+    }
+
+    #[test]
     fn observe_params_default_to_no_hover_probing() {
         let params: ObserveParams =
             serde_json::from_value(serde_json::json!({ "session_id": "s1" })).unwrap();
@@ -352,6 +378,7 @@ mod tests {
     #[test]
     fn observe_result_round_trips_with_hover_probe_report() {
         let r = ObserveResult {
+            next_cursor: None,
             text: "@vom 1\n".into(),
             ref_count: 0,
             tab_id: 42,

--- a/crates/bsk-protocol/src/tools/observation.rs
+++ b/crates/bsk-protocol/src/tools/observation.rs
@@ -226,6 +226,12 @@ pub struct ScreenshotParams {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 pub struct ScreenshotResult {
+    /// Single-use visual point-click capture, in the original PNG coordinate space.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub capture_id: Option<String>,
+    /// Image remains viewable but cannot authorize a point click.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub capture_unavailable: Option<String>,
     /// Base64-encoded PNG payload (no `data:` prefix).
     pub image_base64: String,
     /// Pixel width parsed from the PNG IHDR. May be `0` when parsing
@@ -319,6 +325,8 @@ mod tests {
     #[test]
     fn screenshot_result_round_trips_with_image_fields() {
         let r = ScreenshotResult {
+            capture_id: None,
+            capture_unavailable: None,
             image_base64: "iVBORw0KGgo=".into(),
             width: 800,
             height: 600,

--- a/packages/dsh-plugin-browserskill/skill/SKILL.md
+++ b/packages/dsh-plugin-browserskill/skill/SKILL.md
@@ -112,3 +112,16 @@ Continue from returned sequence cursors instead of rereading the same buffer.
 
 Arbitrary page-script evaluation and interaction recording are intentionally unsupported. Do not
 invent tools or route around those limits.
+
+## Canvas and continued observations
+
+`@eN canvas [visual:screenshot]` supports only `browser_inspect` action=screenshot with that
+ref. Names are optional; do not invent Canvas contents from nearby controls. First observe
+returns text. If you cannot understand images, tell the user to switch to an image-capable
+model and continue with available semantics; BrowserSkill does not detect model capabilities.
+
+No token cap applies by default. With explicit maxTokens, follow nextCursor using
+browser_inspect action=observe and cursor. Use current refs first: each response replaces
+previous refs and may contain many Canvas entries. Continuation reads the same observation,
+without recapture; do not change depth. New observe/snapshot or DOM identity changes invalidate
+it. Use fresh observe for updated content.

--- a/packages/dsh-plugin-browserskill/skill/SKILL.md
+++ b/packages/dsh-plugin-browserskill/skill/SKILL.md
@@ -113,15 +113,16 @@ Continue from returned sequence cursors instead of rereading the same buffer.
 Arbitrary page-script evaluation and interaction recording are intentionally unsupported. Do not
 invent tools or route around those limits.
 
-## Canvas and continued observations
+## Canvas and continuation
 
-`@eN canvas [visual:screenshot]` supports only `browser_inspect` action=screenshot with that
-ref. Names are optional; do not invent Canvas contents from nearby controls. First observe
-returns text. If you cannot understand images, tell the user to switch to an image-capable
-model and continue with available semantics; BrowserSkill does not detect model capabilities.
+[visual:screenshot] means screenshot that ref first; names are optional, not inferred from
+nearby controls. If needed images cannot be understood, ask to switch models and use semantics.
+Click via browser_interact(action=click,target=ref,captureId=...,imageX=...,imageY=...), using
+ORIGINAL PNG pixels. Captures are single-use, last two minutes, and expire on ref replacement
+or a new screenshot of that ref. captureUnavailable means view only; observe and screenshot
+again. Counts 1/2 and buttons/modifiers work, not Canvas fill/IME/drag/hover. Repainting is allowed:
+verify results; use DOM refs for revealed controls. Inspect before retrying effect_state=unknown.
 
-No token cap applies by default. With explicit maxTokens, follow nextCursor using
-browser_inspect action=observe and cursor. Use current refs first: each response replaces
-previous refs and may contain many Canvas entries. Continuation reads the same observation,
-without recapture; do not change depth. New observe/snapshot or DOM identity changes invalidate
-it. Use fresh observe for updated content.
+No default token cap. With maxTokens, follow nextCursor via observe(cursor=...); each page can
+contain many Canvas refs and replaces previous refs. This reads the same observation without
+recapture or depth changes. New observe/snapshot or DOM identity changes invalidate continuation.

--- a/packages/dsh-plugin-browserskill/src/browser-tools.ts
+++ b/packages/dsh-plugin-browserskill/src/browser-tools.ts
@@ -190,7 +190,16 @@ const BROWSER_TOOL_SPECS: BrowserToolSpec[] = [
       tabId: TAB_ID_PARAM,
       target: TARGET_PARAM,
       button: { type: "string", enum: ["left", "middle", "right"], description: "Click button." },
-      clickCount: { type: "integer", description: "Click count." },
+      clickCount: { type: "integer", description: "Click count; Canvas accepts 1 or 2." },
+      captureId: { type: "string", description: "Single-use Canvas screenshot capture for click." },
+      imageX: {
+        type: "number",
+        description: "Click X in original PNG pixels; requires captureId/imageY.",
+      },
+      imageY: {
+        type: "number",
+        description: "Click Y in original PNG pixels; requires captureId/imageX.",
+      },
       value: { type: "string", description: "Text for fill." },
       noClear: { type: "boolean", description: "Append instead of clearing for fill." },
       modifiers: {

--- a/packages/dsh-plugin-browserskill/src/browser-tools.ts
+++ b/packages/dsh-plugin-browserskill/src/browser-tools.ts
@@ -156,6 +156,10 @@ const BROWSER_TOOL_SPECS: BrowserToolSpec[] = [
       tabId: TAB_ID_PARAM,
       maxDepth: { type: "integer", description: "Tree depth cap for observe/snapshot." },
       maxTokens: { type: "integer", description: "Token cap for observe/snapshot." },
+      cursor: {
+        type: "string",
+        description: "Observe continuation cursor; use current refs before continuing.",
+      },
       ref: { type: "string", description: "Fresh ref for scoped html or cropped screenshot." },
       maxBytes: { type: "integer", description: "HTML byte cap." },
       since: { type: "integer", description: "Console/network sequence cursor." },

--- a/packages/dsh-plugin-browserskill/src/client/BrowserInspectToolView.tsx
+++ b/packages/dsh-plugin-browserskill/src/client/BrowserInspectToolView.tsx
@@ -84,6 +84,7 @@ interface InspectArgs {
   tabId?: unknown;
   maxDepth?: unknown;
   maxTokens?: unknown;
+  cursor?: unknown;
   ref?: unknown;
   maxBytes?: unknown;
   since?: unknown;
@@ -105,6 +106,8 @@ function commandOf(argsRaw: string, callId: string): { command: string; title: s
     parts.push(
       typeof args.session === "string" && args.session !== "" ? args.session : "(current)",
     );
+    if (action === "observe" && typeof args.cursor === "string")
+      parts.push("--cursor", args.cursor);
     if (action === "observe" || action === "snapshot") {
       appendNumber(parts, "--max-depth", args.maxDepth);
       appendNumber(parts, "--max-tokens", args.maxTokens);

--- a/packages/dsh-plugin-browserskill/src/tools.ts
+++ b/packages/dsh-plugin-browserskill/src/tools.ts
@@ -496,6 +496,14 @@ function defineBrowserOperations(deps: ToolDeps, register: DefinitionRegistrar):
         description,
         parameters: {
           session: SESSION_PARAM,
+          ...(kind === "observe"
+            ? {
+                cursor: {
+                  type: "string" as const,
+                  description: "Continue omitted content; previous page refs expire.",
+                },
+              }
+            : {}),
           maxDepth: { type: "integer", description: "Cap on tree depth before truncating." },
           maxTokens: {
             type: "integer",
@@ -512,6 +520,7 @@ function defineBrowserOperations(deps: ToolDeps, register: DefinitionRegistrar):
               text: { type: "string", required: true },
               refCount: { type: "integer", required: true },
               truncated: { type: "boolean", required: true },
+              nextCursor: { type: "string" },
             },
           },
           render: (_args, value) => [
@@ -519,7 +528,10 @@ function defineBrowserOperations(deps: ToolDeps, register: DefinitionRegistrar):
               type: "text",
               text:
                 value.text.length > 0
-                  ? value.text + (value.truncated ? "\n(truncated — re-run with looser caps)" : "")
+                  ? value.text +
+                    (value.truncated && !value.nextCursor
+                      ? "\n(truncated — re-run with looser caps)"
+                      : "")
                   : "(empty observation — page may still be loading)",
             },
           ],
@@ -528,6 +540,8 @@ function defineBrowserOperations(deps: ToolDeps, register: DefinitionRegistrar):
         async execute(args, exec) {
           const sessionId = registry.resolve(args.session, name);
           const cmdArgs = [kind, "--session", sessionId];
+          if (kind === "observe" && args.cursor !== undefined)
+            cmdArgs.push("--cursor", String(args.cursor));
           if (args.maxDepth !== undefined) cmdArgs.push("--max-depth", String(args.maxDepth));
           if (args.maxTokens !== undefined) cmdArgs.push("--max-tokens", String(args.maxTokens));
           const reply = (await runBsk(deps, exec, cmdArgs, kind, sessionId)) as {
@@ -535,6 +549,7 @@ function defineBrowserOperations(deps: ToolDeps, register: DefinitionRegistrar):
             ref_count: number;
             tab_id: number;
             truncated?: boolean;
+            next_cursor?: string;
           };
           return {
             session: sessionId,
@@ -542,6 +557,7 @@ function defineBrowserOperations(deps: ToolDeps, register: DefinitionRegistrar):
             text: reply.text,
             refCount: reply.ref_count,
             truncated: reply.truncated ?? false,
+            ...(reply.next_cursor ? { nextCursor: reply.next_cursor } : {}),
           };
         },
         presentCall: (args) => ({

--- a/packages/dsh-plugin-browserskill/src/tools.ts
+++ b/packages/dsh-plugin-browserskill/src/tools.ts
@@ -585,6 +585,16 @@ function defineBrowserOperations(deps: ToolDeps, register: DefinitionRegistrar):
           description: "Snapshot ref (@e3 / e3) or CSS selector of the element to click.",
         },
         session: SESSION_PARAM,
+        captureId: {
+          type: "string",
+          description: "Single-use capture from a Canvas screenshot; requires imageX/imageY.",
+        },
+        imageX: { type: "number", description: "X in the original screenshot PNG pixels." },
+        imageY: { type: "number", description: "Y in the original screenshot PNG pixels." },
+        modifiers: {
+          type: "array",
+          items: { type: "string", enum: ["alt", "ctrl", "meta", "shift"] },
+        },
         button: {
           type: "string",
           enum: ["left", "middle", "right"],
@@ -619,6 +629,23 @@ function defineBrowserOperations(deps: ToolDeps, register: DefinitionRegistrar):
         const cmdArgs = ["click", "--session", sessionId];
         if (args.button !== undefined) cmdArgs.push("--button", args.button);
         if (args.clickCount !== undefined) cmdArgs.push("--click-count", String(args.clickCount));
+        if (
+          args.captureId !== undefined ||
+          args.imageX !== undefined ||
+          args.imageY !== undefined
+        ) {
+          if (!args.captureId || !Number.isFinite(args.imageX) || !Number.isFinite(args.imageY))
+            throw new Error("Canvas click requires captureId, imageX and imageY");
+          cmdArgs.push(
+            "--capture",
+            args.captureId,
+            "--image-x",
+            String(args.imageX),
+            "--image-y",
+            String(args.imageY),
+          );
+        }
+        if (args.modifiers?.length) cmdArgs.push("--modifiers", args.modifiers.join(","));
         cmdArgs.push(args.target);
         const reply = (await runBsk(deps, exec, cmdArgs, "click", sessionId)) as {
           tab_id: number;
@@ -789,6 +816,8 @@ function defineBrowserOperations(deps: ToolDeps, register: DefinitionRegistrar):
             width: { type: "integer", required: true },
             height: { type: "integer", required: true },
             byteSize: { type: "integer", required: true },
+            captureId: { type: "string" },
+            captureUnavailable: { type: "string" },
             image: {
               type: "object",
               additionalProperties: false,
@@ -812,7 +841,12 @@ function defineBrowserOperations(deps: ToolDeps, register: DefinitionRegistrar):
             value.image !== undefined
               ? `[session ${value.session}] screenshot of tab ${value.tabId} (${value.width}x${value.height}px)`
               : `[session ${value.session}] screenshot saved to ${value.path} (${value.width}x${value.height}px, ${value.byteSize} bytes) — this deployment cannot inline images; read the file to view it`;
-          const blocks: ContentBlock[] = [{ type: "text", text }];
+          const captureText = value.captureId
+            ? `; captureId=${value.captureId}, single-use click with original PNG imageX/imageY`
+            : value.captureUnavailable
+              ? `; capture unavailable: ${value.captureUnavailable}`
+              : "";
+          const blocks: ContentBlock[] = [{ type: "text", text: text + captureText }];
           if (value.image !== undefined) {
             blocks.push({
               type: "image",
@@ -851,6 +885,8 @@ function defineBrowserOperations(deps: ToolDeps, register: DefinitionRegistrar):
             height: number;
             path: string;
             byte_size: number;
+            capture_id?: string;
+            capture_unavailable?: string;
           };
           writtenPath = reply.path;
           const data = await readFile(reply.path);
@@ -864,6 +900,8 @@ function defineBrowserOperations(deps: ToolDeps, register: DefinitionRegistrar):
             width: reply.width,
             height: reply.height,
             byteSize: reply.byte_size,
+            ...(reply.capture_id ? { captureId: reply.capture_id } : {}),
+            ...(reply.capture_unavailable ? { captureUnavailable: reply.capture_unavailable } : {}),
             ...(ref !== undefined
               ? {
                   image: {

--- a/packages/dsh-plugin-browserskill/tests/skill.test.ts
+++ b/packages/dsh-plugin-browserskill/tests/skill.test.ts
@@ -50,7 +50,9 @@ describe("registerBskSkill", () => {
     // Keep the lazily injected instructions inside a bounded prompt budget,
     // while the lower bound catches accidental truncation of the guidance.
     expect(content.length).toBeGreaterThan(3_000);
-    expect(content.length).toBeLessThan(6_000);
+    expect(content.length).toBeLessThan(7_000);
+    expect(content).toContain("[visual:screenshot]");
+    expect(content).toContain("nextCursor");
     expect(skill.source).toBe("bundled");
     // Source frontmatter is registration metadata and must not leak into the body.
     expect(content.startsWith("---")).toBe(false);

--- a/packages/dsh-plugin-browserskill/tests/tools.test.ts
+++ b/packages/dsh-plugin-browserskill/tests/tools.test.ts
@@ -1000,7 +1000,15 @@ describe("inspect.screenshot", () => {
     const path = pngFile();
     const { tools, calls } = setup({
       "session start": START_REPLY("s1"),
-      screenshot: { tab_id: 7, width: 800, height: 600, format: "png", path, byte_size: 8 },
+      screenshot: {
+        tab_id: 7,
+        width: 800,
+        height: 600,
+        format: "png",
+        path,
+        byte_size: 8,
+        capture_id: "capture-1",
+      },
     });
     await startSession(tools);
     const screenshot = tools.get("inspect.screenshot");
@@ -1009,10 +1017,12 @@ describe("inspect.screenshot", () => {
       image?: unknown;
     };
     expect(value.path).toBe(path);
+    expect(value).toHaveProperty("captureId", "capture-1");
     expect(value.image).toBeUndefined();
     expect(calls[1].args.slice(0, 3)).toEqual(["screenshot", "--session", "s1"]);
     expect(calls[1].args).toContain("--ref");
     const rendered = screenshot?.output.render({ session: "s1" }, value as never);
+    expect(JSON.stringify(rendered)).toContain("captureId=capture-1");
     expect(rendered?.every((block) => block.type === "text")).toBe(true);
   });
 
@@ -1498,4 +1508,32 @@ it("inspect.observe forwards continuation cursors and exposes the next cursor", 
     "100",
   ]);
   expect(value).toMatchObject({ nextCursor: "page-three", truncated: true });
+});
+
+it("forwards screenshot-bound Canvas coordinates to click", async () => {
+  const { tools, calls } = setup({
+    "session start": START_REPLY("s1"),
+    click: { tab_id: 7, x: 40, y: 50 },
+  });
+  await startSession(tools);
+  await tools
+    .get("interact.click")!
+    .execute(
+      { target: "e1", captureId: "capture", imageX: 20, imageY: 30, modifiers: ["shift"] },
+      makeExec(),
+    );
+  expect(calls.at(-1)!.args).toEqual([
+    "click",
+    "--session",
+    "s1",
+    "--capture",
+    "capture",
+    "--image-x",
+    "20",
+    "--image-y",
+    "30",
+    "--modifiers",
+    "shift",
+    "e1",
+  ]);
 });

--- a/packages/dsh-plugin-browserskill/tests/tools.test.ts
+++ b/packages/dsh-plugin-browserskill/tests/tools.test.ts
@@ -1478,3 +1478,24 @@ describe("wheel action", () => {
     expect(calls).toHaveLength(1);
   });
 });
+
+it("inspect.observe forwards continuation cursors and exposes the next cursor", async () => {
+  const { tools, calls } = setup({
+    "session start": { session_id: "s1", agent_window_id: 100 },
+    observe: { ...SNAPSHOT_REPLY, truncated: true, next_cursor: "page-three" },
+  });
+  await startSession(tools);
+  const value = await tools
+    .get("inspect.observe")
+    ?.execute({ cursor: "page-two", maxTokens: 100 }, makeExec());
+  expect(calls.at(-1)?.args).toEqual([
+    "observe",
+    "--session",
+    "s1",
+    "--cursor",
+    "page-two",
+    "--max-tokens",
+    "100",
+  ]);
+  expect(value).toMatchObject({ nextCursor: "page-three", truncated: true });
+});

--- a/packages/vom/src/index.ts
+++ b/packages/vom/src/index.ts
@@ -2,6 +2,8 @@ export {
   applyVomInteractionRecovery,
   isVomReferenceNode,
   isVomStructuralRole,
+  prepareObservationRender,
+  type RenderRow,
   renderVom,
 } from "./render";
 export type {
@@ -12,6 +14,7 @@ export type {
   Rect,
   RenderedRef,
   Viewport,
+  VisualEntry,
   VomNode,
   VomOptions,
   VomRef,

--- a/packages/vom/src/render.ts
+++ b/packages/vom/src/render.ts
@@ -1109,7 +1109,11 @@ function collectDescendants(nodes: VomNode[], roots: Set<number>): Set<number> {
   return included;
 }
 
-function applyActiveRegionPolicy(nodes: VomNode[], scene: VomScene): VomNode[] {
+function applyActiveRegionPolicy(
+  nodes: VomNode[],
+  scene: VomScene,
+  visualSources?: ReadonlyMap<number, VomNode>,
+): VomNode[] {
   const parentMap = buildParentMap(nodes);
   const nodesById = new Map(nodes.map((node) => [node.id, node]));
   const lineageCache = new Map<number, Map<string | undefined, VomNode>>();
@@ -1127,10 +1131,10 @@ function applyActiveRegionPolicy(nodes: VomNode[], scene: VomScene): VomNode[] {
 
   const blockedRoots = new Set<number>();
   for (const target of nodes) {
-    if (!isVomReferenceNode(target)) continue;
+    if (target.visualKey === undefined && !isVomReferenceNode(target)) continue;
     const blocked = candidates.some((candidate) =>
       isBlockedByRegion(
-        target,
+        visualSources?.get(target.id) ?? target,
         candidate.node,
         parentMap,
         nodesById,
@@ -1208,20 +1212,65 @@ export function prepareObservationRender(
 } {
   const recovered = applyVomInteractionRecovery(scene.nodes);
   const layer = detectBlockingLayer(recovered, scene.viewport, scene.rootFrameId);
-  const included = layer ? collectDescendants(recovered, layer.members) : undefined;
-  const visible = included
-    ? recovered.filter((n) => included.has(n.id))
+  const recoveredById = new Map(recovered.map((n) => [n.id, n]));
+  let nextId = recovered.reduce((max, n) => Math.max(max, n.id), 0) + 1;
+  // Scope targets participate in existing filtering, never in blocker detection.
+  // Keep the exact source as parent so an excluded source cannot reappear via fallback.
+  const visualTargets: VomNode[] = (scene.visuals ?? []).map((v) => ({
+    id: nextId++,
+    parentId: v.sourceId ?? v.parentId,
+    frameId: v.frameId,
+    visualKey: v.key,
+    tag: "canvas",
+    rect: v.rect ?? (v.sourceId === undefined ? null : recoveredById.get(v.sourceId)?.rect) ?? null,
+    paintOrder:
+      v.paintOrder ??
+      (v.sourceId === undefined ? undefined : recoveredById.get(v.sourceId)?.paintOrder) ??
+      0,
+    position: "static",
+    pointerEvents: "none",
+    referenceable: false,
+  }));
+  const visualSources = new Map<number, VomNode>();
+  for (let i = 0; i < visualTargets.length; i++) {
+    const sourceId = scene.visuals![i].sourceId;
+    const source = sourceId === undefined ? undefined : recoveredById.get(sourceId);
+    if (source) visualSources.set(visualTargets[i].id, { ...source, rect: visualTargets[i].rect });
+  }
+  const scopeNodes = [...recovered, ...visualTargets];
+  const members = layer ? new Set(layer.members) : undefined;
+  if (members && layer) {
+    const blocker = recoveredById.get(layer.rootId)!;
+    for (let i = 0; i < visualTargets.length; i++) {
+      const target = visualTargets[i];
+      const v = scene.visuals![i];
+      if (
+        v.sourceId === undefined &&
+        v.paintOrder !== undefined &&
+        target.frameId === blocker.frameId &&
+        target.paintOrder >= blocker.paintOrder
+      )
+        members.add(target.id);
+    }
+  }
+  const included = members ? collectDescendants(scopeNodes, members) : undefined;
+  const scoped = included
+    ? scopeNodes.filter((n) => included.has(n.id))
     : options.activeRegionPolicy
-      ? applyActiveRegionPolicy(recovered, scene)
-      : recovered;
+      ? applyActiveRegionPolicy(scopeNodes, scene, visualSources)
+      : scopeNodes;
+  const allowedVisuals = new Set(
+    scoped.filter((n) => n.visualKey !== undefined).map((n) => n.visualKey),
+  );
+  const visible = scoped.filter((n) => n.visualKey === undefined);
   const byId = new Map(visible.map((n) => [n.id, n]));
   const ids = new Set(byId.keys());
-  let nextId = visible.reduce((max, n) => Math.max(max, n.id), 0) + 1;
   const before = new Map<number, VomNode[]>();
   const tail: VomNode[] = [];
   const fallbackGroups = new Map<string, number>();
   const representedSources = new Set<number>();
   for (const v of scene.visuals ?? []) {
+    if (!allowedVisuals.has(v.key)) continue;
     const source = v.sourceId === undefined ? undefined : byId.get(v.sourceId);
     // Only suppress an exact passive Canvas description already carried by the visual line.
     // Action refs and distinct semantic content remain separate.

--- a/packages/vom/src/render.ts
+++ b/packages/vom/src/render.ts
@@ -777,6 +777,7 @@ function shouldSkipRedundantChildren(node: VomNode, state: RenderState): boolean
 }
 
 interface RenderState {
+  visualAncestors: Set<number>;
   lines: string[];
   refs: RenderedRef[];
   nextRef: number;
@@ -785,7 +786,6 @@ interface RenderState {
   maxTokens: number;
   redactValues: boolean;
   truncated: boolean;
-  stopped: boolean;
   children: Map<number | null, VomNode[]>;
   parentMap: Map<number, number | null>;
   nodesById: Map<number, VomNode>;
@@ -795,33 +795,13 @@ interface RenderState {
   scopeMap: Map<number, ActiveScopeBlock>;
 }
 
-function emitActiveScopeBlock(scope: ActiveScopeBlock, depth: number, state: RenderState): void {
-  if (state.stopped || scope.lines.length === 0) return;
-  const indent = "  ".repeat(depth);
-  const header = `${indent}[§ active: ${scope.label}]`;
-  const headerTokens = estimateTokens(header);
-  if (state.tokens + headerTokens > state.maxTokens) {
-    state.truncated = true;
-    state.stopped = true;
-    return;
-  }
-  state.lines.push(header);
-  state.tokens += headerTokens;
-
-  for (const text of scope.lines.slice(0, MAX_SCOPE_LINES)) {
-    if (state.stopped) return;
-    const clean = cleaned(text);
-    if (!clean) continue;
-    const line = `${indent}  ${clean}`;
-    const nextTokens = state.tokens + estimateTokens(line);
-    if (nextTokens > state.maxTokens) {
-      state.truncated = true;
-      state.stopped = true;
-      return;
-    }
-    state.lines.push(line);
-    state.tokens = nextTokens;
-  }
+export interface RenderRow {
+  context?: string;
+  frameId?: string;
+  text: string;
+  ref?: RenderedRef;
+  /** Minimal complete visual entry when a long label cannot fit. */
+  minimal?: string;
 }
 
 function pushRenderChildren(
@@ -834,69 +814,97 @@ function pushRenderChildren(
   }
 }
 
-function renderTree(children: Map<number | null, VomNode[]>, state: RenderState): void {
+function* renderTreeRows(
+  children: Map<number | null, VomNode[]>,
+  state: RenderState,
+  observation = false,
+  representedSources?: ReadonlySet<number>,
+): Generator<RenderRow> {
   const stack: Array<{ node: VomNode; depth: number }> = [];
   pushRenderChildren(stack, children.get(null) ?? [], 1);
 
-  while (stack.length > 0 && !state.stopped) {
+  while (stack.length > 0) {
     const { node, depth } = stack.pop() as { node: VomNode; depth: number };
 
-    if (!shouldRender(node)) {
+    if (representedSources?.has(node.id) || (node.visualKey === undefined && !shouldRender(node))) {
       pushRenderChildren(stack, children.get(node.id) ?? [], depth);
       continue;
     }
 
-    if (depth > state.maxDepth) {
+    if (depth > state.maxDepth && node.visualKey === undefined) {
       state.truncated = true;
+      if (observation && state.visualAncestors.has(node.id))
+        pushRenderChildren(stack, children.get(node.id) ?? [], depth);
       continue;
     }
 
-    const ref = isVomReferenceNode(node) ? `e${state.nextRef}` : undefined;
-    const context = ref ? handleContext(node, state) : [];
+    const visual = node.visualKey !== undefined;
+    const ref = visual || isVomReferenceNode(node) ? `e${state.nextRef++}` : undefined;
+    const context = ref && !visual ? handleContext(node, state) : [];
     const surface = state.surfaceMap.get(node.id);
-    const line = renderNodeLine(node, depth, ref, context, surface, state.redactValues);
-    const nextTokens = state.tokens + estimateTokens(line);
-    if (nextTokens > state.maxTokens) {
-      state.truncated = true;
-      state.stopped = true;
-      break;
-    }
-
-    state.lines.push(line);
-    state.tokens = nextTokens;
-    if (ref) {
-      const name = cleaned(node.name);
-      state.refs.push({
-        ref,
-        backendNodeId: node.backendNodeId ?? node.id,
-        ...(node.frameId ? { frameId: node.frameId } : {}),
-        ...(node.role ? { role: node.role } : {}),
-        ...(name ? { name } : {}),
-        ...(context.length > 0 ? { ctx: context.join(" > ") } : {}),
-        line: state.lines.length - 1,
-      });
-      state.nextRef += 1;
-    }
-
+    const indent = "  ".repeat(Math.min(depth, state.maxDepth, 32));
+    const minimal = visual ? `${indent}@${ref} canvas [visual:screenshot]` : undefined;
+    const label = cleaned(node.name);
+    const text = visual
+      ? label
+        ? `${indent}@${ref} canvas ${JSON.stringify(Array.from(label).slice(0, 160).join(""))} [visual:screenshot]`
+        : minimal!
+      : renderNodeLine(node, depth, ref, context, surface, state.redactValues);
+    const parent = node.parentId === null ? undefined : state.nodesById.get(node.parentId);
+    const parentLabel = parent ? cleaned(parent.name) : undefined;
+    yield {
+      ...(parent
+        ? {
+            context: `@context ${parent.role ?? parent.tag}${parentLabel ? ` ${JSON.stringify(Array.from(parentLabel).slice(0, 80).join(""))}` : ""}`,
+          }
+        : {}),
+      frameId: node.frameId,
+      text,
+      ...(minimal ? { minimal } : {}),
+      ...(ref
+        ? {
+            ref: {
+              ref,
+              backendNodeId: node.backendNodeId ?? node.id,
+              ...(visual ? { visualKey: node.visualKey } : {}),
+              ...(node.frameId ? { frameId: node.frameId } : {}),
+              ...(node.role ? { role: node.role } : {}),
+              ...(label ? { name: label } : {}),
+              ...(context.length > 0 ? { ctx: context.join(" > ") } : {}),
+              line: 0,
+            },
+          }
+        : {}),
+    };
     const scope = state.scopeMap.get(node.id);
-    if (scope) emitActiveScopeBlock(scope, depth + 1, state);
+    if (scope?.lines.length) {
+      yield { text: `${"  ".repeat(depth + 1)}[§ active: ${scope.label}]` };
+      for (const text of scope.lines.slice(0, MAX_SCOPE_LINES)) {
+        const clean = cleaned(text);
+        if (clean) yield { text: `${"  ".repeat(depth + 2)}${clean}` };
+      }
+    }
 
-    if ((ref && shouldSkipRedundantRefChildren(node)) || shouldSkipRedundantChildren(node, state)) {
+    if (
+      (!observation || !state.visualAncestors.has(node.id)) &&
+      ((ref && shouldSkipRedundantRefChildren(node)) || shouldSkipRedundantChildren(node, state))
+    ) {
       continue;
     }
     pushRenderChildren(stack, children.get(node.id) ?? [], depth + 1);
   }
 }
 
-function renderNodes(
+function createRenderState(
   nodes: VomNode[],
   options: VomOptions,
   initialLines: string[],
-  surfaces: CondSurface[] = [],
-  activeScopeBlocks: ActiveScopeBlock[] = [],
+  surfaces: CondSurface[],
+  activeScopeBlocks: ActiveScopeBlock[],
 ): RenderState {
   const children = buildChildren(nodes);
   const state: RenderState = {
+    visualAncestors: new Set(),
     lines: [...initialLines],
     refs: [],
     nextRef: 1,
@@ -905,7 +913,6 @@ function renderNodes(
     maxTokens: options.maxTokens ?? DEFAULT_MAX_TOKENS,
     redactValues: options.redactValues ?? false,
     truncated: false,
-    stopped: false,
     children,
     parentMap: buildParentMap(nodes),
     nodesById: new Map(nodes.map((node) => [node.id, node])),
@@ -915,7 +922,36 @@ function renderNodes(
     scopeMap: new Map(activeScopeBlocks.map((scope) => [scope.triggerId, scope])),
   };
 
-  renderTree(children, state);
+  for (const node of nodes) {
+    if (node.visualKey === undefined) continue;
+    let id = node.parentId;
+    while (id !== null && !state.visualAncestors.has(id)) {
+      state.visualAncestors.add(id);
+      id = state.parentMap.get(id) ?? null;
+    }
+  }
+  return state;
+}
+
+function renderNodes(
+  nodes: VomNode[],
+  options: VomOptions,
+  initialLines: string[],
+  surfaces: CondSurface[] = [],
+  activeScopeBlocks: ActiveScopeBlock[] = [],
+): RenderState {
+  const state = createRenderState(nodes, options, initialLines, surfaces, activeScopeBlocks);
+  const children = state.children;
+  for (const row of renderTreeRows(children, state)) {
+    const cost = estimateTokens(row.text);
+    if (state.tokens + cost > state.maxTokens) {
+      state.truncated = true;
+      break;
+    }
+    if (row.ref) state.refs.push({ ...row.ref, line: state.lines.length });
+    state.lines.push(row.text);
+    state.tokens += cost;
+  }
 
   return state;
 }
@@ -1159,4 +1195,115 @@ export function renderVom(scene: VomScene, options: VomOptions = {}): VomResult 
     refs: state.refs,
     truncated: state.truncated,
   };
+}
+
+/** Prepare semantics once; the iterator retains traversal position, never raw capture facts. */
+export function prepareObservationRender(
+  scene: VomScene,
+  options: VomOptions = {},
+): {
+  headers: string[];
+  rows: Iterator<RenderRow>;
+  truncated: () => boolean;
+} {
+  const recovered = applyVomInteractionRecovery(scene.nodes);
+  const layer = detectBlockingLayer(recovered, scene.viewport, scene.rootFrameId);
+  const included = layer ? collectDescendants(recovered, layer.members) : undefined;
+  const visible = included
+    ? recovered.filter((n) => included.has(n.id))
+    : options.activeRegionPolicy
+      ? applyActiveRegionPolicy(recovered, scene)
+      : recovered;
+  const byId = new Map(visible.map((n) => [n.id, n]));
+  const ids = new Set(byId.keys());
+  let nextId = visible.reduce((max, n) => Math.max(max, n.id), 0) + 1;
+  const before = new Map<number, VomNode[]>();
+  const tail: VomNode[] = [];
+  const fallbackGroups = new Map<string, number>();
+  const representedSources = new Set<number>();
+  for (const v of scene.visuals ?? []) {
+    const source = v.sourceId === undefined ? undefined : byId.get(v.sourceId);
+    // Only suppress an exact passive Canvas description already carried by the visual line.
+    // Action refs and distinct semantic content remain separate.
+    if (
+      source &&
+      normalizedTag(source) === "canvas" &&
+      normalizedRole(source) === "canvas" &&
+      !isVomReferenceNode(source) &&
+      !source.value &&
+      !source.text &&
+      (!cleaned(source.name) || cleaned(source.name) === cleaned(v.label))
+    ) {
+      representedSources.add(source.id);
+    }
+
+    const node: VomNode = {
+      id: nextId++,
+      parentId: v.parentId !== null && ids.has(v.parentId) ? v.parentId : null,
+      tag: "canvas",
+      role: "canvas",
+      name: v.label,
+      frameId: v.frameId,
+      visualKey: v.key,
+      rect: null,
+      paintOrder: 0,
+      position: "static",
+      pointerEvents: "none",
+      referenceable: false,
+    };
+    if (node.parentId === null) {
+      const label = v.fallbackContext ?? "Unplaced Canvas regions";
+      let groupId = fallbackGroups.get(label);
+      if (groupId === undefined) {
+        groupId = nextId++;
+        fallbackGroups.set(label, groupId);
+        tail.push({
+          id: groupId,
+          parentId: null,
+          tag: "section",
+          role: "group",
+          name: label,
+          rect: null,
+          paintOrder: 0,
+          position: "static",
+          pointerEvents: "none",
+          referenceable: false,
+        });
+      }
+      node.parentId = groupId;
+    }
+    if (
+      v.beforeId !== undefined &&
+      ids.has(v.beforeId) &&
+      byId.get(v.beforeId)?.parentId === node.parentId
+    ) {
+      const list = before.get(v.beforeId) ?? [];
+      list.push(node);
+      before.set(v.beforeId, list);
+    } else tail.push(node);
+  }
+  const nodes = visible.flatMap((n) => [...(before.get(n.id) ?? []), n]).concat(tail);
+  const headers = [
+    "@vom 1",
+    `@view ${scene.viewport.width}x${scene.viewport.height}`,
+    `@layers ${layer ? 2 : 1} focus=L1`,
+    layer ? `L1 ${layer.kind} cover=${Math.round(layer.coverage * 100)}%` : "L1 page",
+  ];
+  const state = createRenderState(
+    nodes,
+    options,
+    [],
+    scene.surfaces ?? [],
+    scene.activeScopeBlocks ?? [],
+  );
+  function* rows(): Generator<RenderRow> {
+    yield* renderTreeRows(state.children, state, true, representedSources);
+    if (layer)
+      yield {
+        text: renderPageOcclusionLine(
+          countRenderable(recovered.filter((n) => !included!.has(n.id))),
+        ),
+      };
+  }
+  return { headers, rows: rows(), truncated: () => state.truncated };
 }

--- a/packages/vom/src/types.ts
+++ b/packages/vom/src/types.ts
@@ -19,6 +19,8 @@ export type LayerKind = "page" | "modal" | "mask";
  * before constructing these nodes.
  */
 export interface VomNode {
+  /** Internal render-only visual entry; never a DOM action target. */
+  visualKey?: number;
   id: number;
   parentId: number | null;
   backendNodeId?: number;
@@ -54,7 +56,19 @@ export interface VomNode {
   insideNative?: boolean;
 }
 
+export interface VisualEntry {
+  /** Exact retained Canvas node, distinct from the next sibling insertion point. */
+  sourceId?: number;
+  fallbackContext?: string;
+  key: number;
+  parentId: number | null;
+  beforeId?: number;
+  label?: string;
+  frameId: string;
+}
+
 export interface VomScene {
+  visuals?: VisualEntry[];
   viewport: Viewport;
   nodes: VomNode[];
   /** Root document whose paint order defines page-level blocking layers. */
@@ -97,6 +111,7 @@ export interface VomRef {
 }
 
 export interface RenderedRef extends VomRef {
+  visualKey?: number;
   role?: string;
   name?: string;
   ctx?: string;

--- a/packages/vom/src/types.ts
+++ b/packages/vom/src/types.ts
@@ -57,6 +57,9 @@ export interface VomNode {
 }
 
 export interface VisualEntry {
+  /** Existing capture geometry/order used only by observation scope filtering. */
+  rect?: Rect;
+  paintOrder?: number;
   /** Exact retained Canvas node, distinct from the next sibling insertion point. */
   sourceId?: number;
   fallbackContext?: string;

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -120,7 +120,8 @@ needed, obtain a fresh observation before acting on screenshot or HTML findings.
 
 `observe` may place `@eN canvas [visual:screenshot]` near related page controls. Names are
 optional: do not infer a table title or controls inside Canvas from adjacent labels. Visual refs
-support `screenshot --ref`, not click/fill/hover or HTML extraction. First observe returns text,
+support `screenshot --ref`; point clicks additionally require its `capture_id` and image coordinates.
+They do not support fill/hover or HTML extraction. First observe returns text,
 not an image. Use the surrounding semantics to decide whether a Canvas screenshot is needed.
 If you cannot receive and understand images in this session, tell the user the Canvas contents
 cannot be interpreted and ask them to switch to an image-capable model; continue with available
@@ -135,6 +136,17 @@ Continuation reads the same captured observation; it does not refresh or hover t
 combine it with depth changes or hover probing. A new observe/snapshot replaces the continuation;
 if the page identity changed, observe again. Screenshot execution checks current target identity
 and geometry, but permits Canvas repainting and does not freeze pixels.
+
+A Canvas screenshot can return `capture_id`. To click a point you identified in that image, use
+`bsk click eN --capture <id> --image-x <x> --image-y <y> --session <id>`.
+Use original PNG pixels (returned width/height), not resized display or viewport coordinates.
+Captures are single-use, expire after two minutes, and are invalidated by a newer screenshot of
+that ref or observation/continuation. With `capture_unavailable`, view the image but observe and
+screenshot again before clicking. Click counts 1/2, buttons and modifiers are supported.
+After clicking, observe or screenshot to verify the result; use DOM refs for revealed controls.
+A completed click does not prove business success. Canvas repainting is allowed; changed identity,
+geometry or hit target is rejected. If `effect_state=unknown`, inspect before retrying with a new
+capture. Do not infer cell-editing, IME, drag or hover support from point-click capability.
 
 ## Respect the Agent Window boundary
 

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -116,6 +116,26 @@ Escalate page reading only as needed:
 Do not start with raw HTML or screenshots merely to discover ordinary controls. When interaction is
 needed, obtain a fresh observation before acting on screenshot or HTML findings.
 
+## Canvas and observation continuation
+
+`observe` may place `@eN canvas [visual:screenshot]` near related page controls. Names are
+optional: do not infer a table title or controls inside Canvas from adjacent labels. Visual refs
+support `screenshot --ref`, not click/fill/hover or HTML extraction. First observe returns text,
+not an image. Use the surrounding semantics to decide whether a Canvas screenshot is needed.
+If you cannot receive and understand images in this session, tell the user the Canvas contents
+cannot be interpreted and ask them to switch to an image-capable model; continue with available
+semantic information. BrowserSkill does not detect the model's capabilities.
+
+There is no default token cap. With an explicit `--max-tokens` limit, an observation may return
+`next_cursor` and an `@more` instruction. Use current refs before calling
+`bsk observe --cursor <token> --session <id>`: each response replaces the ref map, so refs from
+previous pages must not be reused. A response can contain many Canvas entries. Follow cursors
+when relevant content remains, rather than repeatedly reading the same prefix.
+Continuation reads the same captured observation; it does not refresh or hover the page. Do not
+combine it with depth changes or hover probing. A new observe/snapshot replaces the continuation;
+if the page identity changed, observe again. Screenshot execution checks current target identity
+and geometry, but permits Canvas repainting and does not freeze pixels.
+
 ## Respect the Agent Window boundary
 
 Normal page writes affect only Agent Window tabs. To operate a user tab, first list it with


### PR DESCRIPTION
Canvas screenshots can be cropped to the body's box even when its overflow belongs to the viewport. Live validation also follows DOM parents instead of rendered slot ancestry, rejecting Canvas references that discovery correctly found through slot clipping.

- Share viewport-overflow source selection between discovery and live validation. Propagated root/body overflow uses the existing viewport and frame clipping; ordinary element overflow remains local. Account for containment on either root or body, including `content-visibility` and `container-type`.
- Follow assigned slots before DOM parents and shadow hosts. Resolve closed-slot edges only along the verified target ancestry, then reread the current assignment and geometry in the same isolated world. Preserve identity, clip-change and frame checks, and release temporary objects on success or failure.
- Add native Chrome regressions through production discovery, live validation, screenshot capture and hit testing. Cover propagation, root offsets, containment, scrolling, iframe clipping, open/closed/nested slots, redistribution and an assignment race.

Validation:

- Extension suite: 1,444 passed.
- VOM suite: 47 passed.
- New native Chrome suite: 27 passed.
- Existing native coordinate suite: all 13 configurations passed; one initial `Page.navigate` timeout passed on isolated retry.
- TypeScript, extension production build, Biome on changed files and `git diff --check` passed.
- The regression suite also fails on the unmodified #220 code for body propagation, root offsets, and open/closed/nested slot clipping.

Scope and cost: no protocol or CLI changes, and semantic snapshots keep the existing five style columns. Visual captures request two additional computed-style columns. Ordinary and open-slot live reads add no CDP round trips; closed-slot boundaries require local describe/resolve/reread work. No full-document live traversal or snapshot recapture is added. Existing unsupported-geometry handling, including boxless ancestors without snapshot style evidence, remains in place.